### PR TITLE
CI HTML Publishing for Code Coverage

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -56,7 +56,14 @@ pipeline {
                    script: ".ci/scripts/test_all_images.sh $DOCKER_TAG"
                 junit 'test_results/**/*.xml'
                 archiveArtifacts artifacts: 'test_results/**/*.log', fingerprint: true
-                // TODO add HTML publishing of test coverage reports once plugin is installed
+                // TODO: this will require rework once we have more than one PGE to deal with
+                publishHTML([allowMissing: true,
+                             alwaysLinkToLastBuild: true,
+                             keepAll: true,
+                             reportDir: 'test_results/dswx_hls/coverage_html',
+                             reportFiles: 'index.html',
+                             reportName: 'Code Coverage',
+                             reportTitles: 'DSWx-HLS Code Coverage'])
             }
         }
         stage('Upload OPERA PGE Docker image tar files to Artifactory-FN') {

--- a/.ci/scripts/build_dswx_hls.sh
+++ b/.ci/scripts/build_dswx_hls.sh
@@ -15,6 +15,8 @@
 # Script to build the OPERA DSWx-HLS PGE Docker image
 #
 
+set -e
+
 echo '
 =====================================
 

--- a/.ci/scripts/test_dswx_hls.sh
+++ b/.ci/scripts/test_dswx_hls.sh
@@ -15,6 +15,8 @@
 # Script to execute tests on OPERA DSWx-HLS PGE Docker image
 #
 
+set -e
+
 echo '
 =====================================
 
@@ -23,54 +25,73 @@ Testing DSWx-HLS PGE Docker image...
 =====================================
 '
 
-IMAGE="opera_pge/dswx_hls"
+PGE_NAME="dswx_hls"
+IMAGE="opera_pge/${PGE_NAME}"
+TEST_RESULTS_REL_DIR="test_results"
+
 TAG=$1
 WORKSPACE=$2
-TEST_RESULTS_REL_DIR="test_results/dswx_hls"
 
 # defaults
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath $(dirname $(realpath $0))/../..)
 [ -z "${TAG}" ] && TAG="${USER}-dev"
 
-echo "Test results output directory:  ${WORKSPACE}/${TEST_RESULTS_REL_DIR}"
-mkdir --mode=775 --parents ${WORKSPACE}/${TEST_RESULTS_REL_DIR}
+TEST_RESULTS_DIR="${WORKSPACE}/${TEST_RESULTS_REL_DIR}/${PGE_NAME}"
+
+echo "Test results output directory: ${TEST_RESULTS_DIR}"
+mkdir --mode=775 --parents ${TEST_RESULTS_DIR}
+chmod -R 775 ${TEST_RESULTS_DIR}
 
 # Use the environment of the docker image to run linting, tests, etc...
+# Note the change of working directory (-w) to a directory without
+# Python code so that import statements favor Python code found in the
+# Docker image rather than code found on the host.
 DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}:/workspace \
-    -u conda:conda \
+    -w /workspace/${TEST_RESULTS_REL_DIR}
+    -u ${UID}:$(id -g) \
     --entrypoint /opt/conda/bin/pge_tests_entrypoint.sh \
     ${IMAGE}:${TAG}"
+
+# Configure a trap to set permissions on exit regardless of whether the testing succeeds
+function set_perms {
+    # Open up permissions on all test results we can be sure the CI system can
+    # delete them after they're archived within Jenkins
+    ${DOCKER_RUN} bash -c "find \
+        /workspace/${TEST_RESULTS_REL_DIR} -type d -exec chmod 775 {} +"
+
+    ${DOCKER_RUN} bash -c "find \
+        /workspace/${TEST_RESULTS_REL_DIR} -type f -exec chmod 664 {} +"
+}
+
+trap set_perms EXIT
 
 # linting and pep8 style check (configured by .flake8 and .pylintrc)
 ${DOCKER_RUN} flake8 \
     --config /home/conda/opera/.flake8 \
     --jobs auto \
+    --exit-zero \
     --application-import-names opera \
-    --output-file /workspace/${TEST_RESULTS_REL_DIR}/flake8.log \
+    --output-file /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/flake8.log \
     /home/conda/opera
 
 ${DOCKER_RUN} pylint \
     --rcfile=/home/conda/opera/.pylintrc \
     --jobs 0 \
-    --output=/workspace/${TEST_RESULTS_REL_DIR}/pylint.log \
+    --exit-zero \
+    --output=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pylint.log \
     --enable-all-extensions \
     /home/conda/opera
 
 # pytest (including code coverage)
 ${DOCKER_RUN} bash -c "pytest \
-    --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/pytest-junit.xml \
+    --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
     --cov=/home/conda/opera/pge \
     --cov=/home/conda/opera/scripts \
     --cov=/home/conda/opera/util \
     --cov-report=term \
-    --cov-report=html:/workspace/${TEST_RESULTS_REL_DIR}/coverage_html \
-    /home/conda/opera > /workspace/${TEST_RESULTS_REL_DIR}/pytest.log 2>&1"
-
-# Open up permissions on all output reports so the CI system can delete them
-# after they're archived within Jenkins
-${DOCKER_RUN} bash -c "chmod \
-    -R 775 /workspace/${TEST_RESULTS_REL_DIR}/"
+    --cov-report=html:/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/coverage_html \
+    /workspace/src/opera/test > /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest.log 2>&1"
 
 echo "DSWx-HLS PGE Docker image test complete"
 


### PR DESCRIPTION
An update to the Jenkins CI scripts to add a stage for publishing the pytest code coverage HTML. This branch also adds some improvements to permission handling of test results to ensure that Jenkins can always cleanup successfully after a pipeline.