### PR TITLE
Issues 20 21 22

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=docstring-first-line-empty,empty-comment,print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call,too-few-public-methods
+disable=too-many-try-statements,docstring-first-line-empty,empty-comment,print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call,too-few-public-methods
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -245,10 +245,10 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 docstring-min-length=-1
 
 # Naming hint for function names
-function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+function-name-hint=(([a-z][a-z0-9_]{2,60})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct function names
-function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+function-rgx=(([a-z][a-z0-9_]{2,60})|(_[a-z0-9_]*))$
 
 # Good variable names which should always be accepted, separated by a comma
 good-names=i,j,k,ex,Run,_
@@ -263,10 +263,10 @@ inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
 # Naming hint for method names
-method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+method-name-hint=(([a-z][a-z0-9_]{2,60})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct method names
-method-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+method-rgx=(([a-z][a-z0-9_]{2,60})|(_[a-z0-9_]*))$
 
 # Naming hint for module names
 module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$

--- a/src/opera/pge/__init__.py
+++ b/src/opera/pge/__init__.py
@@ -23,3 +23,5 @@ Contains modules for stand-up and execution of a PGE application.
 from .base_pge import PgeExecutor
 from .dswx_pge import DSWxExecutor
 from .runconfig import RunConfig
+
+

--- a/src/opera/pge/__init__.py
+++ b/src/opera/pge/__init__.py
@@ -20,8 +20,6 @@ pge
 Contains modules for stand-up and execution of a PGE application.
 """
 
-from .base_pge import PgeExecutor
-from .dswx_pge import DSWxExecutor
-from .runconfig import RunConfig
-
-
+from .base_pge import PgeExecutor  # noqa: F401
+from .dswx_pge import DSWxExecutor  # noqa: F401
+from .runconfig import RunConfig  # noqa: F401

--- a/src/opera/pge/base_pge.py
+++ b/src/opera/pge/base_pge.py
@@ -22,17 +22,18 @@ Module defining the Base PGE interfaces from which all other PGEs are derived.
 """
 
 import os
-import yaml
-
 from os.path import abspath, basename, exists, join, splitext
 
 from yamale import YamaleError
 
-from .runconfig import RunConfig
+import yaml
+
 from opera.util.error_codes import ErrorCode
 from opera.util.logger import PgeLogger
 from opera.util.run_utils import create_sas_command_line
 from opera.util.run_utils import time_and_execute
+
+from .runconfig import RunConfig
 
 
 class PreProcessorMixin:
@@ -50,6 +51,7 @@ class PreProcessorMixin:
     steps as necessary.
 
     """
+
     _pre_mixin_name = "PreProcessorMixin"
 
     def __init__(self):
@@ -63,8 +65,8 @@ class PreProcessorMixin:
 
         The logger is created using a default name, as the proper filename
         cannot be determined until the RunConfig is parsed and validated.
-        """
 
+        """
         if not self.logger:
             self.logger = PgeLogger()
             self.logger.info(self.name, ErrorCode.LOG_FILE_CREATED,
@@ -154,7 +156,7 @@ class PreProcessorMixin:
         self.logger.move(log_file_destination)
 
         self.logger.info(self.name, ErrorCode.LOG_FILE_INIT_COMPLETE,
-                         f'Log file configuration complete')
+                         'Log file configuration complete')
 
     def run_preprocessor(self, **kwargs):
         """
@@ -194,6 +196,7 @@ class PostProcessorMixin:
     steps as necessary.
 
     """
+
     _post_mixin_name = "PostProcessorMixin"
 
     def __init__(self):
@@ -267,6 +270,7 @@ class PgeExecutor(PreProcessorMixin, PostProcessorMixin):
     common functionality from this class.
 
     """
+
     NAME = "PgeExecutor"
 
     def __init__(self, pge_name, runconfig_path, **kwargs):
@@ -286,9 +290,7 @@ class PgeExecutor(PreProcessorMixin, PostProcessorMixin):
                            to use, rather than creating its own.
 
         """
-
- #       TODO pycharm suggested this, not sure if necessary with mixins, but worth checking in on.
- #       super().__init__()
+        
         self.name = self.NAME
         self.pge_name = pge_name
         self.runconfig_path = runconfig_path

--- a/src/opera/pge/base_pge.py
+++ b/src/opera/pge/base_pge.py
@@ -290,7 +290,6 @@ class PgeExecutor(PreProcessorMixin, PostProcessorMixin):
                            to use, rather than creating its own.
 
         """
-        
         self.name = self.NAME
         self.pge_name = pge_name
         self.runconfig_path = runconfig_path
@@ -313,7 +312,7 @@ class PgeExecutor(PreProcessorMixin, PostProcessorMixin):
         sas_runconfig_filepath = join(self.runconfig.scratch_path, sas_runconfig_filename)
 
         try:
-            with open(sas_runconfig_filepath, 'w') as outfile:
+            with open(sas_runconfig_filepath, 'w', encoding='utf-8') as outfile:
                 yaml.safe_dump(sas_config, outfile, sort_keys=False)
         except OSError as err:
             self.logger.critical(self.name, ErrorCode.SAS_CONFIG_CREATION_FAILED,

--- a/src/opera/pge/base_pge.py
+++ b/src/opera/pge/base_pge.py
@@ -167,7 +167,7 @@ class PreProcessorMixin:
 
         Parameters
         ----------
-        kwargs : dict
+        **kwargs : dict
             Any keyword arguments needed by the pre-processor
 
         """
@@ -240,7 +240,7 @@ class PostProcessorMixin:
 
         Parameters
         ----------
-        kwargs : dict
+        **kwargs : dict
             Any keyword arguments needed by the post-processor
 
         """
@@ -333,7 +333,7 @@ class PgeExecutor(PreProcessorMixin, PostProcessorMixin):
 
         Parameters
         ----------
-        kwargs : dict
+        **kwargs : dict
             Any keyword arguments needed for SAS execution.
 
         """

--- a/src/opera/pge/dswx_pge.py
+++ b/src/opera/pge/dswx_pge.py
@@ -67,11 +67,10 @@ class DSWxPreProcessorMixin(PreProcessorMixin):
                     error_msg = f"Input directory {input_file_path} does not contain any tif files"
 
                     self.logger.critical(self.name, ErrorCode.INPUT_NOT_FOUND, error_msg)
-            else:
-                if not input_file_path.endswith(".tif"):
-                    error_msg = f"Input file {input_file_path} does not have .tif extension"
+            elif not input_file_path.endswith(".tif"):
+                error_msg = f"Input file {input_file_path} does not have .tif extension"
 
-                    self.logger.critical(self.name, ErrorCode.INVALID_INPUT, error_msg)
+                self.logger.critical(self.name, ErrorCode.INVALID_INPUT, error_msg)
 
     def run_preprocessor(self, **kwargs):
         """
@@ -83,11 +82,11 @@ class DSWxPreProcessorMixin(PreProcessorMixin):
 
         Parameters
         ----------
-        kwargs : dict
+        **kwargs : dict
             Any keyword arguments needed by the pre-processor
 
         """
-        super(DSWxPreProcessorMixin, self).run_preprocessor(**kwargs)
+        super().run_preprocessor(**kwargs)
 
         self._validate_inputs()
 
@@ -121,7 +120,7 @@ class DSWxPostProcessorMixin(PostProcessorMixin):
 
             self.logger.critical(self.name, ErrorCode.OUTPUT_NOT_FOUND, error_msg)
 
-        if os.path.getsize(output_path) == 0:
+        if not os.path.getsize(output_path):
             error_msg = f"SAS output file {output_path} was created but is empty"
 
             self.logger.critical(self.name, ErrorCode.INVALID_OUTPUT, error_msg)
@@ -136,7 +135,7 @@ class DSWxPostProcessorMixin(PostProcessorMixin):
 
         Parameters
         ----------
-        kwargs : dict
+        **kwargs : dict
             Any keyword arguments needed by the post-processor
 
         """

--- a/src/opera/pge/runconfig.py
+++ b/src/opera/pge/runconfig.py
@@ -26,10 +26,12 @@ Adapted By: Scott Collins
 """
 import os
 
-import yaml
+from pkg_resources import resource_filename
 
 import yamale
-from pkg_resources import resource_filename
+
+import yaml
+
 
 BASE_PGE_SCHEMA = resource_filename('opera', 'schema/base_pge_schema.yaml')
 """Path to the Yamale schema applicable to the PGE portion of each RunConfig"""
@@ -140,12 +142,12 @@ class RunConfig:
                 sas_schema = yamale.make_schema(sas_schema_filepath)
 
                 # Link the SAS schema to the PGE as an "include"
-                # Note that the key name "sas_configuration" must match the include
+                # Note that the key name "sas_configuration" must match the include statement
                 # reference in the base PGE schema.
                 pge_schema.includes['sas_configuration'] = sas_schema
             else:
                 raise RuntimeError(
-                    f'Can not validate RunConfig {self.name} as the associated SAS '
+                    f'Can not validate RunConfig {self.name}, as the associated SAS '
                     f'schema ({sas_schema_filename}) cannot be located within the '
                     f'schemas directory.'
                 )
@@ -184,92 +186,113 @@ class RunConfig:
 
     @property
     def filename(self) -> str:
+        """Returns the of the file parsed to create the RunConfig"""
         return self._filename
 
     @property
     def name(self) -> str:
+        """Returns the name of the RunConfig file"""
         return self._run_config['Name']
 
     # PGENameGroup
     @property
     def pge_name(self) -> str:
+        """Returns the PGE Name from the PGE Name Group"""
         return self._pge_config['PGENameGroup']['PGEName']
 
     # InputFilesGroup
     @property
     def input_files(self) -> list:
+        """Returns the path from the Input Files Group"""
         return self._pge_config['InputFilesGroup']['InputFilePaths']
 
     # DynamicAncillaryFilesGroup
     @property
     def ancillary_file_map(self) -> dict:
+        """Returns the Ancillary File Map from the Dynamic Ancillary Files Group"""
         return self._pge_config['DynamicAncillaryFilesGroup']['AncillaryFileMap']
 
     # ProductPathGroup
     @property
     def product_counter(self) -> int:
+        """Returns the Product Counter from Product Path Group"""
         return self._pge_config['ProductPathGroup']['ProductCounter']
 
     @property
     def output_product_path(self) -> str:
+        """Returns the Output Product Path from the Product Path Group"""
         return self._pge_config['ProductPathGroup']['OutputProductPath']
 
     @property
     def scratch_path(self) -> str:
+        """Returns the Scratch Path from the Product Path Group"""
         return self._pge_config['ProductPathGroup']['ScratchPath']
 
     @property
     def sas_output_file(self) -> str:
+        """Returns the SAS Output File from the Product Path Group"""
         return self._pge_config['ProductPathGroup']['SASOutputFile']
 
     # PrimaryExecutable
     @property
     def product_identifier(self) -> str:
+        """Returns the Product Identifier from a Primary Executable Category"""
         return self._pge_config['PrimaryExecutable']['ProductIdentifier']
 
     @property
     def sas_program_path(self) -> str:
+        """Returns the Program Path from a Primary Executable Category"""
         return self._pge_config['PrimaryExecutable']['ProgramPath']
 
     @property
     def sas_program_options(self) -> str:
+        """Returns the Program Options (arguments) to a Primary Executable"""
         return self._pge_config['PrimaryExecutable']['ProgramOptions']
 
     @property
     def error_code_base(self) -> int:
+        """Returns the Error Code Base for a particular Primary Executable"""
         return self._pge_config['PrimaryExecutable']['ErrorCodeBase']
 
     @property
     def sas_schema_path(self) -> str:
+        """Returns the path to the Schema file for a Primary Executable"""
         return self._pge_config['PrimaryExecutable']['SchemaPath']
 
     @property
     def iso_template_path(self) -> str:
+        """Returns the ISO Template Path for a Primary Executable"""
         return self._pge_config['PrimaryExecutable']['IsoTemplatePath']
 
     # QAExecutable
     @property
     def qa_enabled(self) -> bool:
-        return self._pge_config['QAExecutable']['Enabled']
+        """Returns a boolean indicating the state of QAExecutable: enabled/disabled"""
+        return bool(self._pge_config['QAExecutable']['Enabled'])
 
     @property
     def qa_program_path(self) -> str:
+        """Return the path to a QA Executable"""
         return self._pge_config['QAExecutable']['ProgramPath']
 
     @property
     def qa_program_options(self) -> str:
+        """Return program options (arguments) for an executable command"""
         return self._pge_config['QAExecutable']['ProgramOptions']
 
     @property
     def debug_switch(self) -> bool:
+        """Returns a boolean indicating the debugging state: enabled/disabled."""
         return bool(self._pge_config['DebugLevelGroup']['DebugSwitch'])
 
     @property
     def execute_via_shell(self) -> bool:
+        """Returns a boolean indicating the state of ExecuteViaShell: enabled/disabled"""
         return bool(self._pge_config['DebugLevelGroup'].get('ExecuteViaShell', False))
 
     @property
     def sas_config(self) -> dict:
+        """Returns the short-cut to the SAS-specific section of the parsed RunConfig"""
         return self._sas_config
 
     def get_ancillary_filenames(self):

--- a/src/opera/pge/runconfig.py
+++ b/src/opera/pge/runconfig.py
@@ -89,15 +89,15 @@ class RunConfig:
             If the parsed config does not define a top-level "RunConfig" entry
 
         """
-        with open(yaml_filename, 'r') as stream:
+        with open(yaml_filename, 'r', encoding='utf-8') as stream:
             dictionary = yaml.safe_load(stream)
 
         try:
             return dictionary['RunConfig']
-        except KeyError:
+        except KeyError as key_error:
             raise RuntimeError(
                 f'Unable to parse {yaml_filename}, expected top-level RunConfig entry'
-            )
+            ) from key_error
 
     def validate(self, pge_schema_file=BASE_PGE_SCHEMA, strict_mode=True):
         """
@@ -182,7 +182,7 @@ class RunConfig:
             # TODO: create exceptions package with more intuitive exception class names
             raise RuntimeError(
                 f'Expected field "{str(error)}" is missing from RunConfig {self.filename}'
-            )
+            ) from error
 
     @property
     def filename(self) -> str:

--- a/src/opera/pge/runconfig.py
+++ b/src/opera/pge/runconfig.py
@@ -175,6 +175,11 @@ class RunConfig:
         attribute : object
             The accessed attribute.
 
+        Raises
+        ------
+        RuntimeError
+            If the attribute requests fails (from missing field in RunConfig).
+
         """
         try:
             return object.__getattribute__(self, item)
@@ -308,8 +313,6 @@ class RunConfig:
             the DynamicAncillaryFilesGroup section.
 
         """
-        result = list(
-            filter(lambda filename: filename, self.ancillary_file_map.values())
-        )
+        result = list(self.ancillary_file_map.values())
 
         return result

--- a/src/opera/scripts/pge_main.py
+++ b/src/opera/scripts/pge_main.py
@@ -32,8 +32,8 @@ import os
 from opera.pge.base_pge import PgeExecutor
 from opera.pge.dswx_pge import DSWxExecutor
 from opera.pge.runconfig import RunConfig
-from opera.util.logger import PgeLogger
 from opera.util.error_codes import ErrorCode
+from opera.util.logger import PgeLogger
 
 PGE_NAME_MAP = {
     'DSWX_HLS_PGE': DSWxExecutor,
@@ -83,7 +83,6 @@ def open_log_file():
         PgeLogger object with initialized filename
 
     """
-
     logger = PgeLogger('PGE::' + os.path.basename(__file__), PgeLogger.LOGGER_CODE_BASE)
 
     logger.info("pge_main", ErrorCode.LOG_FILE_CREATED,
@@ -110,7 +109,6 @@ def load_run_config_file(logger, run_config_filename):
         The python RunConfig instance
 
     """
-
     # Log the yaml config file that is used.
     run_config = RunConfig(run_config_filename)
     msg = f'RunConfig yaml file: {run_config_filename}'
@@ -140,7 +138,6 @@ def pge_start(run_config_filename):
         Path and filename to run config yaml file.
 
     """
-
     logger = open_log_file()
 
     # Load the yaml run config file
@@ -165,7 +162,6 @@ def pge_main():
     specific PGE, then runs that specific PGE.
 
     """
-
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter

--- a/src/opera/test/__init__.py
+++ b/src/opera/test/__init__.py
@@ -18,4 +18,5 @@ test
 ====
 
 The unit-level regression test module for the OPERA PGE Subsystem.
+
 """

--- a/src/opera/test/pge/test_base_pge.py
+++ b/src/opera/test/pge/test_base_pge.py
@@ -107,7 +107,7 @@ class BasePgeTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(expected_log_file))
 
         # Open the log file, and check that "SAS" output was captured
-        with open(expected_log_file, 'r') as infile:
+        with open(expected_log_file, 'r', encoding='utf-8') as infile:
             log_contents = infile.read()
 
         self.assertIn('hello world', log_contents)
@@ -132,7 +132,7 @@ class BasePgeTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(expected_log_file))
 
         # Open the log file, and check that the validation error details were captured
-        with open(expected_log_file, 'r') as infile:
+        with open(expected_log_file, 'r', encoding='utf-8') as infile:
             log_contents = infile.read()
 
         self.assertIn("RunConfig.Groups.PGE.InputFilesGroup.InputFilePaths: 'None' is not a list.", log_contents)
@@ -161,7 +161,7 @@ class BasePgeTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(expected_log_file))
 
         # Open the log file, and check that the execution error details were captured
