### PR TITLE
Improve Python styles to cleanup and pass flake8.

### DIFF
--- a/.ci/scripts/process_metric_data.py
+++ b/.ci/scripts/process_metric_data.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python3
 
-import csv
-import os
-import pathlib
-import sys
-
-
 """
 ======================
 process_metric_data.py
@@ -14,6 +8,11 @@ process_metric_data.py
 Post process the csv file returned when metric data is collected
 
 """
+
+import csv
+import os
+import pathlib
+import sys
 
 
 def remove_unwanted_lines(csv_file):
@@ -44,6 +43,7 @@ def remove_unwanted_lines(csv_file):
 
 
 def delete_temp_files(file_name):
+    """Delete temporary files"""
     try:
         os.remove(file_name)
         print(f'Removing: {file_name} from {pathlib.Path().absolute()}')
@@ -52,7 +52,7 @@ def delete_temp_files(file_name):
 
 
 def main(csv_file):
-    """ main program in process_metric_data.py"""
+    """Main program in process_metric_data.py"""
     remove_unwanted_lines(csv_file)
     delete_temp_files(csv_file)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,8 @@
 import os
 import sys
 
+import opera
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.pardir, "src")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.pardir, "src", "scripts")))
 
@@ -53,7 +55,6 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-import opera
 
 project = opera.__title__
 copyright = opera.__copyright__

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@
 
 """The setup script."""
 
-from setuptools import find_packages, setup
-
 import opera
+
+from setuptools import find_packages, setup
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()

