### PR TITLE
Unit test for the usage_metric.get_self_peak_vmm_kb()

### DIFF
--- a/src/opera/test/pge/test_usage_metrics.py
+++ b/src/opera/test/pge/test_usage_metrics.py
@@ -26,6 +26,7 @@ import re
 import tempfile
 import unittest
 from os.path import abspath, join
+from sys import platform
 
 from pkg_resources import resource_filename
 
@@ -118,7 +119,13 @@ class UsageMetricsTestCase(unittest.TestCase):
             # Verify that the main process, takes more RAM than the child process
             self.assertGreater(metrics['os.max_rss_kb.main_process'], metrics['os.max_rss_kb.largest_child_process'])
 
-# TODO test get_self_peak_vmm_kb() - right now it is not finding the file.
+            # Testing peak_vmm_kb requires the test to run in a Linux environment,
+            # otherwise we expect -1 back, so test both
+            if platform != "linux":
+                self.assertEqual(metrics['os.peak_vm_kb.main_process'], -1)
+            else:
+                self.assertEqual(str(metrics['os.peak_vm_kb.main_process']), re.match(int_regex,
+                                 str(metrics['os.peak_vm_kb.main_process'])).group())
 
 
 if __name__ == "__main__":

--- a/src/opera/util/usage_metrics.py
+++ b/src/opera/util/usage_metrics.py
@@ -28,6 +28,7 @@ Adapted By: Scott Collins
 
 import os
 import resource
+from sys import platform
 
 
 def get_os_metrics():
@@ -93,21 +94,25 @@ def get_self_peak_vmm_kb():
     -------
     vm_peak_kb : int
         Peak virtual memory usage, in kilobytes, of the current process. If
-        this value cannot be obtained for any reason, 0 is returned instead.
+        this value cannot be obtained for any reason, -1 is returned instead.
 
     """
     vm_peak_kb = 0
 
     status_file = os.path.join(os.sep, 'proc', 'self', 'status')
 
-    if not os.path.exists(status_file) or not os.path.isfile(status_file):
-        return f'file_not_found: {status_file}'
+    try:
+        if platform != "linux" or not os.path.exists(status_file):
+            raise EnvironmentError
 
-    with open(status_file, 'r', encoding='utf-8') as infile:
-        for line in infile.readlines():
-            if line.startswith('VmPeak:'):
-                vm_peak_str = line.replace('VmPeak:', '').replace('kB', '')
-                vm_peak_kb = int(vm_peak_str)
-                break
+        with open(status_file, "r", encoding='utf-8') as infile:
+            for line in infile.readlines():
+                if line.startswith("VmPeak:"):
+                    vm_peak_str = line.replace("VmPeak:", "").replace("kB", "")
+                    vm_peak_kb = int(vm_peak_str)
+                    break
+
+    except EnvironmentError:
+        vm_peak_kb = -1
 
     return vm_peak_kb


### PR DESCRIPTION
This PR incorporates the work contributed by @drewmee to add unit test coverage for the `usage_metrics.get_self_peak_vmm_kb()` function. Thanks again to Drew for his contributions!

Previously, testing for this function was skipped since OS file used for the check only exists on Linux based OS. The function and unit test now check to ensure the current platform is Linux or not and take the appropriate action.

Resolves #22