### PR TITLE
Proposed issue template forms for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,17 +6,20 @@ body:
   - type: markdown
     attributes:
       value: |
-        > _Thank you for filing a bug ticket. We very much appreciate your time._
-  - type: checkboxes
-    id: checked
+        > _Thanks for filing a bug ticket. We appreciate your time and effort. Please answer a few questions._
+  - type: dropdown
+    id: checked-for-duplicates
     attributes:
       label: Checked for duplicates
-      description: By submitting this issue, you confirm you've already scanned the [list of existing issues](https://github.com/riverma/github_test_area/issues?q=is%3Aissue) and not found duplicates
+      description: Have you checked for duplicate issue tickets?
+      multiple: false
       options:
-        - label: I confirm this bug is new
-          required: true
+        - "Yes - I've already checked"
+        - "No - I haven't checked"
+    validations:
+      required: yes
   - type: textarea
-    id: bug-description
+    id: description
     attributes:
       label: Describe the bug
       description: A clear and concise description of what the bug is. Plain-text snippets preferred but screenshots welcome.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,12 +6,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        > _Thank you for filing a new feature request. We very much appreciate your time._
+        > _Thanks for filing a new feature request. We appreciate your time and effort. Please answer a few questions._
   - type: dropdown
-    id: checked-duplicates
+    id: checked-for-duplicates
     attributes:
       label: Checked for duplicates
-      description: Have you checked for duplicate issues?
+      description: Have you checked for duplicate issue tickets?
       multiple: false
       options:
         - "Yes - I've already checked"
@@ -29,20 +29,20 @@ body:
     validations:
       required: yes
   - type: textarea
-    id: feature-problem
+    id: related-problems
     attributes:
-      label: Related problem
-      description: Is your feature request related to a problem? Please help us understand if so.
-      placeholder: Tell us the problem
-      value: "Ex. I'm frustrated when [...] happens"
+      label: Related problems
+      description: Is your feature request related to any problems? Please help us understand if so, including linking to any other issue tickets.
+      placeholder: Tell us the problems
+      value: "I'm frustrated when [...] happens as documented in issue-XYZ"
     validations:
       required: false
   - type: textarea
-    id: feature-description
+    id: description
     attributes:
       label: Describe the feature request
       description: A clear and concise description of your request. 
       placeholder: Tell us what you want
-      value: "Ex. I need or want [...]"
+      value: "I need or want [...]"
     validations:
       required: true


### PR DESCRIPTION
* New GitHub template forms for bug reports and new feature requests. 
* For live example, check out: https://github.com/nasa/opera-sds-sys/issues/new/choose. 
* Both templates automatically tag issue with a new label "needs triage". _This label needs to be manually created once for the repository for this automatic tagging to work_".
  * Suggested label name: "needs triage"
  * Suggested description: "Issue requires triage to proceed"
  * Suggested color: "#C24247"
