### PR TITLE
Document Generation Step for Deployment Pipeline

### DIFF
--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -74,28 +74,38 @@ pipeline {
             steps {
                 script {
                     echo "Installing Sphinx Dependencies"
-                    sh '''#!/bin/bash
-                         /usr/local/bin/python3 -m venv sphinx_env
-                         . sphinx_env/bin/activate
-                         pip install -r ./requirements.txt
-                         pip install -r ./requirements_dev.txt
+                    sh label: 'Installing conda environment for Sphinx',
+                       script: '''#!/bin/bash
+                         /usr/local/anaconda3/bin/conda create -n sphinx_env python=3.8 pip
+                         /usr/local/anaconda3/bin/conda init bash
                     '''
+
+                    sh label: 'Installing Sphinx to conda environment',
+                       script: '''#!/bin/bash
+                       . /var/lib/jenkins/.bashrc
+                       conda activate sphinx_env
+                       pip install -r ./requirements.txt
+                       pip install -r ./requirements_dev.txt
+                       '''
 
                     sh label: 'Invoking clean target for Sphinx build',
                        script: '''#!/bin/bash
-                       . sphinx_env/bin/activate
+                       . /var/lib/jenkins/.bashrc
+                       conda activate sphinx_env
                        /usr/bin/make --directory=./docs clean
                        '''
 
                     sh label: 'Invoking html target for Sphinx build',
                        script: '''#!/bin/bash
-                       . sphinx_env/bin/activate
+                       . /var/lib/jenkins/.bashrc
+                       conda activate sphinx_env
                        /usr/bin/make --directory=./docs html
                        '''
 
                     sh label: 'Invoking latexpdf target for Sphinx build',
                        script: '''#!/bin/bash
-                       . sphinx_env/bin/activate
+                       . /var/lib/jenkins/.bashrc
+                       conda activate sphinx_env
                        /usr/bin/make --directory=./docs latexpdf
                        '''
                 }
@@ -200,7 +210,8 @@ pipeline {
             echo "Cleaning up Docker images from local host"
             sh ".ci/scripts/cleanup.sh ${DOCKER_TAG}"
             echo "Removing Sphinx build environment"
-            sh "rm -rf sphinx_env"
+            sh "/usr/local/anaconda3/bin/conda env remove --name sphinx_env"
+            sh "/usr/local/anaconda3/bin/conda init --reverse"
             deleteDir()
         }
         success {

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -31,6 +31,11 @@ pipeline {
                      credentialType: 'com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl',
                      description: 'Artifactory-FN credentials for account collinss. Used to push/pull images from Artifactory during build.',
                      required: true)
+        credentials(name: 'GITHUB_OAUTH_TOKEN',
+                    defaultValue: '8443f80e-014a-4dea-b122-5ca34d8aaab1',
+                    credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl',
+                    description: 'GitHub OAUTH Token for user collinss-jpl on github.com',
+                    required: true)
     }
     environment {
         DOCKER_IMAGE_PREFIX = 'opera_pge'
@@ -111,8 +116,27 @@ pipeline {
                 }
             }
         }
-        // TODO: stage to push html to gh-pages branch
-        stage('Upload OPERA PDF Documentation to Artifactory FN') {
+        stage('Push OPERA PGE HTML documentation to GitHub Pages') {
+            steps {
+                git branch: 'gh-pages',
+                    changelog: false,
+                    poll: false,
+                    url: 'https://github.com/nasa/opera-sds-pge'
+
+                withCredentials([string(credentialsId: params.GITHUB_OAUTH_TOKEN, variable: 'TOKEN')]) {
+                    sh label: 'Updating gh-pages branch with latest HTML docs',
+                       script: '''#!/bin/bash
+                       cp -rf ./docs/_build/html/* .
+                       git add .
+                       git add -u
+                       git commit -m "HTML docs update by Jenkins"
+                       git remote set-url origin https://${TOKEN}@github.com/nasa/opera-sds-pge.git
+                       git push --set-upstream origin gh-pages
+                       '''
+                }
+            }
+        }
+        stage('Upload OPERA PGE PDF Documentation to Artifactory FN') {
             steps {
                 script {
                     rtServer (

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -107,12 +107,13 @@ pipeline {
                        /usr/bin/make --directory=./docs html
                        '''
 
-                    sh label: 'Invoking latexpdf target for Sphinx build',
-                       script: '''#!/bin/bash
-                       . /var/lib/jenkins/.bashrc
-                       conda activate sphinx_env
-                       /usr/bin/make --directory=./docs latexpdf
-                       '''
+                    // TODO: revisit once latexpdf is working on CI system
+                    //sh label: 'Invoking latexpdf target for Sphinx build',
+                    //   script: '''#!/bin/bash
+                    //   . /var/lib/jenkins/.bashrc
+                    //   conda activate sphinx_env
+                    //   /usr/bin/make --directory=./docs latexpdf
+                    //   '''
                 }
             }
         }
@@ -136,37 +137,38 @@ pipeline {
                 }
             }
         }
-        stage('Upload OPERA PGE PDF Documentation to Artifactory FN') {
-            steps {
-                script {
-                    rtServer (
-                        id: 'ARTIFACTORY_FN_SERVER',
-                        url: params.ART_URL,
-                        credentialsId: params.ART_CREDENTIALS,
-                        timeout: 300
-                    )
-
-                    sh "mv ./docs/opera-pge-manual.pdf opera-pge-manual-${DOCKER_TAG}.pdf"
-
-                    echo "Uploading PDF documentation to Artifactory-FN"
-
-                    rtUpload(
-                        serverId: "ARTIFACTORY_FN_SERVER",
-                        spec:
-                          """{
-                              "files": [
-                                  {
-                                      "pattern": "opera-pge-manual-${DOCKER_TAG}.pdf",
-                                      "target": "${params.ART_DOCS_PATH}"
-                                  }
-                              ]
-                          }"""
-                    )
-
-                    sh "rm -f opera-pge-manual-${DOCKER_TAG}.pdf"
-                }
-            }
-        }
+        // TODO: revisit once latexpdf is working on CI system
+//         stage('Upload OPERA PGE PDF Documentation to Artifactory FN') {
+//             steps {
+//                 script {
+//                     rtServer (
+//                         id: 'ARTIFACTORY_FN_SERVER',
+//                         url: params.ART_URL,
+//                         credentialsId: params.ART_CREDENTIALS,
+//                         timeout: 300
+//                     )
+//
+//                     sh "mv ./docs/opera-pge-manual.pdf opera-pge-manual-${DOCKER_TAG}.pdf"
+//
+//                     echo "Uploading PDF documentation to Artifactory-FN"
+//
+//                     rtUpload(
+//                         serverId: "ARTIFACTORY_FN_SERVER",
+//                         spec:
+//                           """{
+//                               "files": [
+//                                   {
+//                                       "pattern": "opera-pge-manual-${DOCKER_TAG}.pdf",
+//                                       "target": "${params.ART_DOCS_PATH}"
+//                                   }
+//                               ]
+//                           }"""
+//                     )
+//
+//                     sh "rm -f opera-pge-manual-${DOCKER_TAG}.pdf"
+//                 }
+//             }
+//         }
         stage('Upload OPERA PGE Docker image tar files to Artifactory-FN') {
             steps {
                 script {

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -19,6 +19,8 @@ pipeline {
                description: 'Artifactory-FN URL.')
         string(name: 'ART_TAR_PATH', defaultValue: 'general/gov/nasa/jpl/opera/sds/pge/',
                description: 'Artifactory path to publish PGE docker image tar files to.')
+        string(name: 'ART_DOCS_PATH', defaultValue: 'general/gov/nasa/jpl/opera/sds/pge/documentation',
+               description: 'Artifactory path to publish PGE documentation files to.')
         string(name: 'ART_DOCKER_PATH', defaultValue: '/gov/nasa/jpl/opera/sds/pge/',
                description: 'Artifactory path to push Docker images.')
         string(name: 'ART_DOCKER_REGISTRY', defaultValue: 'artifactory-fn.jpl.nasa.gov:16001',
@@ -66,6 +68,69 @@ pipeline {
                              reportFiles: 'index.html',
                              reportName: 'Code Coverage',
                              reportTitles: 'DSWx-HLS Code Coverage'])
+            }
+        }
+        stage('Generate OPERA PGE Sphinx Documentation') {
+            steps {
+                script {
+                    echo "Installing Sphinx Dependencies"
+                    sh '''#!/bin/bash
+                         /usr/local/bin/python3 -m venv sphinx_env
+                         . sphinx_env/bin/activate
+                         pip install -r ./requirements.txt
+                         pip install -r ./requirements_dev.txt
+                    '''
+
+                    sh label: 'Invoking clean target for Sphinx build',
+                       script: '''#!/bin/bash
+                       . sphinx_env/bin/activate
+                       /usr/bin/make --directory=./docs clean
+                       '''
+
+                    sh label: 'Invoking html target for Sphinx build',
+                       script: '''#!/bin/bash
+                       . sphinx_env/bin/activate
+                       /usr/bin/make --directory=./docs html
+                       '''
+
+                    sh label: 'Invoking latexpdf target for Sphinx build',
+                       script: '''#!/bin/bash
+                       . sphinx_env/bin/activate
+                       /usr/bin/make --directory=./docs latexpdf
+                       '''
+                }
+            }
+        }
+        // TODO: stage to push html to gh-pages branch
+        stage('Upload OPERA PDF Documentation to Artifactory FN') {
+            steps {
+                script {
+                    rtServer (
+                        id: 'ARTIFACTORY_FN_SERVER',
+                        url: params.ART_URL,
+                        credentialsId: params.ART_CREDENTIALS,
+                        timeout: 300
+                    )
+
+                    sh "mv ./docs/opera-pge-manual.pdf opera-pge-manual-${DOCKER_TAG}.pdf"
+
+                    echo "Uploading PDF documentation to Artifactory-FN"
+
+                    rtUpload(
+                        serverId: "ARTIFACTORY_FN_SERVER",
+                        spec:
+                          """{
+                              "files": [
+                                  {
+                                      "pattern": "opera-pge-manual-${DOCKER_TAG}.pdf",
+                                      "target": "${params.ART_DOCS_PATH}"
+                                  }
+                              ]
+                          }"""
+                    )
+
+                    sh "rm -f opera-pge-manual-${DOCKER_TAG}.pdf"
+                }
             }
         }
         stage('Upload OPERA PGE Docker image tar files to Artifactory-FN') {
@@ -134,6 +199,8 @@ pipeline {
         always {
             echo "Cleaning up Docker images from local host"
             sh ".ci/scripts/cleanup.sh ${DOCKER_TAG}"
+            echo "Removing Sphinx build environment"
+            sh "rm -rf sphinx_env"
             deleteDir()
         }
         success {


### PR DESCRIPTION
This PR integrates a documentation creation step, via Sphinx, into the Jenkins build-test-deploy pipeline for opera-sds-pge.

The new pipeline steps do the following: 

* Create a conda environment with the requisite Python version and Sphinx dependencies installed 
* Clean any pre-existing Sphinx build directory
* Remake the HTML documentation
* Push the created HTML docs to the gh-pages branch of the opera-sds-pge repo (which triggers an automatic redeployment by GitHub)
* Clean up the installed conda environment

I also wanted an PDF generation step that uploaded the PDF manual to Artifactory, but getting a working LaTeX install on our CI machine is on-going, and will eventually be tackled in a later ticket.