-        with open(expected_log_file, 'r') as infile:
+        with open(expected_log_file, 'r', encoding='utf-8') as infile:
             log_contents = infile.read()
 
         expected_error_code = 123

--- a/src/opera/test/pge/test_dswx_pge.py
+++ b/src/opera/test/pge/test_dswx_pge.py
@@ -78,6 +78,7 @@ class DSWxPgeTestCase(unittest.TestCase):
     def tearDown(self) -> None:
         """Return to starting directory"""
         os.chdir(self.test_dir)
+
     def test_dswx_pge_execution(self):
         """
         Test execution of the DSWxExecutor class and its associated mixins using
@@ -122,7 +123,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(expected_log_file))
 
         # Open and read the log
-        with open(expected_log_file, 'r') as infile:
+        with open(expected_log_file, 'r', encoding='utf-8') as infile:
             log_contents = infile.read()
 
         self.assertIn(f"DSWx-HLS invoked with RunConfig {expected_sas_config_file}", log_contents)
@@ -132,7 +133,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         runconfig_path = join(self.data_dir, 'test_dswx_hls_config.yaml')
         test_runconfig_path = join(self.data_dir, 'invalid_dswx_runconfig.yaml')
 
-        with open(runconfig_path, 'r') as stream:
+        with open(runconfig_path, 'r', encoding='utf-8') as stream:
             runconfig_dict = yaml.safe_load(stream)
 
         input_files_group = runconfig_dict['RunConfig']['Groups']['PGE']['InputFilesGroup']
@@ -140,10 +141,8 @@ class DSWxPgeTestCase(unittest.TestCase):
         # Test that a non-existent file is detected by pre-processor
         input_files_group['InputFilePaths'] = ['non_existent_file.tif']
 
-        dir = os.getcwd()
-
-        with open(test_runconfig_path, 'w') as input:
-            yaml.safe_dump(runconfig_dict, input, sort_keys=False)
+        with open(test_runconfig_path, 'w', encoding='utf-8') as input_path:
+            yaml.safe_dump(runconfig_dict, input_path, sort_keys=False)
 
         pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
 
@@ -157,7 +156,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(expected_log_file))
 
         # Open the log file, and check that the validation error details were captured
-        with open(expected_log_file, 'r') as infile:
+        with open(expected_log_file, 'r', encoding='utf-8') as infile:
             log_contents = infile.read()
 
         self.assertIn(f"Could not locate specified input file/directory "
@@ -166,7 +165,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         # Test that an input directory with no .tif files is caught
         input_files_group['InputFilePaths'] = ['dswx_pge_test/scratch_dir']
 
-        with open(test_runconfig_path, 'w') as out_file:
+        with open(test_runconfig_path, 'w', encoding='utf-8') as out_file:
             yaml.safe_dump(runconfig_dict, out_file, sort_keys=False)
 
         pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
@@ -177,7 +176,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         expected_log_file = pge.logger.get_file_name()
         self.assertTrue(os.path.exists(expected_log_file))
 
-        with open(expected_log_file, 'r') as infile:
+        with open(expected_log_file, 'r', encoding='utf-8') as infile:
             log_contents = infile.read()
 
         self.assertIn(f"Input directory {abspath('dswx_pge_test/scratch_dir')} "
@@ -186,7 +185,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         # Lastly, check that a file that exists but is not a tif is caught
         input_files_group['InputFilePaths'] = [runconfig_path]
 
-        with open(test_runconfig_path, 'w') as runconfig_fh:
+        with open(test_runconfig_path, 'w', encoding='utf-8') as runconfig_fh:
             yaml.safe_dump(runconfig_dict, runconfig_fh, sort_keys=False)
 
         pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
@@ -197,7 +196,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         expected_log_file = pge.logger.get_file_name()
         self.assertTrue(os.path.exists(expected_log_file))
 
-        with open(expected_log_file, 'r') as infile:
+        with open(expected_log_file, 'r', encoding='utf-8') as infile:
             log_contents = infile.read()
 
         self.assertIn(f"Input file {abspath(runconfig_path)} does not have "
@@ -208,7 +207,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         runconfig_path = join(self.data_dir, 'test_dswx_hls_config.yaml')
         test_runconfig_path = join(self.data_dir, 'invalid_dswx_runconfig.yaml')
 
-        with open(runconfig_path, 'r') as stream:
+        with open(runconfig_path, 'r', encoding='utf-8') as stream:
             runconfig_dict = yaml.safe_load(stream)
 
         product_path_group = runconfig_dict['RunConfig']['Groups']['PGE']['ProductPathGroup']
@@ -220,7 +219,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         primary_executable_group['ProgramPath'] = 'echo'
         primary_executable_group['ProgramOptions'] = ['hello world']
 
-        with open(test_runconfig_path, 'w') as config_fh:
+        with open(test_runconfig_path, 'w', encoding='utf-8') as config_fh:
             yaml.safe_dump(runconfig_dict, config_fh, sort_keys=False)
 
         pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
@@ -234,7 +233,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         expected_log_file = pge.logger.get_file_name()
         self.assertTrue(os.path.exists(expected_log_file))
 
-        with open(expected_log_file, 'r') as infile:
+        with open(expected_log_file, 'r', encoding='utf-8') as infile:
             log_contents = infile.read()
 
         self.assertIn(f"Expected SAS output file {abspath(expected_output_file)} "
@@ -247,7 +246,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         primary_executable_group['ProgramPath'] = 'touch'
         primary_executable_group['ProgramOptions'] = ['dswx_pge_test/output_dir/empty_dswx_hls.tif']
 
-        with open(test_runconfig_path, 'w') as outfile:
+        with open(test_runconfig_path, 'w', encoding='utf-8') as outfile:
             yaml.safe_dump(runconfig_dict, outfile, sort_keys=False)
 
         pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
@@ -261,7 +260,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         expected_log_file = pge.logger.get_file_name()
         self.assertTrue(os.path.exists(expected_log_file))
 
-        with open(expected_log_file, 'r') as infile:
+        with open(expected_log_file, 'r', encoding='utf-8') as infile:
             log_contents = infile.read()
 
         self.assertIn(f"SAS output file {abspath(expected_output_file)} was "

--- a/src/opera/test/pge/test_dswx_pge.py
+++ b/src/opera/test/pge/test_dswx_pge.py
@@ -144,63 +144,67 @@ class DSWxPgeTestCase(unittest.TestCase):
         with open(test_runconfig_path, 'w', encoding='utf-8') as input_path:
             yaml.safe_dump(runconfig_dict, input_path, sort_keys=False)
 
-        pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
+        try:
+            pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
 
-        with self.assertRaises(RuntimeError):
-            pge.run()
+            with self.assertRaises(RuntimeError):
+                pge.run()
 
-        # Config validation occurs before the log is fully initialized, but the
-        # initial log file should still exist and contain details of the validation
-        # error
-        expected_log_file = pge.logger.get_file_name()
-        self.assertTrue(os.path.exists(expected_log_file))
+            # Config validation occurs before the log is fully initialized, but the
+            # initial log file should still exist and contain details of the validation
+            # error
+            expected_log_file = pge.logger.get_file_name()
+            self.assertTrue(os.path.exists(expected_log_file))
 
-        # Open the log file, and check that the validation error details were captured
-        with open(expected_log_file, 'r', encoding='utf-8') as infile:
-            log_contents = infile.read()
+            # Open the log file, and check that the validation error details were captured
+            with open(expected_log_file, 'r', encoding='utf-8') as infile:
+                log_contents = infile.read()
 
-        self.assertIn(f"Could not locate specified input file/directory "
-                      f"{abspath('non_existent_file.tif')}", log_contents)
+            self.assertIn(f"Could not locate specified input file/directory "
+                          f"{abspath('non_existent_file.tif')}", log_contents)
 
-        # Test that an input directory with no .tif files is caught
-        input_files_group['InputFilePaths'] = ['dswx_pge_test/scratch_dir']
+            # Test that an input directory with no .tif files is caught
+            input_files_group['InputFilePaths'] = ['dswx_pge_test/scratch_dir']
 
-        with open(test_runconfig_path, 'w', encoding='utf-8') as out_file:
-            yaml.safe_dump(runconfig_dict, out_file, sort_keys=False)
+            with open(test_runconfig_path, 'w', encoding='utf-8') as out_file:
+                yaml.safe_dump(runconfig_dict, out_file, sort_keys=False)
 
-        pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
+            pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
 
-        with self.assertRaises(RuntimeError):
-            pge.run()
+            with self.assertRaises(RuntimeError):
+                pge.run()
 
-        expected_log_file = pge.logger.get_file_name()
-        self.assertTrue(os.path.exists(expected_log_file))
+            expected_log_file = pge.logger.get_file_name()
+            self.assertTrue(os.path.exists(expected_log_file))
 
-        with open(expected_log_file, 'r', encoding='utf-8') as infile:
-            log_contents = infile.read()
+            with open(expected_log_file, 'r', encoding='utf-8') as infile:
+                log_contents = infile.read()
 
-        self.assertIn(f"Input directory {abspath('dswx_pge_test/scratch_dir')} "
-                      f"does not contain any tif files", log_contents)
+            self.assertIn(f"Input directory {abspath('dswx_pge_test/scratch_dir')} "
+                          f"does not contain any tif files", log_contents)
 
-        # Lastly, check that a file that exists but is not a tif is caught
-        input_files_group['InputFilePaths'] = [runconfig_path]
+            # Lastly, check that a file that exists but is not a tif is caught
+            input_files_group['InputFilePaths'] = [runconfig_path]
 
-        with open(test_runconfig_path, 'w', encoding='utf-8') as runconfig_fh:
-            yaml.safe_dump(runconfig_dict, runconfig_fh, sort_keys=False)
+            with open(test_runconfig_path, 'w', encoding='utf-8') as runconfig_fh:
+                yaml.safe_dump(runconfig_dict, runconfig_fh, sort_keys=False)
 
-        pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
+            pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
 
-        with self.assertRaises(RuntimeError):
-            pge.run()
+            with self.assertRaises(RuntimeError):
+                pge.run()
 
-        expected_log_file = pge.logger.get_file_name()
-        self.assertTrue(os.path.exists(expected_log_file))
+            expected_log_file = pge.logger.get_file_name()
+            self.assertTrue(os.path.exists(expected_log_file))
 
-        with open(expected_log_file, 'r', encoding='utf-8') as infile:
-            log_contents = infile.read()
+            with open(expected_log_file, 'r', encoding='utf-8') as infile:
+                log_contents = infile.read()
 
-        self.assertIn(f"Input file {abspath(runconfig_path)} does not have "
-                      f".tif extension", log_contents)
+            self.assertIn(f"Input file {abspath(runconfig_path)} does not have "
+                          f".tif extension", log_contents)
+        finally:
+            if os.path.exists(test_runconfig_path):
+                os.unlink(test_runconfig_path)
 
     def test_dswx_pge_output_validation(self):
         """Test the output validation checks made by DSWxPostProcessorMixin."""
@@ -222,49 +226,53 @@ class DSWxPgeTestCase(unittest.TestCase):
         with open(test_runconfig_path, 'w', encoding='utf-8') as config_fh:
             yaml.safe_dump(runconfig_dict, config_fh, sort_keys=False)
 
-        pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
+        try:
+            pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
 
-        with self.assertRaises(RuntimeError):
-            pge.run()
+            with self.assertRaises(RuntimeError):
+                pge.run()
 
-        expected_output_file = 'dswx_pge_test/output_dir/missing_dswx_hls.tif'
-        self.assertFalse(os.path.exists(expected_output_file))
+            expected_output_file = 'dswx_pge_test/output_dir/missing_dswx_hls.tif'
+            self.assertFalse(os.path.exists(expected_output_file))
 
-        expected_log_file = pge.logger.get_file_name()
-        self.assertTrue(os.path.exists(expected_log_file))
+            expected_log_file = pge.logger.get_file_name()
+            self.assertTrue(os.path.exists(expected_log_file))
 
-        with open(expected_log_file, 'r', encoding='utf-8') as infile:
-            log_contents = infile.read()
+            with open(expected_log_file, 'r', encoding='utf-8') as infile:
+                log_contents = infile.read()
 
-        self.assertIn(f"Expected SAS output file {abspath(expected_output_file)} "
-                      f"does not exist", log_contents)
+            self.assertIn(f"Expected SAS output file {abspath(expected_output_file)} "
+                          f"does not exist", log_contents)
 
-        # Test with a SAS command that produces the expected output file, but
-        # one that is empty (size 0 bytes). Post-processor should detect this
-        # and flag an error
-        product_path_group['SASOutputFile'] = 'empty_dswx_hls.tif'
-        primary_executable_group['ProgramPath'] = 'touch'
-        primary_executable_group['ProgramOptions'] = ['dswx_pge_test/output_dir/empty_dswx_hls.tif']
+            # Test with a SAS command that produces the expected output file, but
+            # one that is empty (size 0 bytes). Post-processor should detect this
+            # and flag an error
+            product_path_group['SASOutputFile'] = 'empty_dswx_hls.tif'
+            primary_executable_group['ProgramPath'] = 'touch'
+            primary_executable_group['ProgramOptions'] = ['dswx_pge_test/output_dir/empty_dswx_hls.tif']
 
-        with open(test_runconfig_path, 'w', encoding='utf-8') as outfile:
-            yaml.safe_dump(runconfig_dict, outfile, sort_keys=False)
+            with open(test_runconfig_path, 'w', encoding='utf-8') as outfile:
+                yaml.safe_dump(runconfig_dict, outfile, sort_keys=False)
 
-        pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
+            pge = DSWxExecutor(pge_name="DSWxPgeTest", runconfig_path=test_runconfig_path)
 
-        with self.assertRaises(RuntimeError):
-            pge.run()
+            with self.assertRaises(RuntimeError):
+                pge.run()
 
-        expected_output_file = 'dswx_pge_test/output_dir/empty_dswx_hls.tif'
-        self.assertTrue(os.path.exists(expected_output_file))
+            expected_output_file = 'dswx_pge_test/output_dir/empty_dswx_hls.tif'
+            self.assertTrue(os.path.exists(expected_output_file))
 
-        expected_log_file = pge.logger.get_file_name()
-        self.assertTrue(os.path.exists(expected_log_file))
+            expected_log_file = pge.logger.get_file_name()
+            self.assertTrue(os.path.exists(expected_log_file))
 
-        with open(expected_log_file, 'r', encoding='utf-8') as infile:
-            log_contents = infile.read()
+            with open(expected_log_file, 'r', encoding='utf-8') as infile:
+                log_contents = infile.read()
 
-        self.assertIn(f"SAS output file {abspath(expected_output_file)} was "
-                      f"created but is empty", log_contents)
+            self.assertIn(f"SAS output file {abspath(expected_output_file)} was "
+                          f"created but is empty", log_contents)
+        finally:
+            if os.path.exists(test_runconfig_path):
+                os.unlink(test_runconfig_path)
 
 
 if __name__ == "__main__":

--- a/src/opera/test/pge/test_logger.py
+++ b/src/opera/test/pge/test_logger.py
@@ -203,7 +203,7 @@ class LoggerTestCase(unittest.TestCase):
 
         # Test append text from another file
         test_append_file = tempfile.NamedTemporaryFile(prefix="new_file_", suffix='_txt', dir=os.curdir)
-        with open(test_append_file.name, 'w') as temp_file:
+        with open(test_append_file.name, 'w', encoding='utf-8') as temp_file:
             temp_file.write(f'Text from "{test_append_file.name}" to test append_text_from another file().')
         self.logger.append(test_append_file.name)
 
@@ -217,8 +217,8 @@ class LoggerTestCase(unittest.TestCase):
         # Verify that when a critical event is logged via the critical() method, that a RunTimeError is raised
         self.assertRaises(RuntimeError, self.logger.critical, 'opera_pge', 8, "Test critical() method.")
 
-        with open('test_move.log', 'r') as fn:
-            log = fn.read()
+        with open('test_move.log', 'r', encoding='utf-8') as file_handle:
+            log = file_handle.read()
 
         # Verify that the entries have been made in the log
 
@@ -260,8 +260,8 @@ class LoggerTestCase(unittest.TestCase):
 
         self.arg_test_logger.close_log_stream()
 
-        with open('test_args.log', 'r') as fn:
-            args_log = fn.read()
+        with open('test_args.log', 'r', encoding='utf-8') as file_handle:
+            args_log = file_handle.read()
 
         # Verify warnings
         self.assertIn("Could not increment severity level: 'Broken' ", args_log)
@@ -269,8 +269,8 @@ class LoggerTestCase(unittest.TestCase):
         # Verify the log file was created
         self.assertTrue(exists('test_args.log'))
         # Verify workflow and error_code_base arguments
-        with open('test_args.log', 'r') as f:
-            for line in f:
+        with open('test_args.log', 'r', encoding='utf-8') as file_handle:
+            for line in file_handle:
                 self.assertIn("test_pge_args", line)
                 self.assertIn("1717", line)
 

--- a/src/opera/test/pge/test_pge_main.py
+++ b/src/opera/test/pge/test_pge_main.py
@@ -149,7 +149,7 @@ class PgeMainTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(expected_log_file))
 
         # Open the log file, and check that "SAS" output was captured
-        with open(expected_log_file, 'r') as infile:
+        with open(expected_log_file, 'r', encoding='utf-8') as infile:
             log_contents = infile.read()
 
         self.assertIn('hello world', log_contents)

--- a/src/opera/test/pge/test_run_utils.py
+++ b/src/opera/test/pge/test_run_utils.py
@@ -111,7 +111,7 @@ class RunUtilsTestCase(unittest.TestCase):
 
         if not exists(sas_runconfig_filepath):
             try:
-                with open(sas_runconfig_filepath, 'w') as outfile:
+                with open(sas_runconfig_filepath, 'w', encoding='utf-8') as outfile:
                     yaml.safe_dump(sas_config, outfile, sort_keys=False)
             except OSError as err:
                 self.logger.critical("test_run_utils", ErrorCode.SAS_CONFIG_CREATION_FAILED,
@@ -173,7 +173,7 @@ class RunUtilsTestCase(unittest.TestCase):
         log_file = self.logger.get_file_name()
         self.assertTrue(os.path.exists(log_file))
         # Open the log file, and check for specific messages
-        with open(log_file, 'r') as infile:
+        with open(log_file, 'r', encoding='utf-8') as infile:
             log = infile.read()
 
         self.assertIn('Testing create_sas_command_line().', log)

--- a/src/opera/test/pge/test_run_utils.py
+++ b/src/opera/test/pge/test_run_utils.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2021, by the California Institute of Technology.
+# ALL RIGHTS RESERVED.
+# United States Government sponsorship acknowledged.
+# Any commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+# This software may be subject to U.S. export control laws and regulations.
+# By accepting this document, the user agrees to comply with all applicable
+# U.S. export laws and regulations. User has the responsibility to obtain
+# export licenses, or other export authority as may be required, before
+# exporting such information to foreign countries or providing access to
+# foreign persons.
+#
+
+"""
+=================
+test_run_utils.py
+=================
+
+Unit tests for the util/run_utils.py module.
+
+"""
+import os
+import tempfile
+import unittest
+from os.path import abspath, basename, exists, join, splitext
+
+from pkg_resources import resource_filename
+
+import yaml
+
+from opera.pge.runconfig import RunConfig
+from opera.util.error_codes import ErrorCode
+from opera.util.logger import PgeLogger
+from opera.util.run_utils import create_sas_command_line
+from opera.util.run_utils import time_and_execute
+
+
+class RunUtilsTestCase(unittest.TestCase):
+    """Base test class using unittest"""
+
+    starting_dir = None
+    working_dir = None
+    config_file = None
+    data_dir = None
+    test_dir = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """
+        Set up class variables:
+        Initialize the number of times to exercise the module (currently 1000)
+
+        """
+        cls.starting_dir = abspath(os.curdir)
+        cls.test_dir = resource_filename(__name__, "")
+        cls.data_dir = join(cls.test_dir, "data")
+
+        os.chdir(cls.test_dir)
+
+        cls.working_dir = tempfile.TemporaryDirectory(
+            prefix="test_run_utils_", suffix='temp', dir=os.curdir)
+        cls.config_file = join(cls.data_dir, "test_run_utils_config.yaml")
+        cls.first_time = 0.0
+        cls.second_time = 0.0
+        cls.logger = PgeLogger()
+        cls.run_config = RunConfig(cls.config_file)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        At completion re-establish starting directory
+        -------
+        """
+        cls.working_dir.cleanup()
+        os.chdir(cls.starting_dir)
+
+    def setUp(self) -> None:
+        """
+        Use the temporary directory as the working directory
+        -------
+        """
+        os.chdir(self.working_dir.name)
+
+    def tearDown(self) -> None:
+        """
+        Return to starting directory
+        -------
+        """
+        os.chdir(self.test_dir)
+
+    def _isolate_sas_runconfig(self):
+        """
+        Isolates the SAS-specific portion of the RunConfig into its own
+        YAML file, so it may be fed into the SAS executable without unneeded
+        PGE configuration settings.  (Note) This is copied from base_pge.py
+        and modified slightly.
+
+        """
+        sas_config = self.run_config.sas_config
+
+        pge_runconfig_filename = basename(self.run_config.filename)
+        pge_runconfig_fileparts = splitext(pge_runconfig_filename)
+
+        sas_runconfig_filename = f'{pge_runconfig_fileparts[0]}_sas{pge_runconfig_fileparts[1]}'
+        # Working in a temporary directory; adjust path to access files
+        dir_tweak = '/base_pge_test/scratch/'
+        sas_runconfig_filepath = join(os.path.dirname(os.getcwd()) + dir_tweak, sas_runconfig_filename)
+
+        if not exists(sas_runconfig_filepath):
+            try:
+                with open(sas_runconfig_filepath, 'w') as outfile:
+                    yaml.safe_dump(sas_config, outfile, sort_keys=False)
+            except OSError as err:
+                self.logger.critical("test_run_utils", ErrorCode.SAS_CONFIG_CREATION_FAILED,
+                                     f'Failed to create SAS config file {sas_runconfig_filepath}, '
+                                     f'reason: {str(err)}')
+
+        self.logger.info("test_run_utils", ErrorCode.CREATED_SAS_CONFIG,
+                         f'SAS RunConfig created at {sas_runconfig_filepath}')
+
+        return sas_runconfig_filepath
+
+    def test_create_sas_command_line(self):
+        """
+        This test creates a simple linux command:
+            /bin/echo Hello from test_create_command_line function.
+
+        It uses create_sas_command_line() to make the function then
+        it then uses time_and_execute() to execute the command.
+        It records the elapsed time and writes it to the log file
+
+        """
+        # Make a command from something locally available
+        self.logger.info('test', 1, 'Testing create_sas_command_line().')
+        cmd = '/bin/echo'
+        command = create_sas_command_line(cmd, self.config_file,
+                                          sas_program_options=['Hello from test_create_command_line function.'])
+        self.first_time = time_and_execute(command, self.logger, execute_via_shell=False)
+        self.logger.info('test', 1, f'First elapsed time: {self.first_time}.')
+
+    def test_time_and_execute(self):
+        """
+        This is first tested in test_create_sas_command_line().
+        This test generates a command that is derived from a .yaml
+        configuration file.  The command is created by
+        create_sas_command_line(), then executed. It calls
+        check_results() to examine the log file.
+
+        """
+        self.logger.info('test', 1, 'Testing test_time_and_execute().')
+        sas_program_path = self.run_config.sas_program_path
+        sas_program_options = self.run_config.sas_program_options
+        sas_runconfig_filepath = self._isolate_sas_runconfig()
+
+        command_line = create_sas_command_line(sas_program_path, sas_runconfig_filepath, sas_program_options)
+
+        # Execute the command
+        self.second_time = time_and_execute(command_line, self.logger, execute_via_shell=False)
+        self.logger.info('test', 1, f'Second elapsed time: {self.second_time}.')
+
+        self.check_results()
+
+    def check_results(self):
+        """
+        Save the log stream to a file, then examine the file for
+        expected values.
+
+        """
+        self.logger.close_log_stream()
+        log_file = self.logger.get_file_name()
+        self.assertTrue(os.path.exists(log_file))
+        # Open the log file, and check for specific messages
+        with open(log_file, 'r') as infile:
+            log = infile.read()
+
+        self.assertIn('Testing create_sas_command_line().', log)
+        self.assertIn('Hello from test_create_command_line function.', log)
+        self.assertIn(f'First elapsed time: {self.first_time}', log)
+
+        self.assertIn('Testing test_time_and_execute().', log)
+        self.assertIn('Hello from run_utils unit test, testing time_and_execute().', log)
+        self.assertIn(f'Second elapsed time: {self.second_time}', log)

