### PR TITLE
CSLC-S1 Filename Convention Application

### DIFF
--- a/src/opera/pge/base/runconfig.py
+++ b/src/opera/pge/base/runconfig.py
@@ -353,14 +353,23 @@ class RunConfig:
     def get_output_product_filenames(self):
         """
         Returns a sorted list of all product file paths currently written to the
-        output location specified by the RunConfig. Note that only top-level files
-        are returned, this function does not recurse into any directories
-        encountered.
+        output location specified by the RunConfig.
+
+        Any hidden files (starting with ".") are ignored, as well as any files
+        within the designated "scratch" path (if it happens to be defined within
+        the output product directory).
 
         """
         output_product_path = abspath(self.output_product_path)
-        output_products = [join(output_product_path, filename)
-                           for filename in os.listdir(output_product_path)
-                           if isfile(join(output_product_path, filename))]
+        scratch_path = abspath(self.scratch_path)
+
+        output_products = []
+
+        for dirpath, dirnames, filenames in os.walk(output_product_path, topdown=False):
+            for filename in filter(lambda name: not name.startswith('.'), filenames):
+                product_path = os.path.join(dirpath, filename)
+
+                if scratch_path not in product_path:
+                    output_products.append(product_path)
 
         return sorted(output_products)

--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -10,9 +10,15 @@ from Sentinel-1 A/B (S1) PGE.
 
 """
 
+import json
+import os.path
+from datetime import datetime
+
 from opera.pge.base.base_pge import PgeExecutor
 from opera.pge.base.base_pge import PostProcessorMixin
 from opera.pge.base.base_pge import PreProcessorMixin
+from opera.util.error_codes import ErrorCode
+from opera.util.time import get_time_for_filename
 
 
 class CslcS1PreProcessorMixin(PreProcessorMixin):
@@ -61,6 +67,130 @@ class CslcS1PostProcessorMixin(PostProcessorMixin):
     _post_mixin_name = "CslcS1PostProcessorMixin"
     _cached_core_filename = None
 
+    def _core_filename(self, inter_filename=None):
+        """
+        Returns the core file name component for products produced by the
+        CSLC-S1 PGE.
+
+        The core file name component of the CSLC-S1 PGE consists of:
+
+        <PROJECT>_<LEVEL>_<PGE NAME>_<SENSOR>_<MODE>_<BURST ID>_<POL>_<ACQ TIMETAG>_<PRODUCT VER>_<PROD TIMETAG>
+
+        Callers of this function are responsible for assignment of any other
+        product-specific fields, such as the file extension.
+
+        Notes
+        -----
+        On first call to this function, the returned core filename is cached
+        for subsequent calls. This allows the core filename to be easily reused
+        across product types without needing to provide inter_filename for each
+        subsequent call.
+
+        Parameters
+        ----------
+        inter_filename : str, optional
+            The intermediate filename of the output product to generate the
+            core filename for. This parameter may be used to inspect the file
+            in order to derive any necessary components of the returned filename.
+            Once the core filename is cached upon first call to this function,
+            this parameter may be omitted.
+
+        Returns
+        -------
+        core_filename : str
+            The core file name component to assign to products created by this PGE.
+
+        """
+        # Check if the core filename has already been generated and cached,
+        # and return it if so
+        if self._cached_core_filename is not None:
+            return self._cached_core_filename
+
+        if not inter_filename:
+            msg = (f"No filename provided to {self.__class__.__name__}._core_filename(), "
+                   f"First call must provide a filename before result is cached.")
+            self.logger.critical(self.name, ErrorCode.FILE_MOVE_FAILED, msg)
+
+        # CSLC-S1 SAS produces two output files: the image and a separate
+        # json metadata file, each with the same base filename.
+        # We use that here to always locate and read the json metadata file.
+        metadata_filename = os.path.splitext(inter_filename)[0] + '.json'
+
+        with open(metadata_filename, 'r') as infile:
+            cslc_metadata = json.load(infile)
+
+        sensor = cslc_metadata['platform_id']
+        mode = 'IW'  # fixed for all S1-based CSLC products
+        burst_id = cslc_metadata['burst_id'].upper().replace('_', '-')
+        pol = cslc_metadata['polarization']
+        acquisition_time = get_time_for_filename(
+            datetime.strptime(cslc_metadata['sensing_start'], '%Y-%m-%d %H:%M:%S.%f')
+        )
+        product_version = self.SAS_VERSION  # TODO: may extract from cslc_metadata eventually
+        production_time = get_time_for_filename(self.production_datetime)
+
+        self._cached_core_filename = (
+            f"{self.PROJECT}_{self.LEVEL}_{self.NAME}_{sensor}_{mode}_{burst_id}_"
+            f"{pol}_{acquisition_time}Z_v{product_version}_{production_time}Z"
+        )
+
+        return self._cached_core_filename
+
+    def _geotiff_filename(self, inter_filename):
+        """
+        Returns the file name to use for GeoTIFF's produced by the CSLC-S1 PGE.
+
+        The GeoTIFF filename for the CSLC-S1 PGE consists of:
+
+            <Core filename>.tiff
+
+        Where <Core filename> is returned by CslcS1PostProcessorMixin._core_filename()
+
+        Parameters
+        ----------
+        inter_filename : str
+            The intermediate filename of the output GeoTIFF to generate a
+            filename for. This parameter may be used to inspect the file in order
+            to derive any necessary components of the returned filename.
+
+        Returns
+        -------
+        geotiff_filename : str
+            The file name to assign to GeoTIFF product(s) created by this PGE.
+
+        """
+        core_filename = self._core_filename(inter_filename)
+
+        return f"{core_filename}.tiff"
+
+    def _json_metadata_filename(self, inter_filename):
+        """
+        Returns the file name to use for JSON metadata files produced by the
+        CSLC-S1 PGE.
+
+        The JSON metadata filename for the CSLC-S1 PGE consists of:
+
+            <Core filename>.json
+
+        Where <Core filename> is returned by CslcS1PostProcessorMixin._core_filename()
+
+        Parameters
+        ----------
+        inter_filename : str
+            The intermediate filename of the output JSON metadata to generate a
+            filename for. This parameter may be used to inspect the file in order
+            to derive any necessary components of the returned filename.
+
+        Returns
+        -------
+        json_metadata_filename : str
+            The file name to assign to JSON metadata product(s) created by this PGE.
+
+        """
+        core_filename = self._core_filename(inter_filename)
+
+        return f"{core_filename}.json"
+
     def run_postprocessor(self, **kwargs):
         """
         Executes the post-processing steps for the CSLC-S1 PGE.
