### PR TITLE
ISO metadata temporal/spatial extent updates

### DIFF
--- a/src/opera/pge/dswx_pge.py
+++ b/src/opera/pge/dswx_pge.py
@@ -19,6 +19,7 @@ from opera.util.img_utils import get_geotiff_hls_dataset
 from opera.util.img_utils import get_geotiff_metadata
 from opera.util.img_utils import get_geotiff_spacecraft_name
 from opera.util.img_utils import get_hls_filename_fields
+from opera.util.metadata_utils import get_geographic_boundaries_from_mgrs_tile
 from opera.util.render_jinja2 import render_jinja2
 
 from .base_pge import PgeExecutor
@@ -259,9 +260,21 @@ class DSWxPostProcessorMixin(PostProcessorMixin):
         hls_fields = get_hls_filename_fields(
             get_geotiff_hls_dataset(representative_product)
         )
+        mgrs_tile_id = hls_fields['tile_id']
 
-        output_product_metadata['tileCode'] = hls_fields['tile_id']
-        output_product_metadata['zoneIdentifier'] = hls_fields['tile_id'][:2]
+        output_product_metadata['tileCode'] = mgrs_tile_id
+        output_product_metadata['zoneIdentifier'] = mgrs_tile_id[:2]
+
+        # Translate the MGRS tile ID to a lat/lon bounding box
+        (lat_min,
+         lat_max,
+         lon_min,
+         lon_max) = get_geographic_boundaries_from_mgrs_tile(mgrs_tile_id)
+
+        output_product_metadata['geospatial_lon_min'] = lon_min
+        output_product_metadata['geospatial_lon_max'] = lon_max
+        output_product_metadata['geospatial_lat_min'] = lat_min
+        output_product_metadata['geospatial_lat_max'] = lat_max
 
         # Add some fields on the dimensions of the data. These values should
         # be the same for all DSWx-HLS products, and were derived from the

--- a/src/opera/pge/dswx_pge.py
+++ b/src/opera/pge/dswx_pge.py
@@ -276,6 +276,20 @@ class DSWxPostProcessorMixin(PostProcessorMixin):
         output_product_metadata['geospatial_lat_min'] = lat_min
         output_product_metadata['geospatial_lat_max'] = lat_max
 
+        # Split the sensing time into the beginning/end portions
+        sensing_time = output_product_metadata.pop('SENSING_TIME')
+
+        # Sensing time for L30 datasets contain both begin and end times delimited
+        # by semi-colon
+        if ';' in sensing_time:
+            sensing_time_begin, sensing_time_end = sensing_time.split(';')
+        # S30 datasets seem to only provide a single sensing time value
+        else:
+            sensing_time_begin = sensing_time_end = sensing_time
+
+        output_product_metadata['sensingTimeBegin'] = sensing_time_begin.strip()
+        output_product_metadata['sensingTimeEnd'] = sensing_time_end.strip()
+
         # Add some fields on the dimensions of the data. These values should
         # be the same for all DSWx-HLS products, and were derived from the
         # ADT product spec

--- a/src/opera/pge/templates/OPERA_ISO_metadata_L3_DSWx_HLS_template.xml.jinja2
+++ b/src/opera/pge/templates/OPERA_ISO_metadata_L3_DSWx_HLS_template.xml.jinja2
@@ -549,9 +549,10 @@
                         <!--RangeDateTime-->
                         <gmd:EX_TemporalExtent id="boundingTemporalExtent">
                             <gmd:extent>