--- a/src/opera/test/pge/test_time.py
+++ b/src/opera/test/pge/test_time.py
@@ -30,7 +30,7 @@ from os.path import abspath, join
 
 from pkg_resources import resource_filename
 
-from opera.util.time import get_catalog_metadata_datetime_str
+from opera.util.time import get_cat_metadata_datetime_str
 from opera.util.time import get_current_iso_time
 from opera.util.time import get_iso_time
 from opera.util.time import get_time_for_filename
@@ -164,7 +164,7 @@ class TimeTestCase(unittest.TestCase):
         self.assertIsNone(re.match(filename_regex, t5))
         self.assertIsNone(re.match(filename_regex, t6))
 
-    def test_get_catalog_metadata_datetime_str(self):
+    def test_get_cat_metadata_datetime_str(self):
         """
         Converts the provided datetime object to a time-tag string suitable for use
         in catalog metadata.
@@ -174,7 +174,7 @@ class TimeTestCase(unittest.TestCase):
         # Test multiple times
         for i in range(self.reps):
             dt = datetime.now()
-            nano_str = get_catalog_metadata_datetime_str(dt).split('.')[-1]
+            nano_str = get_cat_metadata_datetime_str(dt).split('.')[-1]
             self.assertEqual(nano_str, re.match(nano_regex, nano_str).group())
 
         # Test some bad strings

--- a/src/opera/test/pge/test_time.py
+++ b/src/opera/test/pge/test_time.py
@@ -30,7 +30,7 @@ from os.path import abspath, join
 
 from pkg_resources import resource_filename
 
-from opera.util.time import get_cat_metadata_datetime_str
+from opera.util.time import get_catalog_metadata_datetime_str
 from opera.util.time import get_current_iso_time
 from opera.util.time import get_iso_time
 from opera.util.time import get_time_for_filename
@@ -174,7 +174,7 @@ class TimeTestCase(unittest.TestCase):
         # Test multiple times
         for i in range(self.reps):
             dt = datetime.now()
-            nano_str = get_cat_metadata_datetime_str(dt).split('.')[-1]
+            nano_str = get_catalog_metadata_datetime_str(dt).split('.')[-1]
             self.assertEqual(nano_str, re.match(nano_regex, nano_str).group())
 
         # Test some bad strings

--- a/src/opera/util/__init__.py
+++ b/src/opera/util/__init__.py
@@ -22,5 +22,5 @@ metrics gathering, for use with the OPERA PGE Subsystem.
 
 """
 