@@ -101,4 +231,8 @@ class CslcS1Executor(CslcS1PreProcessorMixin, CslcS1PostProcessorMixin, PgeExecu
     def __init__(self, pge_name, runconfig_path, **kwargs):
         super().__init__(pge_name, runconfig_path, **kwargs)
 
-        self.rename_by_pattern_map = {}
+        self.rename_by_pattern_map = {
+            '*.slc': self._geotiff_filename,
+            '*.tif*': self._geotiff_filename,
+            '*.json': self._json_metadata_filename
+        }

--- a/src/opera/pge/dswx_hls/dswx_hls_pge.py
+++ b/src/opera/pge/dswx_hls/dswx_hls_pge.py
@@ -140,7 +140,7 @@ class DSWxHLSPostProcessorMixin(PostProcessorMixin):
 
         The core file name component of the DSWx PGE consists of:
 
-        <PROJECT>_<LEVEL>_<PGE NAME>_<SOURCE>_<SPACECRAFT_NAME>_<TILE ID>_<TIMETAG>_<PRODUCT VERSION>
+        <PROJECT>_<LEVEL>_<PGE NAME>_<SOURCE>_<SENSOR>_<SPACING>_<TILE ID>_<ACQ TIMETAG>_<PROD TIMETAG>_<PRODUCT VERSION>
 
         Callers of this function are responsible for assignment of any other
         product-specific fields, such as the file extension.
@@ -217,7 +217,7 @@ class DSWxHLSPostProcessorMixin(PostProcessorMixin):
 
         The GeoTIFF filename for the DSWx-HLS PGE consists of:
 
-            <Core filename>_<Band Index>_<Band Name>.tif
+            <Core filename>_<Band Index>_<Band Name>.tiff
 
         Where <Core filename> is returned by DSWxHLSPostProcessorMixin._core_filename()
         and <Band Index> and <Band Name> are determined from the name of the

--- a/src/opera/test/data/test_cslc_s1_config.yaml
+++ b/src/opera/test/data/test_cslc_s1_config.yaml
@@ -17,14 +17,15 @@ RunConfig:
 
             ProductPathGroup:
                 OutputProductPath: cslc_pge_test/output_dir
-                ScratchPath: cslc_pge_test/scratch_dir
+                ScratchPath: cslc_pge_test/output_dir/scratch_dir
 
             PrimaryExecutable:
                 ProductIdentifier: CSLC_S1
-                ProgramPath: /bin/echo
+                ProgramPath: mkdir
                 ProgramOptions:
-                    - 'hello world > cslc_pge_test/output_dir/t64_iw2_b204_20220501_VV.slc;'
-                    - '/bin/echo "hello json" > cslc_pge_test/output_dir/t64_iw2_b204_20220501_VV.json;'
+                    - '-p cslc_pge_test/output_dir/t64_iw2_b204/20220501/;'
+                    - '/bin/echo hello world > cslc_pge_test/output_dir/t64_iw2_b204/20220501/t64_iw2_b204_20220501_VV.slc;'
+                    - '/bin/echo "{\"sensing_start\": \"2022-05-01 01:50:52.530024\", \"polarization\": \"VV\", \"burst_id\": \"t64_iw2_b204\", \"platform_id\": \"S1A\"}" > cslc_pge_test/output_dir/t64_iw2_b204/20220501/t64_iw2_b204_20220501_VV.json;'
                     - '/bin/echo CSLC-S1 invoked with RunConfig'
                 ErrorCodeBase: 200000
                 SchemaPath: pge/cslc_s1/schema/cslc_s1_sas_schema.yaml


### PR DESCRIPTION
This branch adds an implementation for file name application to the CSLC-S1 PGE.

The information required to fill in the components of the final filename are obtained from the JSON metadata file produced by the SAS.

This branch also modifies the `get_output_product-filenames()` method of the `RunConfig` class to support finding of output products within an arbitrary number of sub-directories.