### PR TITLE
HLS Sensing Time parsing fix

### DIFF
--- a/src/opera/pge/dswx_hls/dswx_hls_pge.py
+++ b/src/opera/pge/dswx_hls/dswx_hls_pge.py
@@ -302,6 +302,12 @@ class DSWxHLSPostProcessorMixin(PostProcessorMixin):
         # by semi-colon
         if ';' in sensing_time:
             sensing_time_begin, sensing_time_end = sensing_time.split(';')
+        # Certain L30 datasets have been observed with multiple sensing times
+        # concatenated by a plus sign, for this case just take the first of the
+        # times
+        elif '+' in sensing_time:
+            sensing_time_begin = sensing_time.split('+')[0]
+            sensing_time_end = sensing_time_begin
         # S30 datasets seem to only provide a single sensing time value
         else:
             sensing_time_begin = sensing_time_end = sensing_time

--- a/src/opera/util/img_utils.py
+++ b/src/opera/util/img_utils.py
@@ -9,6 +9,7 @@ Image file utilities for use with OPERA PGEs.
 
 """
 
+from copy import deepcopy
 from collections import namedtuple
 from datetime import datetime
 from functools import lru_cache
@@ -29,30 +30,31 @@ class MockGdal:  # pragma: no cover
     # pylint: disable=all
     class MockGdalDataset:
         """Mock class for gdal.Dataset objects, as returned from an Open call."""
+        dummy_metadata = {
+            'ACCODE': 'LaSRC', 'CLOUD_COVERAGE': '43', 'DEM_FILE': 'dem.tif',
+            'HLS_DATASET': 'HLS.L30.T22VEQ.2021248T143156.v2.0',
+            'LANDCOVER_FILE': 'landcover.tif', 'LEVEL': '3',
+            'MEAN_SUN_AZIMUTH_ANGLE': '145.002203258435',
+            'MEAN_SUN_ZENITH_ANGLE': '30.7162834439185',
+            'MEAN_VIEW_AZIMUTH_ANGLE': '100.089770731169',
+            'MEAN_VIEW_ZENITH_ANGLE': '4.6016561116873',
+            'NBAR_SOLAR_ZENITH': '31.7503071022442',
+            'PROCESSING_DATETIME': '2022-01-31T21:54:26',
+            'PRODUCT_ID': 'dswx_hls', 'PRODUCT_SOURCE': 'HLS',
+            'PRODUCT_TYPE': 'DSWx', 'PRODUCT_VERSION': '0.1',
+            'PROJECT': 'OPERA', 'WORLDCOVER_FILE': 'worldcover.tif',
+            'SENSING_TIME': '2021-09-05T14:31:56.9300799Z; 2021-09-05T14:32:20.8126470Z',
+            'SENSOR': 'MSI',
+            'SENSOR_PRODUCT_ID': 'S2A_MSIL1C_20210907T163901_N0301_R126_T15SXR_20210907T202434.SAFE',
+            'SPACECRAFT_NAME': 'SENTINEL-2A', 'SPATIAL_COVERAGE': '99'
+        }
 
         def GetMetadata(self):
             """
             Returns a subset of dummy metadata expected by the PGE.
             This function should be updated as needed for requisite metadata fields.
             """
-            return {
-                'ACCODE': 'LaSRC', 'CLOUD_COVERAGE': '43', 'DEM_FILE': 'dem.tif',
-                'HLS_DATASET': 'HLS.L30.T22VEQ.2021248T143156.v2.0',
-                'LANDCOVER_FILE': 'landcover.tif', 'LEVEL': '3',
-                'MEAN_SUN_AZIMUTH_ANGLE': '145.002203258435',
-                'MEAN_SUN_ZENITH_ANGLE': '30.7162834439185',
-                'MEAN_VIEW_AZIMUTH_ANGLE': '100.089770731169',
-                'MEAN_VIEW_ZENITH_ANGLE': '4.6016561116873',
-                'NBAR_SOLAR_ZENITH': '31.7503071022442',
-                'PROCESSING_DATETIME': '2022-01-31T21:54:26',
-                'PRODUCT_ID': 'dswx_hls', 'PRODUCT_SOURCE': 'HLS',
-                'PRODUCT_TYPE': 'DSWx', 'PRODUCT_VERSION': '0.1',
-                'PROJECT': 'OPERA', 'WORLDCOVER_FILE': 'worldcover.tif',
-                'SENSING_TIME': '2021-09-05T14:31:56.9300799Z; 2021-09-05T14:32:20.8126470Z',
-                'SENSOR': 'MSI',
-                'SENSOR_PRODUCT_ID': 'S2A_MSIL1C_20210907T163901_N0301_R126_T15SXR_20210907T202434.SAFE',
-                'SPACECRAFT_NAME': 'SENTINEL-2A', 'SPATIAL_COVERAGE': '99'
-            }
+            return deepcopy(self.dummy_metadata)
 
     @staticmethod
     def Open(filename):


### PR DESCRIPTION
This branch fixes an issue where multiple timestamps concatenated with a plus sign assigned to the `SENSING_TIME` field of DSWx-HLS metadata were propagated to the ISO metadata, resulting in validation errors.

Logic has been added to the method that collects DSWx product metadata to detect sensing time fields containing a "+", and simply parse out the first timestamp for use as the begin/end value.