### PR TITLE
Landsat-9 Metadata Correction

### DIFF
--- a/src/opera/util/error_codes.py
+++ b/src/opera/util/error_codes.py
@@ -65,6 +65,7 @@ class ErrorCode(IntEnum):
     RENDERING_ISO_METADATA = auto()
     CLOSING_LOG_FILE = auto()
     LOGGED_INFO_LINE = auto()
+    UPDATING_PRODUCT_METADATA = auto()
 
     # Debug - 1000 – 1999
     CONFIGURATION_DETAILS = DEBUG_RANGE_START

--- a/src/opera/util/metadata_utils.py
+++ b/src/opera/util/metadata_utils.py
@@ -97,9 +97,10 @@ def get_sensor_from_spacecraft_name(spacecraft_name):
     try:
         return {
             'LANDSAT-8': 'L8',
+            'LANDSAT-9': 'L9',
             'SENTINEL-2A': 'S2A',
             'SENTINEL-2B': 'S2B'
-        }[spacecraft_name]
+        }[spacecraft_name.upper()]
     except KeyError:
         raise RuntimeError(f"Unknown spacecraft name '{spacecraft_name}'")
 


### PR DESCRIPTION
This branch adds a step to the post-processor of the DSWx-HLS PGE to perform a correction to output product metadata for DSWx products based on Landsat-9 HLS inputs. Certain HLS products have been observed to be based on Landsat-9 data (based on sensor product ID), but erroneously specify Landsat-8 as the spacecraft name. In addition, this branch also adds the "L9" shortname for use when renaming products that have been corrected to specify Landsat-9 as the originating spacecraft.