### PR TITLE
DSWx-HLS Filename Convention and Int Test Updates

### DIFF
--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -2,7 +2,17 @@
 
 pipeline {
     agent any
+    environment {
+        DOCKER_IMAGE_PREFIX = 'opera_pge'
+        DOCKER_TAG = """${sh(
+                     returnStdout: true,
+                     script: 'echo ${GIT_BRANCH##*/}'
+                     ).trim()}"""
+    }
     parameters {
+        // TODO: update default value as newer PGE's are added
+        string(name: 'DOCKER_IMAGE_SUFFIXES', defaultValue: 'dswx_hls',
+               description: 'Comma-delimited list of PGE names to run integration tests for')
         string(name: 'ART_DOCKER_REGISTRY', defaultValue: 'artifactory-fn.jpl.nasa.gov:16001',
                description: 'Address of Artifactory-FN Docker registry for uploading Docker images.')
         credentials (name: 'ART_CREDENTIALS',
@@ -11,53 +21,59 @@ pipeline {
                      description: 'Artifactory-FN credentials for account operapgebot. Used to push/pull images from Artifactory during build.',
                      required: true)
     }
-    environment {
-        DOCKER_IMAGE_PREFIX = 'opera_pge'
-        // TODO: update as newer PGE's are added
-        DOCKER_IMAGE_SUFFIXES = 'dswx_hls'
-        DOCKER_TAG = """${sh(
-                     returnStdout: true,
-                     script: 'echo ${GIT_BRANCH##*/}'
-                     ).trim()}"""
-    }
     stages {
         stage('Build OPERA PGE Docker image(s)') {
             steps {
                 script {
                     docker.withRegistry ('https://' + params.ART_DOCKER_REGISTRY, params.ART_CREDENTIALS) {
-                        echo "Building ${DOCKER_IMAGE_PREFIX} docker images with tag ${DOCKER_TAG}"
-                        sh label: 'Build all OPERA Docker images',
-                           script: ".ci/scripts/build_all_images.sh $DOCKER_TAG"
+                        DOCKER_IMAGE_SUFFIXES.tokenize(',').each { DOCKER_IMAGE_SUFFIX ->
+                            echo "Building ${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_SUFFIX} docker image with tag ${DOCKER_TAG}"
+                            sh label: "Build ${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_SUFFIX} OPERA Docker image",
+                               script: ".ci/scripts/build_${DOCKER_IMAGE_SUFFIX}.sh --tag $DOCKER_TAG"
+                        }
                     }
                 }
             }
         }
-        stage('Test OPERA PGE Docker image(s)') {
+        stage('Integration Test OPERA PGE Docker image(s)') {
             steps {
-                echo "Testing ${DOCKER_IMAGE_PREFIX} docker images with tag ${DOCKER_TAG}"
                 script {
-                    def statusCode = sh label: 'Test all OPERA Docker images', returnStatus:true,
-                       script: ".ci/scripts/test_int_dswx_hls.sh --tag $DOCKER_TAG --testdata delivery_2.1_mid_may.zip --runconfig opera_pge_dswx_hls_delivery_2.1_mid_may_runconfig.yaml"
-                    echo "Test returned code ${statusCode}"
-                    if (statusCode == 2) {
-                        unstable "Product comparison failure detected. Setting stage result to unstable."
+                    def htmlFiles = []
+                    def reportTitles = []
+
+                    DOCKER_IMAGE_SUFFIXES.tokenize(',').each { DOCKER_IMAGE_SUFFIX ->
+                        echo "Integration testing Docker image ${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_SUFFIX}:${DOCKER_TAG}"
+
+                        def statusCode = sh label: "Running Integration Test for image ${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_SUFFIX}:${DOCKER_TAG}", returnStatus:true,
+                           script: ".ci/scripts/test_int_${DOCKER_IMAGE_SUFFIX}.sh --tag ${DOCKER_TAG}"
+
+                        echo "Test returned code ${statusCode}"
+
+                        if (statusCode == 2) {
+                            unstable "Product comparison failure detected. Setting stage result to unstable."
+                        }
+                        else if (statusCode != 0) {
+                            currentStage.result = 'FAILURE'
+                        }
+                        else if (statusCode == 0) {
+                            currentStage.result = 'SUCCESS'
+                        }
+
+                        htmlFiles << "${DOCKER_IMAGE_SUFFIX}/test_int_${DOCKER_IMAGE_SUFFIX}_results.html"
+                        reportTitles << "${DOCKER_IMAGE_SUFFIX}"
                     }
-                    else if (statusCode != 0) {
-                        currentStage.result = 'FAILURE'
-                    }
-                    else if (statusCode == 0) {
-                        currentStage.result = 'SUCCESS'
-                    }
+
+                    publishHTML target: [
+                        allowMissing: true,
+                        alwaysLinkToLastBuild: true,
+                        keepAll: true,
+                        reportDir: "test_results",
+                        reportFiles: htmlFiles.join(','),
+                        reportName: "Integration Test Results",
+                        reportTitles: reportTitles.join(',')
+                    ]
                 }
-                archiveArtifacts artifacts: 'test_results/dswx_hls/test_int_dswx_results.html'
-                publishHTML target: [
-                    allowMissing: true,
-                    alwaysLinkToLastBuild: true,
-                    keepAll: true,
-                    reportDir: "test_results",
-                    reportFiles: "dswx_hls/test_int_dswx_results.html",
-                    reportName: "Integration Test Results",
-                ]
+                archiveArtifacts artifacts: 'test_results/**/test_int_*_results.html'
             }
         }
     }

--- a/.ci/scripts/test_int_dswx_hls.sh
+++ b/.ci/scripts/test_int_dswx_hls.sh
@@ -49,21 +49,25 @@ Integration Testing DSWx-HLS PGE docker image...
 
 PGE_NAME="dswx_hls"
 PGE_IMAGE="opera_pge/${PGE_NAME}"
-
 TEST_RESULTS_REL_DIR="test_results"
+
+# defaults, test data and runconfig files should be updated as-needed to use
+# the latest available as defaults for use with the Jenkins pipeline call
+# TESTDATA should be the name of the test data archive in s3://operasds-dev-pge/dswx_hls/
+# RUNCONFIG should be the name of the runconfig in s3://operasds-dev-pge/dswx_hls/
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath $(dirname $(realpath $0))/../..)
+[ -z "${TESTDATA}" ] && TESTDATA="delivery_3_cal_val.zip"
+[ -z "${RUNCONFIG}" ] && RUNCONFIG="opera_pge_dswx_hls_delivery_3.0_cal_val_runconfig.yaml"
+
 TEST_RESULTS_DIR="${WORKSPACE}/${TEST_RESULTS_REL_DIR}/${PGE_NAME}"
 
 echo "Test results output directory: ${TEST_RESULTS_DIR}"
 mkdir --parents ${TEST_RESULTS_DIR}
 chmod -R 775 ${TEST_RESULTS_DIR}
-RESULTS_FILE="${TEST_RESULTS_DIR}/test_int_dswx_results.html"
+RESULTS_FILE="${TEST_RESULTS_DIR}/test_int_${PGE_NAME}_results.html"
 
 # For this version of integration test, an archive has been created which contains
 # the unmodified ADT SAS test data archive and PGE expected output.
-
-# TESTDATA should be the name of the test data archive in s3://operasds-dev-pge/dswx_hls/
-# RUNCONFIG should be the name of the runconfig in s3://operasds-dev-pge/dswx_hls/
 
 # Create a temporary directory to allow Jenkins to write to it and avoid collisions
 # with other users
@@ -74,7 +78,7 @@ cd $local_dir
 local_testdata_archive=${local_dir}/${TESTDATA}
 local_runconfig=${local_dir}/${RUNCONFIG}
 
-results_html_init="<html><b>dswx_hls product comparison results</b> \
+results_html_init="<html><b>${PGE_NAME} product comparison results</b> \
     <style>* {font-family: sans-serif;} \
     table {border-collapse: collapse;} \
     th,td {padding: 4px 6px; border: thin solid white} \
@@ -98,10 +102,10 @@ function cleanup {
 trap cleanup EXIT
 
 # Pull in test data and runconfig from S3
-echo "Downloading test data from s3://operasds-dev-pge/dswx_hls/${TESTDATA} to $local_testdata_archive"
-aws s3 cp s3://operasds-dev-pge/dswx_hls/${TESTDATA} $local_testdata_archive
-echo "Downloading runconfig from s3://operasds-dev-pge/dswx_hls/${RUNCONFIG} to $local_runconfig"
-aws s3 cp s3://operasds-dev-pge/dswx_hls/${RUNCONFIG} $local_runconfig
+echo "Downloading test data from s3://operasds-dev-pge/${PGE_NAME}/${TESTDATA} to $local_testdata_archive"
+aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/${TESTDATA} $local_testdata_archive
+echo "Downloading runconfig from s3://operasds-dev-pge/${PGE_NAME}/${RUNCONFIG} to $local_runconfig"
+aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/${RUNCONFIG} $local_runconfig
 
 # Extract the test data archive to the current directory
 if [ -f $local_testdata_archive ]; then

--- a/src/opera/pge/dswx_hls/dswx_hls_pge.py
+++ b/src/opera/pge/dswx_hls/dswx_hls_pge.py
@@ -140,7 +140,7 @@ class DSWxHLSPostProcessorMixin(PostProcessorMixin):
 
         The core file name component of the DSWx PGE consists of:
 
-        <PROJECT>_<LEVEL>_<PGE NAME>_<SOURCE>_<SENSOR>_<SPACING>_<TILE ID>_<ACQ TIMETAG>_<PROD TIMETAG>_<PRODUCT VERSION>
+        <PROJECT>_<LEVEL>_<PGE NAME>_<SOURCE>_<TILE ID>_<ACQ TIMETAG>_<PROD TIMETAG>_<SENSOR>_<SPACING>_<PRODUCT VERSION>
 
         Callers of this function are responsible for assignment of any other
         product-specific fields, such as the file extension.
@@ -205,8 +205,9 @@ class DSWxHLSPostProcessorMixin(PostProcessorMixin):
 
         # Assign the core file to the cached class attribute
         self._cached_core_filename = (
-            f"{self.PROJECT}_{self.LEVEL}_{self.NAME}_{source}_{sensor}_{pixel_spacing}_"
-            f"{tile_id}_{acquisition_time}_{processing_time}_{product_version}"
+            f"{self.PROJECT}_{self.LEVEL}_{self.NAME}_{source}_{tile_id}_"
+            f"{acquisition_time}_{processing_time}_{sensor}_{pixel_spacing}_"
+            f"{product_version}"
         )
 
         return self._cached_core_filename

--- a/src/opera/test/pge/dswx_hls/test_dswx_hls_pge.py
+++ b/src/opera/test/pge/dswx_hls/test_dswx_hls_pge.py
@@ -25,6 +25,7 @@ from opera.pge import RunConfig
 from opera.pge.dswx_hls.dswx_hls_pge import DSWxHLSExecutor
 from opera.util import PgeLogger
 from opera.util.img_utils import MockGdal
+from opera.util.metadata_utils import get_sensor_from_spacecraft_name
 
 
 class DSWxPgeTestCase(unittest.TestCase):
@@ -293,14 +294,18 @@ class DSWxPgeTestCase(unittest.TestCase):
 
         pge.run()
 
-        image_files = glob.glob(join(pge.runconfig.output_product_path, "*.tif"))
+        image_files = glob.glob(join(pge.runconfig.output_product_path, "*.tiff"))
 
-        for i in range(len(image_files)):
-            file_name = pge._geotiff_filename(image_files[i])
+        for image_file in image_files:
+            file_name = pge._geotiff_filename(image_file)
             md = MockGdal.MockGdalDataset().GetMetadata()
-            file_name_regex = rf"{pge.PROJECT}_{pge.LEVEL}_{md['PRODUCT_TYPE']}_{md['PRODUCT_SOURCE']}_" \
-                              rf"{md['SPACECRAFT_NAME']}_{md['HLS_DATASET'].split('.')[2]}_\d{{8}}T\d{{6}}_" \
-                              rf"{'.'.join(md['HLS_DATASET'].split('.')[-2:])}_\d{{3}}_B\d{{2}}_\w+.tif?"
+            file_name_regex = rf"{pge.PROJECT}_{pge.LEVEL}_" \
+                              rf"{md['PRODUCT_TYPE']}_{md['PRODUCT_SOURCE']}_" \
+                              rf"{md['HLS_DATASET'].split('.')[2]}_" \
+                              rf"\d{{8}}T\d{{6}}Z_\d{{8}}T\d{{6}}Z_" \
+                              rf"{get_sensor_from_spacecraft_name(md['SPACECRAFT_NAME'])}_" \
+                              rf"30_v{md['PRODUCT_VERSION']}_" \
+                              rf"B\d{{2}}_\w+.tiff"
             self.assertEqual(re.match(file_name_regex, file_name).group(), file_name)
 
 


### PR DESCRIPTION
This PR addresses the recent change to the output product filename format for DSWx-HLS products where some fields were shuffled around.

I wanted to try this branch out with the Integration Test pipeline, so I also ended up make some modifications to allow the pipeline to support multiple PGE's, in expectation of the CSLC-S1 test script. I also updated the test assets for DSWx to the versions received from ADT for the CalVal delivery.