-from .error_codes import ErrorCode
-from .logger import PgeLogger
+from .error_codes import ErrorCode  # noqa: F401
+from .logger import PgeLogger  # noqa: F401

--- a/src/opera/util/__init__.py
+++ b/src/opera/util/__init__.py
@@ -19,6 +19,7 @@ util
 
 Contains utility modules for performing common operations, such as logging and
 metrics gathering, for use with the OPERA PGE Subsystem.
+
 """
 
 from .error_codes import ErrorCode

--- a/src/opera/util/logger.py
+++ b/src/opera/util/logger.py
@@ -395,6 +395,12 @@ class PgeLogger:
         description : str
             Description message to write to the log.
 
+        Raises
+        ------
+        RuntimeError
+            Raised when this method is called. The contents of the description
+            parameter is provided as the exception string.
+
         """
         self.write("Critical", module, error_code_offset, description,
                    additional_back_frames=1)

--- a/src/opera/util/logger.py
+++ b/src/opera/util/logger.py
@@ -29,11 +29,10 @@ import inspect
 import shutil
 import time
 from io import StringIO
-
 from os.path import basename, isfile
 
-from opera.util import error_codes
 import opera.util.time as time_util
+from opera.util import error_codes
 
 from .error_codes import ErrorCode
 from .usage_metrics import get_os_metrics
