### PR TITLE
Return to starting directory in tearDown(), so temporary directory is cleaned up appropriately.

### DIFF
--- a/src/opera/test/util/test_logger.py
+++ b/src/opera/test/util/test_logger.py
@@ -74,7 +74,7 @@ class LoggerTestCase(unittest.TestCase):
 
     def tearDown(self) -> None:
         """Return to starting directory"""
-        os.chdir(self.test_dir)
+        os.chdir(self.starting_dir)
         self.working_dir.cleanup()
 
     def add_backframe(self, back_frames):


### PR DESCRIPTION
The solution was to replace __os.chdir(self.test_dir)__ by __os.chdir(self.starting_dir)__ on __tearDown()__ method to correctly return to starting directory, so temporary directory is cleaned up appropriately without leaving a __test_logger_xxxxxtemp__  directory within whatever working directory the test was started in.