--- a/src/opera/pge/base_pge.py
+++ b/src/opera/pge/base_pge.py
@@ -10,15 +10,11 @@ Module defining the Base PGE interfaces from which all other PGEs are derived.
 """
 
 import os
-from datetime import datetime
-from functools import lru_cache
 from collections import OrderedDict
+from datetime import datetime
 from fnmatch import fnmatch
+from functools import lru_cache
 from os.path import abspath, basename, exists, join, splitext
-
-from yamale import YamaleError
-
-import yaml
 
 import opera
 from opera.util.error_codes import ErrorCode
@@ -31,6 +27,10 @@ from opera.util.run_utils import get_checksum
 from opera.util.run_utils import time_and_execute
 from opera.util.time import get_catalog_metadata_datetime_str
 from opera.util.time import get_time_for_filename
+
+from yamale import YamaleError
+
+import yaml
 
 from .runconfig import RunConfig
 

--- a/src/opera/pge/dswx_pge.py
+++ b/src/opera/pge/dswx_pge.py
@@ -21,8 +21,8 @@ from opera.util.img_utils import get_geotiff_processing_datetime
 from opera.util.img_utils import get_geotiff_product_version
 from opera.util.img_utils import get_geotiff_spacecraft_name
 from opera.util.img_utils import get_hls_filename_fields
-from opera.util.metadata_utils import get_sensor_from_spacecraft_name
 from opera.util.metadata_utils import get_geographic_boundaries_from_mgrs_tile
+from opera.util.metadata_utils import get_sensor_from_spacecraft_name
 from opera.util.render_jinja2 import render_jinja2
 from opera.util.time import get_time_for_filename
 

--- a/src/opera/test/pge/test_base_pge.py
+++ b/src/opera/test/pge/test_base_pge.py
@@ -17,13 +17,13 @@ from os.path import abspath, join
 from pathlib import Path
 from unittest.mock import patch
 
-from pkg_resources import resource_filename
-
-import yaml
-
 import opera
 from opera.pge import PgeExecutor, RunConfig
 from opera.util import PgeLogger
+
+from pkg_resources import resource_filename
+
+import yaml
 
 
 class BasePgeTestCase(unittest.TestCase):

--- a/src/opera/test/pge/test_dswx_pge.py
+++ b/src/opera/test/pge/test_dswx_pge.py
@@ -16,14 +16,14 @@ from io import StringIO
 from os.path import abspath, join
 from unittest.mock import patch
 
-from pkg_resources import resource_filename
-
-import yaml
-
 import opera.util.img_utils
 from opera.pge import DSWxExecutor, RunConfig
 from opera.util import PgeLogger
 from opera.util.img_utils import MockGdal
+
+from pkg_resources import resource_filename
+
+import yaml
 
 
 class DSWxPgeTestCase(unittest.TestCase):

--- a/src/opera/test/pge/test_pge_main.py
+++ b/src/opera/test/pge/test_pge_main.py
@@ -14,8 +14,6 @@ import unittest
 from os.path import abspath, join
 from pathlib import Path
 
-from pkg_resources import resource_filename
-
 from opera.pge import PgeExecutor, RunConfig
 from opera.scripts import pge_main
 from opera.scripts.pge_main import get_pge_class
@@ -23,6 +21,8 @@ from opera.scripts.pge_main import load_run_config_file
 from opera.scripts.pge_main import open_log_file
 from opera.scripts.pge_main import pge_start
 from opera.util import PgeLogger
+
+from pkg_resources import resource_filename
 
 
 class PgeMainTestCase(unittest.TestCase):

--- a/src/opera/test/pge/test_runconfig.py
+++ b/src/opera/test/pge/test_runconfig.py
@@ -12,12 +12,12 @@ import tempfile
 import unittest
 from os.path import join
 
+from opera.pge import RunConfig
+from opera.pge.runconfig import ISO_TEMPLATE_DIR
+
 from pkg_resources import resource_filename
 
 from yamale import YamaleError
-
-from opera.pge import RunConfig
-from opera.pge.runconfig import ISO_TEMPLATE_DIR
 
 
 class RunconfigTestCase(unittest.TestCase):

--- a/src/opera/test/util/test_img_utils.py
+++ b/src/opera/test/util/test_img_utils.py
@@ -16,14 +16,14 @@ from os.path import abspath, join
 from re import match
 from unittest import skipIf
 
-from pkg_resources import resource_filename
-
 from opera.util.img_utils import get_geotiff_hls_dataset
 from opera.util.img_utils import get_geotiff_metadata
 from opera.util.img_utils import get_geotiff_processing_datetime
 from opera.util.img_utils import get_geotiff_product_version
 from opera.util.img_utils import get_geotiff_spacecraft_name
 from opera.util.img_utils import get_hls_filename_fields
+
+from pkg_resources import resource_filename
 
 
 def gdal_is_available():

--- a/src/opera/test/util/test_logger.py
+++ b/src/opera/test/util/test_logger.py
@@ -16,8 +16,6 @@ from io import StringIO
 from os.path import abspath, exists, join
 from random import randint
 
-from pkg_resources import resource_filename
-
 from opera.util.error_codes import (CODES_PER_RANGE,
                                     CRITICAL_RANGE_START,
                                     DEBUG_RANGE_START,
@@ -29,6 +27,8 @@ from opera.util.logger import default_log_file_name
 from opera.util.logger import get_severity_from_error_code
 from opera.util.logger import standardize_severity_string
 from opera.util.logger import write
+
+from pkg_resources import resource_filename
 
 
 class LoggerTestCase(unittest.TestCase):

--- a/src/opera/test/util/test_metfile.py
+++ b/src/opera/test/util/test_metfile.py
@@ -12,9 +12,9 @@ import tempfile
 import unittest
 from os.path import abspath, exists
 
-from pkg_resources import resource_filename
-
 from opera.util.metfile import MetFile
+
+from pkg_resources import resource_filename
 
 
 class MetFileTestCase(unittest.TestCase):

--- a/src/opera/test/util/test_render_jinja2.py
+++ b/src/opera/test/util/test_render_jinja2.py
@@ -13,10 +13,10 @@ import tempfile
 import unittest
 from os.path import abspath, join
 
-from pkg_resources import resource_filename
-
 from opera.util.logger import PgeLogger
 from opera.util.render_jinja2 import render_jinja2
+
+from pkg_resources import resource_filename
 
 
 class RenderJinja2TestCase(unittest.TestCase):

--- a/src/opera/test/util/test_run_utils.py
+++ b/src/opera/test/util/test_run_utils.py
@@ -15,12 +15,12 @@ import unittest
 from os.path import abspath
 from unittest.mock import patch
 
-from pkg_resources import resource_filename
-
 from opera.util.logger import PgeLogger
 from opera.util.run_utils import create_qa_command_line
 from opera.util.run_utils import create_sas_command_line
 from opera.util.run_utils import time_and_execute
+
+from pkg_resources import resource_filename
 
 
 class RunUtilsTestCase(unittest.TestCase):

--- a/src/opera/test/util/test_time.py
+++ b/src/opera/test/util/test_time.py
@@ -14,12 +14,12 @@ import unittest
 from datetime import datetime
 from os.path import abspath, join
 
-from pkg_resources import resource_filename
-
 from opera.util.time import get_catalog_metadata_datetime_str
 from opera.util.time import get_current_iso_time
 from opera.util.time import get_iso_time
 from opera.util.time import get_time_for_filename
+
+from pkg_resources import resource_filename
 
 
 class TimeTestCase(unittest.TestCase):

--- a/src/opera/test/util/test_usage_metrics.py
+++ b/src/opera/test/util/test_usage_metrics.py
@@ -14,9 +14,9 @@ import unittest
 from os.path import abspath, join
 from sys import platform
 
-from pkg_resources import resource_filename
-
 from opera.util.usage_metrics import get_os_metrics
+
+from pkg_resources import resource_filename
 
 
 class UsageMetricsTestCase(unittest.TestCase):


### PR DESCRIPTION
I made some changes on imports to improve Python styles, cleanup and pass flake8 with the command:

```text
flake8 --config .flake8 --application-import-names src
```