@@ -62,7 +61,6 @@ def write(log_stream, severity, workflow, module, error_code, error_location,
         Description of the logged event.
 
     """
-
     time_tag = time_util.get_current_iso_time()
 
     message_str = f'{time_tag}, {severity}, {workflow}, {module},' \
@@ -151,6 +149,7 @@ class PgeLogger:
     * The class's write() function has fewer arguments that need to be provided.
 
     """
+
     LOGGER_CODE_BASE = 900000
 
     def __init__(self, workflow=None, error_code_base=None,
@@ -190,6 +189,7 @@ class PgeLogger:
 
     @property
     def workflow(self):
+        """Return specific workflow"""
         return self._workflow
 
     @workflow.setter
@@ -198,6 +198,7 @@ class PgeLogger:
 
     @property
     def error_code_base(self):
+        """Return the error code base from error_codes.py"""
         return self._error_code_base
 
     @error_code_base.setter
@@ -216,7 +217,7 @@ class PgeLogger:
 
             self.log_stream.seek(0)
 
-            with open(self.log_filename, 'w') as outfile:
+            with open(self.log_filename, 'w', encoding='utf-8') as outfile:
                 shutil.copyfileobj(self.log_stream, outfile)
 
             self.log_stream.close()
@@ -469,9 +470,8 @@ class PgeLogger:
             text is appended as is.
 
         """
-
         if isfile(source):
-            with open(source, 'r') as source_file_object:
+            with open(source, 'r', encoding='utf-8') as source_file_object:
                 source_contents = source_file_object.read()
         else:
             source_contents = source
@@ -550,6 +550,6 @@ class PgeLogger:
                     count_by_severity[severity] += 1
                 except KeyError:
                     self.warning("PgeLogger", ErrorCode.LOGGING_RESYNC_FAILED,
-                                 f"Unable to resync the 'log_count_by_severity' dict.")
+                                 "Unable to resync the 'log_count_by_severity' dict.")
 
         self.log_count_by_severity = count_by_severity

--- a/src/opera/util/run_utils.py
+++ b/src/opera/util/run_utils.py
@@ -26,7 +26,6 @@ import os
 import shutil
 import subprocess
 import time
-
 from os.path import abspath
 
 from .error_codes import ErrorCode
@@ -73,9 +72,8 @@ def create_sas_command_line(sas_program_path, sas_runconfig_path,
     else:
         executable_path = abspath(sas_program_path)
 
-        # Check if the executable exists, but does not have execute permissions on it
-        if (os.access(executable_path, mode=os.F_OK)
-                and not os.access(executable_path, mode=os.X_OK)):
+        # Check if the executable exists, but does not have 'execute' permissions on it
+        if os.access(executable_path, mode=os.F_OK) and not os.access(executable_path, mode=os.X_OK):
             raise OSError(f"Requested SAS program path {sas_program_path} exists, "
                           f"but does not have execute permissions.")
         # Otherwise, sas_program_path might be a python module path

--- a/src/opera/util/run_utils.py
+++ b/src/opera/util/run_utils.py
@@ -65,9 +65,9 @@ def create_sas_command_line(sas_program_path, sas_runconfig_path,
         set with execute permissions for the current process.
 
     """
-    executable_path = shutil.which(sas_program_path)
+    command_line = []
 
-    if executable_path:
+    if executable_path := shutil.which(sas_program_path):
         command_line = [executable_path]
     else:
         executable_path = abspath(sas_program_path)
@@ -131,8 +131,6 @@ def time_and_execute(command_line, logger, execute_via_shell=False):
 
     # Append the stdout/stderr captured by the subprocess to our log
     logger.append(run_result.stdout.decode())
-
-    print(run_result.stdout.decode())
 
     if run_result.returncode:
         error_msg = (f'Command "{" ".join(command_line)}" failed with exit '

--- a/src/opera/util/run_utils.py
+++ b/src/opera/util/run_utils.py
@@ -26,8 +26,6 @@ import os
 import shutil
 import subprocess
 import time
-from io import StringIO
-import sys
 
 from os.path import abspath
 
@@ -133,6 +131,8 @@ def time_and_execute(command_line, logger, execute_via_shell=False):
 
     # Append the stdout/stderr captured by the subprocess to our log
     logger.append(run_result.stdout.decode())
+
+    print(run_result.stdout.decode())
 
     if run_result.returncode:
         error_msg = (f'Command "{" ".join(command_line)}" failed with exit '

--- a/src/opera/util/run_utils.py
+++ b/src/opera/util/run_utils.py
@@ -72,10 +72,12 @@ def create_sas_command_line(sas_program_path, sas_runconfig_path,
     else:
         executable_path = abspath(sas_program_path)
 
-        # Check if the executable exists, but does not have 'execute' permissions on it
-        if os.access(executable_path, mode=os.F_OK) and not os.access(executable_path, mode=os.X_OK):
-            raise OSError(f"Requested SAS program path {sas_program_path} exists, "
-                          f"but does not have execute permissions.")
+        # Check if the executable exists
+        if os.access(executable_path, mode=os.F_OK):
+            # Check if the executable has 'execute' permissions on it
+            if not os.access(executable_path, mode=os.X_OK):
+                raise OSError(f"Requested SAS program path {sas_program_path} exists, "
+                              f"but does not have execute permissions.")
         # Otherwise, sas_program_path might be a python module path
         else:
             command_line = ['python3', '-m', sas_program_path]

--- a/src/opera/util/time.py
+++ b/src/opera/util/time.py
@@ -85,7 +85,7 @@ def get_time_for_filename(date_time):
     return datetime_str
 
 
-def get_cat_metadata_datetime_str(date_time):
+def get_catalog_metadata_datetime_str(date_time):
     """
     Converts the provided datetime object to a time-tag string suitable for use
     in catalog metadata.
@@ -103,7 +103,7 @@ def get_cat_metadata_datetime_str(date_time):
 
     """
     # TODO: Rework to support 0.1 nanosecond resolution
-    # That probably means ditching Python's datetime class.
+    #       That probably means ditching Python's datetime class.
     datetime_str = date_time.isoformat(sep='T', timespec='microseconds') + "0000" + "Z"
 
     return datetime_str

--- a/src/opera/util/time.py
+++ b/src/opera/util/time.py
@@ -44,13 +44,13 @@ def get_current_iso_time():
     return time_in_iso
 
 
-def get_iso_time(dt):
+def get_iso_time(date_time):
     """
     Converts the provided datetime object to an ISO-format time-tag.
 
     Parameters
     ----------
-    dt : datetime.datetime
+    date_time : datetime.datetime
         Datetime object to convert to ISO format.
 
     Returns
@@ -59,19 +59,19 @@ def get_iso_time(dt):
         Provided time in ISO format: YYYY-MM-DDTHH:MM:SS.mmmmmmZ
 
     """
-    time_in_iso = dt.isoformat(sep='T', timespec='microseconds') + "Z"
+    time_in_iso = date_time.isoformat(sep='T', timespec='microseconds') + "Z"
 
     return time_in_iso
 
 
-def get_time_for_filename(dt):
+def get_time_for_filename(date_time):
     """
     Converts the provided datetime object to a time-tag string suitable for
     use with output filenames.
 
     Parameters
     ----------
-    dt : datetime.datetime
+    date_time : datetime.datetime
         Datetime object to convert to a filename time-tag.
 
     Returns
@@ -80,19 +80,19 @@ def get_time_for_filename(dt):
         The provided time converted to YYYYMMDDTHHmmss format.
 
     """
-    datetime_str = dt.strftime('%Y%m%dT%H%M%S')
+    datetime_str = date_time.strftime('%Y%m%dT%H%M%S')
 
     return datetime_str
 
 
-def get_catalog_metadata_datetime_str(dt):
+def get_cat_metadata_datetime_str(date_time):
     """
     Converts the provided datetime object to a time-tag string suitable for use
     in catalog metadata.
 
     Parameters
     ----------
-    dt : datetime.datetime
+    date_time : datetime.datetime
         Datetime object to convert to a catalog metadata time-tag string.
 
     Returns
@@ -104,6 +104,6 @@ def get_catalog_metadata_datetime_str(dt):
     """
     # TODO: Rework to support 0.1 nanosecond resolution
     # That probably means ditching Python's datetime class.
-    datetime_str = dt.isoformat(sep='T', timespec='microseconds') + "0000" + "Z"
+    datetime_str = date_time.isoformat(sep='T', timespec='microseconds') + "0000" + "Z"
 
     return datetime_str

--- a/src/opera/util/usage_metrics.py
+++ b/src/opera/util/usage_metrics.py
@@ -100,7 +100,7 @@ def get_self_peak_vmm_kb():
     status_file = os.path.join(os.sep, 'proc', 'self', 'status')
 
     if not os.path.exists(status_file) or not os.path.isfile(status_file):
-        return 'file_not_found: {}'.format(status_file)
+        return f'file_not_found: {status_file}'
 
     with open(status_file, 'r') as infile:
         for line in infile.readlines():

--- a/src/opera/util/usage_metrics.py
+++ b/src/opera/util/usage_metrics.py
@@ -102,7 +102,7 @@ def get_self_peak_vmm_kb():
     if not os.path.exists(status_file) or not os.path.isfile(status_file):
         return f'file_not_found: {status_file}'
 
-    with open(status_file, 'r') as infile:
+    with open(status_file, 'r', encoding='utf-8') as infile:
         for line in infile.readlines():
             if line.startswith('VmPeak:'):
                 vm_peak_str = line.replace('VmPeak:', '').replace('kB', '')


### PR DESCRIPTION
These were the pylint results that I did not act upon:

from src/opera/pge:
base_pge.py:36:0: E0402: Attempted relative import beyond top-level package (relative-beyond-top-level)
base_pge.py:161:0: W0613: Unused argument 'kwargs' (unused-argument)
base_pge.py:234:0: W0613: Unused argument 'kwargs' (unused-argument)
base_pge.py:276:4: W0231: __init__ method from base class 'PreProcessorMixin' is not called (super-init-not-called)
base_pge.py:276:4: W0231: __init__ method from base class 'PostProcessorMixin' is not called (super-init-not-called)
base_pge.py:327:0: W0613: Unused argument 'kwargs' (unused-argument)
dswx_pge.py:30:0: E0402: Attempted relative import beyond top-level package (relative-beyond-top-level)
dswx_pge.py:31:0: E0402: Attempted relative import beyond top-level package (relative-beyond-top-level)
dswx_pge.py:32:0: E0402: Attempted relative import beyond top-level package (relative-beyond-top-level)
dswx_pge.py:90:8: R1725: Consider using Python 3 style super() without arguments (super-with-arguments)
dswx_pge.py:129:0: W0613: Unused argument 'kwargs' (unused-argument)
runconfig.py - only TODO errors.

from src/opera/util/
error_codes.py - 100%
logger.py:37:0: E0402: Attempted relative import beyond top-level package (relative-beyond-top-level)
logger.py:38:0: E0402: Attempted relative import beyond top-level package (relative-beyond-top-level)
run_utils.py:31:0: E0402: Attempted relative import beyond top-level package (relative-beyond-top-level)
time.py - only TODO errors

from src/opera/scripts
pge_main.py - 100%