### PR TITLE
Changes to incorporate redelivery of CSLC-S1 SAS interface

### DIFF
--- a/.ci/scripts/build_cslc_s1.sh
+++ b/.ci/scripts/build_cslc_s1.sh
@@ -50,7 +50,7 @@ BUILD_DATE_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 # defaults, SAS image should be updated as necessary for new image releases from ADT
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath $(dirname $(realpath $0))/../..)
 [ -z "${TAG}" ] && TAG="${USER}-dev"
-[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/cslc_s1:interface"
+[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/cslc_s1:interface_0.1"
 
 echo "WORKSPACE: $WORKSPACE"
 echo "IMAGE: $IMAGE"

--- a/src/opera/pge/cslc_s1/schema/cslc_s1_sas_schema.yaml
+++ b/src/opera/pge/cslc_s1/schema/cslc_s1_sas_schema.yaml
@@ -14,10 +14,6 @@ runconfig:
             safe_file_path: list(str(), min=1)
             # Required. List of orbit (EOF) files
             orbit_file_path: list(str(), min=1)
-            # Required. Path to the burst data to process
-            burst_file_path: str(required=True)
-            # Required. Path to burst light metadata file
-            light_metadata_path: str(required=True)
             # List of (unique) burst ID to process
             burst_id: str(required=True)
 
@@ -60,7 +56,7 @@ geocoding_options:
    output_format: enum('ENVI', 'GTiff', 'COG', required=False)
    # Boolean flag to enable/disable flattening
    flatten: bool(required=False)
-             # Number of lines to process in batch
+   # Number of lines to process in batch
    lines_per_block: int(min=1, required=False)
    # Product EPSG code. Same as DEM if not provided
    output_epsg: int(min=1024, max=32767, required=False)

--- a/src/opera/test/data/test_cslc_s1_config.yaml
+++ b/src/opera/test/data/test_cslc_s1_config.yaml
@@ -55,10 +55,6 @@ RunConfig:
                         # Required. List of orbit (EOF) files (min=1)
                         orbit_file_path:
                             - input_data/S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF
-                        # Required. Path to the burst data
-                        burst_file_path: input_data/burst_t64_iw2_b204_20210501_VV.slc.vrt
-                        # Required. Path to light metadata file
-                        light_metadata_path: input_data/light_metadata_t64_iw2_b204_20210501_VV.json
                         # Required. The unique burst ID to process
                         burst_id: t64_iw2_b204
 


### PR DESCRIPTION
Small update to incorporate the latest version of the CSLC-S1 interface SAS with our PGE repo. 

Main change is the removal of the `burst_file_path` and `light_metadata_path` from the list of input files expected by the SAS runconfig schema.