### PR TITLE
DSWx-HLS PGE Dockerfile Addition

### DIFF
--- a/.ci/docker/Dockerfile_dswx_hls
+++ b/.ci/docker/Dockerfile_dswx_hls
@@ -1,0 +1,66 @@
+# Copyright 2021, by the California Institute of Technology.
+# ALL RIGHTS RESERVED.
+# United States Government sponsorship acknowledged.
+# Any commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+# This software may be subject to U.S. export control laws and regulations.
+# By accepting this document, the user agrees to comply with all applicable
+# U.S. export laws and regulations. User has the responsibility to obtain
+# export licenses, or other export authority as may be required, before
+# exporting such information to foreign countries or providing access to
+# foreign persons.
+
+# Dockerfile to produce the production DSWx-HLS PGE Docker image for OPERA
+# Author: Scott Collins
+
+# TODO: could this become an argument?
+FROM artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/dswx_hls:interface
+
+ARG PGE_SOURCE_DIR
+ARG PGE_DEST_DIR=/home/conda
+
+ARG BUILD_DATE_TIME
+ARG BUILD_VERSION
+
+# labels
+# the label-schema convention: http://label-schema.org/rc1/
+LABEL org.label-schema.build-date=${BUILD_DATE_TIME} \
+  org.label-schema.version=${BUILD_VERSION} \
+  org.label-schema.license="Copyright 2021,\
+ by the California Institute of Technology.\
+ ALL RIGHTS RESERVED.\
+ United States Government sponsorship acknowledged.\
+ Any commercial use must be negotiated with the Office of Technology Transfer\
+ at the California Institute of Technology.\
+ This software may be subject to U.S. export control laws and regulations.\
+ By accepting this document, the user agrees to comply with all applicable\
+ U.S. export laws and regulations. User has the responsibility to obtain\
+ export licenses, or other export authority as may be required, before\
+ exporting such information to foreign countries or providing access to\
+ foreign persons." \
+  org.label-schema.name="OPERA Product Generation Executable (PGE) Image" \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.vendor="California Institute of Technology" \
+  maintainer="California Institute of Technology"
+
+# Copy the OPERA PGE software into the container
+# the base container has a default user "conda" with UID/GID 1000/1000
+COPY --chown=conda:conda ${PGE_SOURCE_DIR} ${PGE_DEST_DIR}
+
+# Switch to root for installing into Conda Env
+USER 0:0
+
+# Install dependencies into existing Conda Env
+RUN set -ex \
+    && cd ${PGE_DEST_DIR} \
+    && mkdir -p /opt/conda/bin \
+    && cp ${PGE_DEST_DIR}/opera/scripts/pge_docker_entrypoint.sh /opt/conda/bin \
+    && chmod +x /opt/conda/bin/pge_docker_entrypoint.sh
+
+
+# Set the Docker entrypoint and clear the default command
+ENTRYPOINT ["/opt/conda/bin/pge_docker_entrypoint.sh"]
+CMD []
+
+# Set the user/group back to the default
+USER conda:conda