-                                <gml:TimeInstant>
-                                    <gml:timePosition>{{ product_output.SENSING_TIME }}{# ISO_OPERA_ProductSensingTime #}</gml:timePosition>
-                                </gml:TimeInstant>
+                                <gml:TimePeriod gml:id="d11e38">
+                                    <gml:beginPosition>{{ product_output.sensingTimeBegin }}{# ISO_OPERA_SensingTimeBegin #}</gml:beginPosition>
+                                    <gml:endPosition>{{ product_output.sensingTimeEnd}}{# ISO_OPERA_SensingTimeEnd #}</gml:endPosition>>
+                                </gml:TimePeriod>
                             </gmd:extent>
                         </gmd:EX_TemporalExtent>
                     </gmd:temporalElement>

--- a/src/opera/pge/templates/OPERA_ISO_metadata_L3_DSWx_HLS_template.xml.jinja2
+++ b/src/opera/pge/templates/OPERA_ISO_metadata_L3_DSWx_HLS_template.xml.jinja2
@@ -848,7 +848,7 @@
                     <gmd:source>
                         <gmd:LI_Source>
                             <gmd:description>
-                                <gco:CharacterString>Built Up Cover Fraction File - {{ product_output.BUILT_UP_COVER_FRACTION_FILE }}{# ISO_OPERA_builtUpCoverFractionFile #}</gco:CharacterString>
+                                <gco:CharacterString>Worldcover File - {{ product_output.WORLDCOVER_FILE }}{# ISO_OPERA_worldcoverFile #}</gco:CharacterString>
                             </gmd:description>
                         </gmd:LI_Source>
                     </gmd:source>

--- a/src/opera/pge/templates/OPERA_ISO_metadata_L3_DSWx_HLS_template.xml.jinja2
+++ b/src/opera/pge/templates/OPERA_ISO_metadata_L3_DSWx_HLS_template.xml.jinja2
@@ -509,6 +509,23 @@
             <gmd:extent>
                 <!-- the EX_Extent id must exist with boundingExtent -->
                 <gmd:EX_Extent id="boundingExtent">
+                    <!--Bounding Rectangle-->
+                    <gmd:geographicElement>
+                        <gmd:EX_GeographicBoundingBox>
+                            <gmd:westBoundLongitude>
+                                <gco:Decimal>{{ product_output.geospatial_lon_min }}{# doc ID ISO_OPERA_westBoundLongitude #}</gco:Decimal>
+                            </gmd:westBoundLongitude>
+                            <gmd:eastBoundLongitude>
+                                <gco:Decimal>{{ product_output.geospatial_lon_max }}{# doc ID ISO_OPERA_eastBoundLongitude #}</gco:Decimal>
+                            </gmd:eastBoundLongitude>
+                            <gmd:southBoundLatitude>
+                                <gco:Decimal>{{ product_output.geospatial_lat_min }}{# doc ID ISO_OPERA_southBoundLatitude #}</gco:Decimal>
+                            </gmd:southBoundLatitude>
+                            <gmd:northBoundLatitude>
+                                <gco:Decimal>{{ product_output.geospatial_lat_max }}{# doc ID ISO_OPERA_northBoundLatitude #}</gco:Decimal>
+                            </gmd:northBoundLatitude>
+                        </gmd:EX_GeographicBoundingBox>
+                    </gmd:geographicElement>
                     <!-- This section documents the ZoneIdentifier -->
                     <gmd:geographicElement>
                         <gmd:EX_GeographicDescription id="ZoneIdentifier">

--- a/src/opera/test/util/test_metadata_utils.py
+++ b/src/opera/test/util/test_metadata_utils.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 """
-=================
+======================
 test_metadata_utils.py
-=================
+======================
 
 Unit tests for the util/metadata_utils.py module.
 
@@ -12,22 +12,17 @@ Unit tests for the util/metadata_utils.py module.
 import unittest
 from unittest import skipIf
 
-try:
-    # If mgrs, osr, or gdal are not available for import, this will raise an exception
-    from opera.util.metadata_utils import get_geographic_boundaries_from_mgrs_tile
-except:
-    pass
+from opera.util.metadata_utils import get_geographic_boundaries_from_mgrs_tile
 
-def mgrs_osr_gdal_are_available():
+
+def osr_is_available():
     """
     Helper function to check for a local installation of the Python bindings for
-    the Geospatial Data Abstraction Library (GDAL), osr and mgrs.
-    Used to skip tests that require GDAL, osr or mgrs if they are not available.
+    the Geospatial Data Abstraction Library (GDAL).
+    Used to skip tests that require GDAL if it is not available.
     """
     try:
-        from osgeo import gdal  # noqa: F401
         from osgeo import osr  # noqa: F401
-        import mgrs  # noqa: F401
         return True
     except (ImportError, ModuleNotFoundError):
         return False
@@ -36,10 +31,9 @@ def mgrs_osr_gdal_are_available():
 class MetadataUtilsTestCase(unittest.TestCase):
     """Unit test Metadata Utilities"""
 
-    @skipIf(not mgrs_osr_gdal_are_available(), reason="gdal, osr, and/or mgrs is not installed on the local instance")
+    @skipIf(not osr_is_available(), reason="osgeo.osr is not installed on the local instance")
     def test_get_geographic_boundaries_from_mgrs_tile_nominal(self):
-
-        """ Reproduce ADT results from values provided with code """
+        """Reproduce ADT results from values provided with code"""
         lat_min, lat_max, lon_min, lon_max = get_geographic_boundaries_from_mgrs_tile('15SXR')
 
         self.assertAlmostEqual(lat_min, 31.616027943130398)
@@ -47,9 +41,9 @@ class MetadataUtilsTestCase(unittest.TestCase):
         self.assertAlmostEqual(lon_min, -91.94552881416524)
         self.assertAlmostEqual(lon_max, -90.76425651871281)
 
-    @skipIf(not mgrs_osr_gdal_are_available(), reason="gdal, osr, and/or mgrs is not installed on the local instance")
+    @skipIf(not osr_is_available(), reason="osgeo.osr is not installed on the local instance")
     def test_get_geographic_boundaries_from_mgrs_tile_leading_T(self):
-
+        """Test MGRS tile code conversion when code starts with T"""
         lat_min, lat_max, lon_min, lon_max = get_geographic_boundaries_from_mgrs_tile('T15SXR')
 
         self.assertAlmostEqual(lat_min, 31.616027943130398)
@@ -57,10 +51,11 @@ class MetadataUtilsTestCase(unittest.TestCase):
         self.assertAlmostEqual(lon_min, -91.94552881416524)
         self.assertAlmostEqual(lon_max, -90.76425651871281)
 
-    @skipIf(not mgrs_osr_gdal_are_available(), reason="gdal, osr, and/or mgrs is not installed on the local instance")
+    @skipIf(not osr_is_available(), reason="osgeo.osr is not installed on the local instance")
     def test_get_geographic_boundaries_from_mgrs_tile_invalid_tile(self):
-
+        """Test MGRS tile code conversion with an invalid code"""
         self.assertRaises(RuntimeError, get_geographic_boundaries_from_mgrs_tile, 'X15SXR')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/opera/util/img_utils.py
+++ b/src/opera/util/img_utils.py
@@ -36,10 +36,9 @@ class MockGdal:  # pragma: no cover
             This function should be updated as needed for requisite metadata fields.
             """
             return {
-                'BUILT_UP_COVER_FRACTION_FILE': '(not provided)',
-                'CLOUD_COVERAGE': '43', 'DEM_FILE': '(not provided)',
+                'CLOUD_COVERAGE': '43', 'DEM_FILE': 'dem.tif',
                 'HLS_DATASET': 'HLS.L30.T22VEQ.2021248T143156.v2.0',
-                'LANDCOVER_FILE': '(not provided)', 'LEVEL': '3',
+                'LANDCOVER_FILE': 'landcover.tif', 'LEVEL': '3',
                 'MEAN_SUN_AZIMUTH_ANGLE': '145.002203258435',
                 'MEAN_SUN_ZENITH_ANGLE': '30.7162834439185',
                 'MEAN_VIEW_AZIMUTH_ANGLE': '100.089770731169',
@@ -48,7 +47,8 @@ class MockGdal:  # pragma: no cover
                 'PROCESSING_DATETIME': '2022-01-31T21:54:26',
                 'PRODUCT_ID': 'dswx_hls', 'PRODUCT_SOURCE': 'HLS',
                 'PRODUCT_TYPE': 'DSWx', 'PRODUCT_VERSION': '0.1',
-                'PROJECT': 'OPERA', 'SENSING_TIME': '2021-09-07T16:54:47.751044Z',
+                'PROJECT': 'OPERA', 'WORLDCOVER_FILE': 'worldcover.tif',
+                'SENSING_TIME': '2021-09-05T14:31:56.9300799Z; 2021-09-05T14:32:20.8126470Z',
                 'SENSOR': 'MSI', 'SPACECRAFT_NAME': 'SENTINEL-2A',
                 'SPATIAL_COVERAGE': '99'
             }

--- a/src/opera/util/metadata_utils.py
+++ b/src/opera/util/metadata_utils.py
@@ -1,18 +1,76 @@
 #!/usr/bin/env python3
-#
 
 """
-============
+=================
 metadata_utils.py
-============
+=================
 
 ISO metadata utilities for use with OPERA PGEs.
 
 """
 
-from osgeo import gdal
-from osgeo import osr
 import mgrs
+from mgrs.core import MGRSError
+
+
+class MockOsr:  # pragma: no cover
+    """
+    Mock class for the osgeo.osr module.
+
+    This class is defined so the opera-sds-pge project does not require the
+    Geospatial Data Abstraction Library (GDAL) as an explicit dependency for
+    developers. When PGE code is eventually run from within a Docker container,
+    osgeo.osr should always be installed and importable.
+    """
+
+    # pylint: disable=all
+    class MockSpatialReference:
+        """Mock class for the osgeo.osr module"""
+
+        def SetWellKnownGeogCS(self, name):
+            """Mock implementation for osr.SetWellKnownGeogCS"""
+            pass
+
+        def SetUTM(self, zone, north=True):
+            """Mock implementation for osr.SetUTM"""
+            self.zone = zone
+            self.hemi = "N" if north else "S"
+
+    class MockCoordinateTransformation:
+        """Mock class for the osgeo.osr.CoordinateTransformation class"""
+
+        def __init__(self, src, dest):
+            self.src = src
+            self.dest = dest
+
+        def TransformPoint(self, x, y, z):
+            """Mock implementation for CoordinateTransformation.TransformPoint"""
+            # Use mgrs to convert UTM back to a tile ID, then covert to rough
+            # lat/lon, this should be accurate enough for development testing
+            mgrs_obj = mgrs.MGRS()
+            mgrs_tile = mgrs_obj.UTMToMGRS(self.src.zone, self.src.hemi, x, y)
+            lat, lon = mgrs_obj.toLatLon(mgrs_tile)
+            return lat, lon, z
+
+    @staticmethod
+    def SpatialReference():
+        """Mock implementation for osgeo.osr.SpatialReference"""
+        return MockOsr.MockSpatialReference()
+
+    @staticmethod
+    def CoordinateTransformation(src, dest):
+        """Mock implementation for osgeo.osr.CoordinateTransformation"""
+        return MockOsr.MockCoordinateTransformation(src, dest)
+
+
+# When running a PGE within a Docker image delivered from ADT, the gdal import
+# below should work. When running in a dev environment, the import will fail
+# resulting in the MockGdal class being substituted instead.
+try:
+    from osgeo import osr
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
+    osr = MockOsr                           # pragma: no cover
+
 
 def get_geographic_boundaries_from_mgrs_tile(mgrs_tile_name):
     """
@@ -22,6 +80,7 @@ def get_geographic_boundaries_from_mgrs_tile(mgrs_tile_name):
     ----------
     mgrs_tile_name : str
         MGRS tile name
+
     Returns
     -------
     lat_min : float
@@ -32,51 +91,59 @@ def get_geographic_boundaries_from_mgrs_tile(mgrs_tile_name):
         minimum longitude of bounding box
     lon_max : float
         maximum longitude of bounding box
+
+    Raises
+    ------
+    RuntimeError
+        If an invalid MGRS tile code is provided.
+
     """
- 
     # mgrs_tile_name may begin with the letter T which must be removed
     if mgrs_tile_name.startswith('T'):
         mgrs_tile_name = mgrs_tile_name[1:]
+
     mgrs_obj = mgrs.MGRS()
+
     try:
         lower_left_utm_coordinate = mgrs_obj.MGRSToUTM(mgrs_tile_name)
-    except:
+    except MGRSError as err:
         raise RuntimeError(
-            f'Failed to convert MGRS tile name "{mgrs_tile_name}" to lat/lon.'
+            f'Failed to convert MGRS tile name "{mgrs_tile_name}" to lat/lon, '
+            f'reason: {str(err)}'
         )
 
     utm_zone = lower_left_utm_coordinate[0]
     is_northern = lower_left_utm_coordinate[1] == 'N'
-    x_min = lower_left_utm_coordinate[2]
-    y_min = lower_left_utm_coordinate[3]
- 
+    x_min = lower_left_utm_coordinate[2]  # east
+    y_min = lower_left_utm_coordinate[3]  # north
+
     # create UTM spatial reference
     utm_coordinate_system = osr.SpatialReference()
     utm_coordinate_system.SetWellKnownGeogCS("WGS84")
     utm_coordinate_system.SetUTM(utm_zone, is_northern)
- 
+
     # create geographic (lat/lon) spatial reference
     wgs84_coordinate_system = osr.SpatialReference()
     wgs84_coordinate_system.SetWellKnownGeogCS("WGS84")
- 
+
     # create transformation of coordinates from UTM to geographic (lat/lon)
     transformation = osr.CoordinateTransformation(utm_coordinate_system,
                                                   wgs84_coordinate_system)
- 
+
     # compute boundaries
     elevation = 0
     lat_min = None
     lat_max = None
     lon_min = None
     lon_max = None
- 
+
     for offset_x_multiplier in range(2):
         for offset_y_multiplier in range(2):
- 
+
             x = x_min + offset_x_multiplier * 109.8 * 1000
             y = y_min + offset_y_multiplier * 109.8 * 1000
             lat, lon, z = transformation.TransformPoint(x, y, elevation)
- 
+
             if lat_min is None or lat_min > lat:
                 lat_min = lat
             if lat_max is None or lat_max < lat:
@@ -85,5 +152,5 @@ def get_geographic_boundaries_from_mgrs_tile(mgrs_tile_name):
                 lon_min = lon
             if lon_max is None or lon_max < lon:
                 lon_max = lon
- 
+
     return lat_min, lat_max, lon_min, lon_max


### PR DESCRIPTION
This PR adds the final updates to the ISO metadata for the DSWx-HLS PGE to address all feedback we received from PO.DAAC. Updates include:

- Addition of lat/lon bounding box extent to ISO metadata, leveraging the new MGRS to lat/lon utility
- Corrections to the temporal extent in the ISO metadata to specify a begin/end time range
- Replacement of the Built up cover fraction file with the Worldcover file in the ancillary input section of the ISO metadata