--- a/.ci/scripts/build_dswx_hls.sh
+++ b/.ci/scripts/build_dswx_hls.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Copyright 2021, by the California Institute of Technology.
+# ALL RIGHTS RESERVED.
+# United States Government sponsorship acknowledged.
+# Any commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+# This software may be subject to U.S. export control laws and regulations.
+# By accepting this document, the user agrees to comply with all applicable
+# U.S. export laws and regulations. User has the responsibility to obtain
+# export licenses, or other export authority as may be required, before
+# exporting such information to foreign countries or providing access to
+# foreign persons.
+#
+# Script to build the OPERA DSWx-HLS PGE Docker image
+#
+
+echo '
+=====================================
+
+Building DSWx-HLS PGE docker image...
+
+=====================================
+'
+
+set -e
+
+IMAGE='opera_pge/dswx_hls'
+TAG=$1
+WORKSPACE=$2
+BUILD_DATE_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+# defaults
+[ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath $(dirname $(realpath $0))/../..)
+[ -z "${TAG}" ] && TAG="${USER}-dev"
+
+echo "WORKSPACE: $WORKSPACE"
+echo "IMAGE: $IMAGE"
+echo "TAG: $TAG"
+
+# Check that the .ci scripts directory exists
+if [ ! -d "${WORKSPACE}/.ci" ]; then
+  echo "Error: the .ci directory doesn't exist at ${WORKSPACE}/.ci"
+  exit 1
+fi
+
+# Create a directory on the host to use as a staging area for files to be
+# copied into the resulting Docker image.
+STAGING_DIR=$(mktemp -d -p ${WORKSPACE} docker_image_staging_XXXXXXXXXX)
+
+# Configure a trap to clean up on exit regardless of whether the build succeeds
+function cleanup {
+  if [[ -z ${KEEP_TEMP_FILES} ]]; then
+    echo "Cleaning up staging directory ${STAGING_DIR}..."
+    rm -rf ${STAGING_DIR}
+  fi
+}
+
+trap cleanup EXIT
+
+# Copy files to the staging area and build the PGE docker image
+cp -r ${WORKSPACE}/src/opera \
+      ${STAGING_DIR}/
+
+cp ${WORKSPACE}/COPYING \
+   ${STAGING_DIR}/opera
+
+# Create a VERSION file in the staging area to track version and build time
+printf "pge_version: ${TAG}\npge_build_datetime: ${BUILD_DATE_TIME}\n" \
+    > ${STAGING_DIR}/opera/VERSION \
+
+# Remove the old Docker image, if it exists
+EXISTING_IMAGE_ID=$(docker images -q ${IMAGE}:${TAG})
+if [[ ! -z ${EXISTING_IMAGE_ID} ]]; then
+  docker rmi ${EXISTING_IMAGE_ID}
+fi
+
+# Build the PGE docker image
+docker build --rm --force-rm -t ${IMAGE}:${TAG} \
+    --build-arg BUILD_DATE_TIME=${BUILD_DATE_TIME} \
+    --build-arg BUILD_VERSION=${TAG} \
+    --build-arg PGE_SOURCE_DIR=$(basename ${STAGING_DIR}) \
+    --file ${WORKSPACE}/.ci/docker/Dockerfile_dswx_hls ${WORKSPACE}
+
+exit $?

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,14 @@
+Copyright 2021, California Institute of Technology.
+            ALL RIGHTS RESERVED.
+  U.S. Government Sponsorship acknowledged.
+
+Any commercial use must be negotiated with the Office of Technology
+Transfer to the California Institute of Technology.
+
+This software may be subject to U.S. export control laws and
+regulations.  By accepting this document, the user agrees to comply
+with all applicable U.S. export laws and regulations.
+
+User has the responsibility to obtain export licenses, or other export
+authority as may be required before exporting such information to
+foreign countries or providing access to foreign persons.

--- a/src/opera/scripts/pge_docker_entrypoint.sh
+++ b/src/opera/scripts/pge_docker_entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Docker entrypoint script for OPERA PGE docker containers
+# Responsible for configuring the shell environment for the execution of pge_main.py
+
+DOCKER_ENTRYPOINT_SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+PGE_PROGRAM_DIR=/home/conda
+
+# Python path setup
+export PYTHONPATH=$PYTHONPATH:${PGE_PROGRAM_DIR}
+
+# Run the PGE wrapped by the following:
+# 1) docker-stats-on-exit-shim to collect computer usage info.  TODO
+#    https://github.com/delcypher/docker-stats-on-exit-shim
+# 2) The "PGE main" script, which is part of the opera_pge repo copied into the
+#    SAS container
+
+${PGE_PROGRAM_DIR}/opera/scripts/pge_main.py "$@"

--- a/src/opera/scripts/pge_main.py
+++ b/src/opera/scripts/pge_main.py
@@ -21,7 +21,8 @@
 pge_main.py
 ============
 
-Instantiates and runs a PGEExecutor instance.
+Instantiates and runs an OPERA Product Generation Executable (PGE) instance.
+The PGE type instantiated is determined from the provided RunConfig.
 
 """
 

--- a/src/opera/util/run_utils.py
+++ b/src/opera/util/run_utils.py
@@ -83,8 +83,8 @@ def create_sas_command_line(sas_program_path, sas_runconfig_path,
             command_line = ['python3', '-m', sas_program_path]
 
     # Add any provided arguments
-    if sas_program_options:
-        command_line.extend(sas_program_options)
+    for sas_program_option in sas_program_options:
+        command_line.extend(sas_program_option.split())
 
     # Lastly, only explicit input should ever be the path to the runconfig
     command_line.append(sas_runconfig_path)


### PR DESCRIPTION
This PR adds the initial set of scripts to create a combined PGE-SAS Docker Image, based on the DSWx-HLS interface image provided by ADT. This includes a Dockerfile for injecting the `opera_pge` repo into the existing DSWx-HLS image, an entrypoint script for kicking off `pge_main` when the container is invoked, and a script for building the image itself.

@JHofman728 