### PR TITLE
RTC-S1 Stub Implementation

### DIFF
--- a/.ci/docker/Dockerfile_rtc_s1
+++ b/.ci/docker/Dockerfile_rtc_s1
@@ -1,0 +1,60 @@
+# Dockerfile to produce the production RTC-S1 PGE Docker image for OPERA
+# Author: Scott Collins
+
+# Default SAS image path, must be provided by the docker build call via --build-arg
+ARG SAS_IMAGE
+FROM $SAS_IMAGE
+
+ARG PGE_SOURCE_DIR
+ARG PGE_DEST_DIR=/home/rtc_user
+ARG CONDA_ROOT=/home/rtc_user/miniconda3
+
+ENV PGE_DEST_DIR=$PGE_DEST_DIR
+ENV CONDA_ROOT=$CONDA_ROOT
+
+ARG BUILD_DATE_TIME
+ARG BUILD_VERSION
+
+# labels
+# the label-schema convention: http://label-schema.org/rc1/
+LABEL org.label-schema.build-date=${BUILD_DATE_TIME} \
+  org.label-schema.version=${BUILD_VERSION} \
+  org.label-schema.license="Copyright 2022,\
+ by the California Institute of Technology.\
+ ALL RIGHTS RESERVED.\
+ United States Government sponsorship acknowledged.\
+ Any commercial use must be negotiated with the Office of Technology Transfer\
+ at the California Institute of Technology.\
+ This software may be subject to U.S. export control laws and regulations.\
+ By accepting this document, the user agrees to comply with all applicable\
+ U.S. export laws and regulations. User has the responsibility to obtain\
+ export licenses, or other export authority as may be required, before\
+ exporting such information to foreign countries or providing access to\
+ foreign persons." \
+  org.label-schema.name="OPERA Product Generation Executable (PGE) Image" \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.vendor="California Institute of Technology" \
+  maintainer="California Institute of Technology"
+
+# Copy the OPERA PGE software into the container
+# the base container has a default user "rtc_user" with UID/GID 1000/1000
+COPY --chown=rtc_user:rtc_user ${PGE_SOURCE_DIR} ${PGE_DEST_DIR}
+
+# Switch to root for installing into Conda Env
+USER 0:0
+
+# Install dependencies into existing Conda Env
+RUN set -ex \
+    && cd ${PGE_DEST_DIR} \
+    && mkdir -p ${CONDA_ROOT}/bin \
+    && cp ${PGE_DEST_DIR}/opera/scripts/*_entrypoint.sh ${CONDA_ROOT}/bin \
+    && chmod +x ${CONDA_ROOT}/bin/*_entrypoint.sh \
+    && . ${CONDA_ROOT}/bin/activate root \
+    && conda install --yes --channel conda-forge --file ${PGE_DEST_DIR}/opera/requirements.txt
+
+# Set the Docker entrypoint and clear the default command \
+ENTRYPOINT ["sh", "-c", "exec ${CONDA_ROOT}/bin/pge_docker_entrypoint.sh  \"${@}\"", "--"]
+CMD []
+
+# Set the user/group back to the default
+USER rtc_user:rtc_user

--- a/.ci/scripts/build_all_images.sh
+++ b/.ci/scripts/build_all_images.sh
@@ -30,6 +30,7 @@ fi
 BUILD_SCRIPTS_DIR=${WORKSPACE}/.ci/scripts
 ${BUILD_SCRIPTS_DIR}/build_dswx_hls.sh --tag ${TAG} --workspace ${WORKSPACE}
 ${BUILD_SCRIPTS_DIR}/build_cslc_s1.sh --tag ${TAG} --workspace ${WORKSPACE}
+${BUILD_SCRIPTS_DIR}/build_rtc_s1.sh --tag ${TAG} --workspace ${WORKSPACE}
 
 echo 'Build Complete'
 

--- a/.ci/scripts/build_cslc_s1.sh
+++ b/.ci/scripts/build_cslc_s1.sh
@@ -1,39 +1,13 @@
 #!/bin/bash
 set -e
 
+# Source the build script utility functions
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+. "${SCRIPT_DIR}"/util.sh
+
 # Parse args
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    -h|--help)
-      echo "Usage: build_cslc_s1.sh [-h|--help] [-s|--sas-image <image name>] [-t|--tag <tag>] [-w|--workspace <path>]"
-      exit 0
-      ;;
-    -s|--sas-image)
-      SAS_IMAGE=$2
-      shift
-      shift
-      ;;
-    -t|--tag)
-      TAG=$2
-      shift
-      shift
-      ;;
-    -w|--workspace)
-      WORKSPACE=$2
-      shift
-      shift
-      ;;
-    -*|--*)
-      echo "Unknown arguments $1 $2, ignoring..."
-      shift
-      shift
-      ;;
-    *)
-      echo "Unknown argument $1, ignoring..."
-      shift
-      ;;
-  esac
-done
+parse_build_args "$@"
 
 echo '
 =====================================
@@ -80,38 +54,7 @@ trap cleanup EXIT
 # Copy files to the staging area and build the PGE docker image
 mkdir -p ${STAGING_DIR}/opera/pge
 
-cp ${WORKSPACE}/src/opera/__init__.py \
-   ${STAGING_DIR}/opera/
-
-cp ${WORKSPACE}/src/opera/_package.py \
-   ${STAGING_DIR}/opera/
-
-cp ${WORKSPACE}/src/opera/pge/__init__.py \
-   ${STAGING_DIR}/opera/pge/
-
-cp -r ${WORKSPACE}/src/opera/pge/base \
-      ${STAGING_DIR}/opera/pge/
-
-cp -r ${WORKSPACE}/src/opera/pge/${PGE_NAME} \
-      ${STAGING_DIR}/opera/pge/
-
-cp -r ${WORKSPACE}/src/opera/scripts \
-      ${STAGING_DIR}/opera/
-
-cp -r ${WORKSPACE}/src/opera/util \
-      ${STAGING_DIR}/opera/
-
-cp ${WORKSPACE}/COPYING \
-   ${STAGING_DIR}/opera
-
-cp ${WORKSPACE}/requirements.txt \
-   ${STAGING_DIR}/opera
-
-cp ${WORKSPACE}/.flake8 \
-   ${STAGING_DIR}/opera
-
-cp ${WORKSPACE}/.pylintrc \
-   ${STAGING_DIR}/opera
+copy_pge_files $WORKSPACE $STAGING_DIR $PGE_NAME
 
 # Create a VERSION file in the staging area to track version and build time
 printf "pge_version: ${TAG}\npge_build_datetime: ${BUILD_DATE_TIME}\n" \

--- a/.ci/scripts/build_dswx_hls.sh
+++ b/.ci/scripts/build_dswx_hls.sh
@@ -1,39 +1,13 @@
 #!/bin/bash
 set -e
 
+# Source the build script utility functions
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+. "${SCRIPT_DIR}"/util.sh
+
 # Parse args
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    -h|--help)
-      echo "Usage: build_dswx_hls.sh [-h|--help] [-s|--sas-image <image name>] [-t|--tag <tag>] [-w|--workspace <path>]"
-      exit 0
-      ;;
-    -s|--sas-image)
-      SAS_IMAGE=$2
-      shift
-      shift
-      ;;
-    -t|--tag)
-      TAG=$2
-      shift
-      shift
-      ;;
-    -w|--workspace)
-      WORKSPACE=$2
-      shift
-      shift
-      ;;
-    -*|--*)
-      echo "Unknown arguments $1 $2, ignoring..."
-      shift
-      shift
-      ;;
-    *)
-      echo "Unknown argument $1, ignoring..."
-      shift
-      ;;
-  esac
-done
+parse_build_args "$@"
 
 echo '
 =====================================
@@ -80,38 +54,7 @@ trap cleanup EXIT
 # Copy files to the staging area and build the PGE docker image
 mkdir -p ${STAGING_DIR}/opera/pge
 
-cp ${WORKSPACE}/src/opera/__init__.py \
-   ${STAGING_DIR}/opera/
-
-cp ${WORKSPACE}/src/opera/_package.py \
-   ${STAGING_DIR}/opera/
-
-cp ${WORKSPACE}/src/opera/pge/__init__.py \
-   ${STAGING_DIR}/opera/pge/
-
-cp -r ${WORKSPACE}/src/opera/pge/base \
-      ${STAGING_DIR}/opera/pge/
-
-cp -r ${WORKSPACE}/src/opera/pge/${PGE_NAME} \
-      ${STAGING_DIR}/opera/pge/
-
-cp -r ${WORKSPACE}/src/opera/scripts \
-      ${STAGING_DIR}/opera/
-
-cp -r ${WORKSPACE}/src/opera/util \
-      ${STAGING_DIR}/opera/
-
-cp ${WORKSPACE}/COPYING \
-   ${STAGING_DIR}/opera
-
-cp ${WORKSPACE}/requirements.txt \
-   ${STAGING_DIR}/opera
-
-cp ${WORKSPACE}/.flake8 \
-   ${STAGING_DIR}/opera
-
-cp ${WORKSPACE}/.pylintrc \
-   ${STAGING_DIR}/opera
+copy_pge_files $WORKSPACE $STAGING_DIR $PGE_NAME
 
 # Create a VERSION file in the staging area to track version and build time
 printf "pge_version: ${TAG}\npge_build_datetime: ${BUILD_DATE_TIME}\n" \

--- a/.ci/scripts/build_rtc_s1.sh
+++ b/.ci/scripts/build_rtc_s1.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+# Source the build script utility functions
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+. "${SCRIPT_DIR}"/util.sh
+
+# Parse args
+parse_build_args "$@"
+
+echo '
+=====================================
+
+Building RTC-S1 PGE docker image...
+
+=====================================
+'
+
+PGE_NAME="rtc_s1"
+IMAGE="opera_pge/${PGE_NAME}"
+BUILD_DATE_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+# defaults, SAS image should be updated as necessary for new image releases from ADT
+[ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath $(dirname $(realpath $0))/../..)
+[ -z "${TAG}" ] && TAG="${USER}-dev"
+[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/rtc:interface_0.1"
+
+echo "WORKSPACE: $WORKSPACE"
+echo "IMAGE: $IMAGE"
+echo "TAG: $TAG"
+echo "SAS_IMAGE: $SAS_IMAGE"
+
+# Check that the .ci scripts directory exists
+if [ ! -d "${WORKSPACE}/.ci" ]; then
+  echo "Error: the .ci directory doesn't exist at ${WORKSPACE}/.ci"
+  exit 1
+fi
+
+# Create a directory on the host to use as a staging area for files to be
+# copied into the resulting Docker image.
+STAGING_DIR=$(mktemp -d -p ${WORKSPACE} docker_image_staging_XXXXXXXXXX)
+
+# Configure a trap to clean up on exit regardless of whether the build succeeds
+trap build_script_cleanup EXIT
+
+# Copy files to the staging area and build the PGE docker image
+mkdir -p ${STAGING_DIR}/opera/pge
+
+copy_pge_files $WORKSPACE $STAGING_DIR $PGE_NAME
+
+# Create a VERSION file in the staging area to track version and build time
+printf "pge_version: ${TAG}\npge_build_datetime: ${BUILD_DATE_TIME}\n" \
+    > ${STAGING_DIR}/opera/VERSION \
+
+# Remove the old Docker image, if it exists
+EXISTING_IMAGE_ID=$(docker images -q ${IMAGE}:${TAG})
+if [[ -n ${EXISTING_IMAGE_ID} ]]; then
+  docker rmi ${EXISTING_IMAGE_ID}
+fi
+
+# Build the PGE docker image
+docker build --rm --force-rm -t ${IMAGE}:${TAG} \
+    --build-arg SAS_IMAGE=${SAS_IMAGE} \
+    --build-arg BUILD_DATE_TIME=${BUILD_DATE_TIME} \
+    --build-arg BUILD_VERSION=${TAG} \
+    --build-arg PGE_SOURCE_DIR=$(basename ${STAGING_DIR}) \
+    --file ${WORKSPACE}/.ci/docker/Dockerfile_${PGE_NAME} ${WORKSPACE}
+
+echo "RTC-S1 PGE Docker image build complete"
+
+exit 0

--- a/.ci/scripts/test_all_images.sh
+++ b/.ci/scripts/test_all_images.sh
@@ -30,6 +30,7 @@ fi
 BUILD_SCRIPTS_DIR=${WORKSPACE}/.ci/scripts
 ${BUILD_SCRIPTS_DIR}/test_dswx_hls.sh --tag ${TAG} --workspace ${WORKSPACE}
 ${BUILD_SCRIPTS_DIR}/test_cslc_s1.sh --tag ${TAG} --workspace ${WORKSPACE}
+${BUILD_SCRIPTS_DIR}/test_rtc_s1.sh --tag ${TAG} --workspace ${WORKSPACE}
 
 echo 'Build Complete'
 

--- a/.ci/scripts/test_cslc_s1.sh
+++ b/.ci/scripts/test_cslc_s1.sh
@@ -1,37 +1,15 @@
 #!/bin/bash
-# Script to execute tests on OPERA CSLC-S1 PGE Docker image
-#
+# Script to execute unit tests on the OPERA CSLC-S1 PGE Docker image
 
 set -e
 
+# Source the build script utility functions
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+. "${SCRIPT_DIR}"/util.sh
+
 # Parse args
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    -h|--help)
-      echo "Usage: test_cslc_s1.sh [-h|--help] [-t|--tag <tag>] [-w|--workspace <path>]"
-      exit 0
-      ;;
-    -t|--tag)
-      TAG=$2
-      shift
-      shift
-      ;;
-    -w|--workspace)
-      WORKSPACE=$2
-      shift
-      shift
-      ;;
-    -*|--*)
-      echo "Unknown arguments $1 $2, ignoring..."
-      shift
-      shift
-      ;;
-    *)
-      echo "Unknown argument $1, ignoring..."
-      shift
-      ;;
-  esac
-done
+parse_build_args "$@"
 
 echo '
 =====================================

--- a/.ci/scripts/test_dswx_hls.sh
+++ b/.ci/scripts/test_dswx_hls.sh
@@ -1,37 +1,15 @@
 #!/bin/bash
-# Script to execute tests on OPERA DSWx-HLS PGE Docker image
-#
+# Script to execute unit tests on the OPERA DSWx-HLS PGE Docker image
 
 set -e
 
+# Source the build script utility functions
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+. "${SCRIPT_DIR}"/util.sh
+
 # Parse args
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    -h|--help)
-      echo "Usage: test_dswx_hls.sh [-h|--help] [-t|--tag <tag>] [-w|--workspace <path>]"
-      exit 0
-      ;;
-    -t|--tag)
-      TAG=$2
-      shift
-      shift
-      ;;
-    -w|--workspace)
-      WORKSPACE=$2
-      shift
-      shift
-      ;;
-    -*|--*)
-      echo "Unknown arguments $1 $2, ignoring..."
-      shift
-      shift
-      ;;
-    *)
-      echo "Unknown argument $1, ignoring..."
-      shift
-      ;;
-  esac
-done
+parse_build_args "$@"
 
 echo '
 =====================================

--- a/.ci/scripts/test_rtc_s1.sh
+++ b/.ci/scripts/test_rtc_s1.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Script to execute unit tests on the OPERA RTC-S1 PGE Docker image
+
+set -e
+
+# Source the build script utility functions
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+. "${SCRIPT_DIR}"/util.sh
+
+# Parse args
+parse_build_args "$@"
+
+echo '
+=====================================
+
+Testing RTC-S1 PGE Docker image...
+
+=====================================
+'
+
+PGE_NAME="rtc_s1"
+IMAGE="opera_pge/${PGE_NAME}"
+TEST_RESULTS_REL_DIR="test_results"
+CONTAINER_HOME="/home/rtc_user"
+CONDA_ROOT="/home/rtc_user/miniconda3"
+
+# defaults
+[ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath $(dirname $(realpath $0))/../..)
+[ -z "${TAG}" ] && TAG="${USER}-dev"
+
+TEST_RESULTS_DIR="${WORKSPACE}/${TEST_RESULTS_REL_DIR}/${PGE_NAME}"
+
+echo "Test results output directory: ${TEST_RESULTS_DIR}"
+mkdir --parents ${TEST_RESULTS_DIR}
+chmod -R 775 ${WORKSPACE}/${TEST_RESULTS_REL_DIR}
+
+# Use the environment of the docker image to run linting, tests, etc...
+# Note the change of working directory (-w) to a directory without
+# Python code so that import statements favor Python code found in the
+# Docker image rather than code found on the host.
+DOCKER_RUN="docker run --rm \
+    -v ${WORKSPACE}:/workspace \
+    -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
+    -w /workspace/${TEST_RESULTS_REL_DIR} \
+    -u ${UID}:$(id -g) \
+    --entrypoint ${CONDA_ROOT}/bin/pge_tests_entrypoint.sh \
+    ${IMAGE}:${TAG}"
+
+# Configure a trap to set permissions on exit regardless of whether the testing succeeds
+function set_perms {
+    # Open up permissions on all test results so we can be sure the CI system can
+    # delete them after results are archived within Jenkins
+    ${DOCKER_RUN} bash -c "find \
+        /workspace/${TEST_RESULTS_REL_DIR} -type d -exec chmod 775 {} +"
+
+    ${DOCKER_RUN} bash -c "find \
+        /workspace/${TEST_RESULTS_REL_DIR} -type f -exec chmod 664 {} +"
+}
+
+trap set_perms EXIT
+
+# linting and pep8 style check (configured by .flake8 and .pylintrc)
+${DOCKER_RUN} flake8 \
+    --config ${CONTAINER_HOME}/opera/.flake8 \
+    --jobs auto \
+    --exit-zero \
+    --application-import-names opera \
+    --output-file /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/flake8.log \
+    ${CONTAINER_HOME}/opera
+
+${DOCKER_RUN} pylint \
+    --rcfile=${CONTAINER_HOME}/opera/.pylintrc \
+    --jobs 0 \
+    --exit-zero \
+    --output=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pylint.log \
+    --enable-all-extensions \
+    ${CONTAINER_HOME}/opera
+
+# pytest (including code coverage)
+${DOCKER_RUN} bash -c "pytest \
+    --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
+    --cov=${CONTAINER_HOME}/opera/pge/base \
+    --cov=${CONTAINER_HOME}/opera/pge/${PGE_NAME} \
+    --cov=${CONTAINER_HOME}/opera/scripts \
+    --cov=${CONTAINER_HOME}/opera/util \
+    --cov-report=term \
+    --cov-report=html:/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/coverage_html \
+    /workspace/src/opera/test/pge/base \
+    /workspace/src/opera/test/pge/${PGE_NAME} \
+    /workspace/src/opera/test/scripts \
+    /workspace/src/opera/test/util > /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest.log 2>&1"
+
+echo "RTC-S1 PGE Docker image test complete"
+
+exit 0

--- a/.ci/scripts/util.sh
+++ b/.ci/scripts/util.sh
@@ -2,6 +2,119 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
+parse_build_args()
+{
+  while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help)
+      echo "Usage: $(basename $0) [-h|--help] [-s|--sas-image <image name>] [-t|--tag <tag>] [-w|--workspace <path>]"
+      exit 0
+      ;;
+    -s|--sas-image)
+      SAS_IMAGE=$2
+      shift
+      shift
+      ;;
+    -t|--tag)
+      TAG=$2
+      shift
+      shift
+      ;;
+    -w|--workspace)
+      WORKSPACE=$2
+      shift
+      shift
+      ;;
+    -*|--*)
+      echo "Unknown arguments $1 $2, ignoring..."
+      shift
+      shift
+      ;;
+    *)
+      echo "Unknown argument $1, ignoring..."
+      shift
+      ;;
+  esac
+  done
+}
+
+parse_test_args()
+{
+  while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help)
+      echo "Usage: $(basename $0) [-h|--help] [-t|--tag <tag>] [-w|--workspace <path>]"
+      exit 0
+      ;;
+    -t|--tag)
+      TAG=$2
+      shift
+      shift
+      ;;
+    -w|--workspace)
+      WORKSPACE=$2
+      shift
+      shift
+      ;;
+    -*|--*)
+      echo "Unknown arguments $1 $2, ignoring..."
+      shift
+      shift
+      ;;
+    *)
+      echo "Unknown argument $1, ignoring..."
+      shift
+      ;;
+  esac
+  done
+}
+
+build_script_cleanup() {
+  if [[ -z ${KEEP_TEMP_FILES} ]]; then
+    echo "Cleaning up staging directory ${STAGING_DIR}..."
+    rm -rf ${STAGING_DIR}
+  fi
+}
+
+copy_pge_files() {
+  WORKSPACE=$1
+  STAGING_DIR=$2
+  PGE_NAME=$3
+
+  cp ${WORKSPACE}/src/opera/__init__.py \
+   ${STAGING_DIR}/opera/
+
+  cp ${WORKSPACE}/src/opera/_package.py \
+     ${STAGING_DIR}/opera/
+
+  cp ${WORKSPACE}/src/opera/pge/__init__.py \
+     ${STAGING_DIR}/opera/pge/
+
+  cp -r ${WORKSPACE}/src/opera/pge/base \
+        ${STAGING_DIR}/opera/pge/
+
+  cp -r ${WORKSPACE}/src/opera/pge/${PGE_NAME} \
+        ${STAGING_DIR}/opera/pge/
+
+  cp -r ${WORKSPACE}/src/opera/scripts \
+        ${STAGING_DIR}/opera/
+
+  cp -r ${WORKSPACE}/src/opera/util \
+        ${STAGING_DIR}/opera/
+
+  cp ${WORKSPACE}/COPYING \
+     ${STAGING_DIR}/opera
+
+  cp ${WORKSPACE}/requirements.txt \
+     ${STAGING_DIR}/opera
+
+  cp ${WORKSPACE}/.flake8 \
+     ${STAGING_DIR}/opera
+
+  cp ${WORKSPACE}/.pylintrc \
+     ${STAGING_DIR}/opera
+}
+
 # Start the metrics collection of both docker stats and the miscellaneous os statistics.
 # Parameters:
 #     pge:  pge we are working on

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+
+"""
+=============
+rtc_s1_pge.py
+=============
+
+Module defining the implementation for the Radiometric Terrain Corrected (RTC)
+from Sentinel-1 A/B (S1) PGE.
+
+"""
+
+import os.path
+from pathlib import Path
+
+from opera.pge.base.base_pge import PgeExecutor
+from opera.pge.base.base_pge import PostProcessorMixin
+from opera.pge.base.base_pge import PreProcessorMixin
+from opera.util.time import get_time_for_filename
+
+
+class RtcS1PreProcessorMixin(PreProcessorMixin):
+    """
+    Mixin class responsible for handling all pre-processing steps for the RTC-S1
+    PGE. The pre-processing phase is defined as all steps necessary prior to
+    SAS execution.
+
+    In addition to the base functionality inherited from PreProcessorMixin, this
+    mixin adds an input validation step to ensure that input(s) defined by the
+    RunConfig exist and are valid (TODO).
+
+    """
+
+    _pre_mixin_name = "RtcS1PreProcessorMixin"
+
+    def run_preprocessor(self, **kwargs):
+        """
+        Executes the pre-processing steps for RTC-S1 PGE initialization.
+
+        The RtcS1PreProcessorMixin version of this class performs all actions of
+        the base PreProcessorMixin class, and adds an input validation step for
+        the inputs defined within the RunConfig. (TODO)
+
+        Parameters
+        ----------
+        **kwargs: dict
+            Any keyword arguments needed by the pre-processor
+
+        """
+        super().run_preprocessor(**kwargs)
+
+        # TODO: call input validation routine here
+
+
+class RtcS1PostProcessorMixin(PostProcessorMixin):
+    """
+    Mixin class responsible for handling all post-processing steps for the RTC-S1
+    PGE. The post-processing phase is defined as all steps required after SAS
+    execution has completed, prior to handover of output products to PCM.
+
+    In addition to the base functionality inherited from PostProcessorMixin, this
+    mixin adds an output validation step to ensure that the output file(s) defined
+    by the RunConfig exist and are valid. (TODO)
+
+    """
+
+    _post_mixin_name = "RtcS1PostProcessorMixin"
+    _cached_core_filename = None
+
+    def _core_filename(self, inter_filename=None):
+        """
+        Returns the core file name component for products produced by the
+        RTC-S1 PGE.
+
+        The core file name component for RTC-S1 products consists of:
+
+        <PROJECT>_<LEVEL>_<PGE NAME>_<SOURCE>_{burst_id}_{acquisition_time}_{production_time}_<SENSOR>_<SPACING>_<PRODUCT VERSION>
+
+        Where {burst_id}, {acquisition_time} and {production_time} are literal
+        format-string placeholders and are NOT filled in by this method.
+        Callers are responsible for assignment of these fields product-specific
+        fields via a format() call.
+
+        Notes
+        -----
+        On first call to this function, the returned core filename is cached
+        for subsequent calls. This allows the core filename to be easily reused
+        across product types without needing to provide inter_filename for
+        each subsequent call.
+
+        Parameters
+        ----------
+        inter_filename : str, optional
+            The intermediate filename of the output product to generate the
+            core filename for. This parameter may be used to inspect the file
+            in order to derive any necessary components of the returned filename.
+            Once the core filename is cached upon first call to this function,
+            this parameter may be omitted.
+
+        Returns
+        -------
+        core_filename : str
+            The core file name component to assign to products created by this PGE.
+
+        """
+        # Check if the core filename has already been generated and cached,
+        # and return it if so
+        if self._cached_core_filename is not None:
+            return self._cached_core_filename
+
+        product_version = self.runconfig.product_version
+
+        if not product_version.startswith('v'):
+            product_version = f'v{product_version}'
+
+        # Assign the core file to the cached class attribute
+        self._cached_core_filename = (
+            f"{self.PROJECT}_{self.LEVEL}_{self.NAME}_{self.SOURCE}_"
+            "{burst_id}_{acquisition_time}Z_{production_time}Z_"  # To be filled in per-product
+            f"{self.SENSOR}_{self.SPACING}_{product_version}"
+        )
+
+        return self._cached_core_filename
+
+    def _rtc_filename(self, inter_filename):
+        """
+        Returns the file name to use for RTC products produced by this PGE.
+
+        The filename for the RTC PGE consists of:
+
+            <Core filename>.<ext>
+
+        Where <Core filename> is returned by RtcS1PostProcessorMixin._core_filename()
+        and <ext> is the file extension carried over from inter_filename
+
+        Parameters
+        ----------
+        inter_filename : str
+            The intermediate filename of the output product to generate
+            a filename for. This parameter may be used to inspect the file
+            in order to derive any necessary components of the returned filename.
+
+        Returns
+        -------
+        rtc_filename : str
+            The file name to assign to RTC product(s) created by this PGE.
+
+        """
+        core_filename = self._core_filename(inter_filename)
+
+        # Each RTC product is stored in a directory named for the corresponding burst ID
+        burst_id = Path(os.path.dirname(inter_filename)).parts[-1]
+
+        ext = os.path.splitext(inter_filename)[-1]
+
+        # TODO: this will come from product metadata eventually
+        production_time = get_time_for_filename(self.production_datetime)
+
+        # TODO: this needs to be parsed from input SAFE file
+        acquisition_time = production_time
+
+        rtc_filename = core_filename.format(
+            burst_id=burst_id,
+            acquisition_time=acquisition_time,
+            production_time=production_time
+        ) + ext
+
+        return rtc_filename
+
+    def _ancillary_filename(self):
+        """
+        Helper method to derive the core component of the file names for
+        the ancillary products associated to a PGE job (catalog metadata, log
+        file, etc...).
+
+        The core file name component for RTC-S1 ancillary products consists of:
+
+        <PROJECT>_<LEVEL>_<PGE NAME>_<SOURCE>_<PRODUCTION TIME>_<SENSOR>_<SPACING>_<PRODUCT VERSION>
+
+        Since these files are not specific to any particular burst processed
+        for an RTC job, fields such as burst ID and acquisition time are omitted
+        from this file pattern.
+
+        Returns
+        -------
+        ancillary_filename : str
+            The file name component to assign to ancillary products created by this PGE.
+
+        """
+        production_time = get_time_for_filename(self.production_datetime)
+        product_version = self.runconfig.product_version
+
+        if not product_version.startswith('v'):
+            product_version = f'v{product_version}'
+
+        ancillary_filename = (
+            f"{self.PROJECT}_{self.LEVEL}_{self.NAME}_{self.SOURCE}_"
+            f"{production_time}Z_{self.SENSOR}_{self.SPACING}_{product_version}"
+        )
+
+        return ancillary_filename
+
+    def _catalog_metadata_filename(self):
+        """
+        Returns the file name to use for Catalog Metadata produced by the RTC-S1 PGE.
+
+        The Catalog Metadata file name for the RTC-S1 PGE consists of:
+
+            <Ancillary filename>.catalog.json
+
+        Where <Ancillary filename> is returned by RtcS1PostProcessorMixin._ancillary_filename()
+
+        Returns
+        -------
+        catalog_metadata_filename : str
+            The file name to assign to the Catalog Metadata product created by this PGE.
+
+        """
+        return self._ancillary_filename() + ".catalog.json"
+
+    def _iso_metadata_filename(self):
+        """
+        Returns the file name to use for ISO Metadata produced by the RTC-S1 PGE.
+
+        The ISO Metadata file name for the RTC-S1 PGE consists of:
+
+            <Ancillary filename>.iso.xml
+
+        Where <Ancillary filename> is returned by RtcS1PostProcessorMixin._ancillary_filename()
+
+        Returns
+        -------
+        iso_metadata_filename : str
+            The file name to assign to the ISO Metadata product created by this PGE.
+
+        """
+        return self._ancillary_filename() + ".iso.xml"
+
+    def _log_filename(self):
+        """
+        Returns the file name to use for the PGE/SAS log file produced by the RTC-S1 PGE.
+
+        The log file name for the RTC-S1 PGE consists of:
+
+            <Ancillary filename>.log
+
+        Where <Ancillary filename> is returned by RtcS1PostProcessorMixin._ancillary_filename()
+
+        Returns
+        -------
+        log_filename : str
+            The file name to assign to the PGE/SAS log created by this PGE.
+
+        """
+        return self._ancillary_filename() + ".log"
+
+    def _qa_log_filename(self):
+        """
+        Returns the file name to use for the Quality Assurance application log
+        file produced by the RTC-S1 PGE.
+
+        The log file name for the RTC-S1 PGE consists of:
+
+            <Ancillary filename>.qa.log
+
+        Where <Ancillary filename> is returned by RtcS1PostProcessorMixin._ancillary_filename()
+
+        Returns
+        -------
+        log_filename : str
+            The file name to assign to the QA log created by this PGE.
+
+        """
+        return self._ancillary_filename() + ".qa.log"
+
+    def run_postprocessor(self, **kwargs):
+        """
+        Executes the post-processing steps for the RTC-S1 PGE.
+
+        The RtcS1PostProcessorMixin version of this method performs the same
+        steps as the base PostProcessorMixin, but inserts a step to perform
+        output product validation prior to staging and renaming of the output
+        files. (TODO)
+
+        Parameters
+        ----------
+        **kwargs: dict
+            Any keyword arguments needed by the post-processo
+
+        """
+        super().run_postprocessor(**kwargs)
+
+        # TODO replace super().run_postprocessor() call with reimplementation
+        #      that invokes the output validation step in-between the SAS QA and
+        #      output file staging steps inherited from the base PGE
+
+
+class RtcS1Executor(RtcS1PreProcessorMixin, RtcS1PostProcessorMixin, PgeExecutor):
+    """
+    Main class for execution of the RTC-S1 PGE, including the SAS layer.
+
+    This class essentially rolls up the RTC-specific pre- and post-processor
+    functionality, while inheriting all other functionality for setup and execution
+    of the SAS from the base PgeExecutor class.
+
+    """
+
+    NAME = "RTC"
+    """Short name for the RTC-S1 PGE"""
+
+    LEVEL = "L2"
+    """Processing Level for RTC-S1 Products"""
+
+    SAS_VERSION = "0.1"  # Interface release https://github.com/opera-adt/RTC/releases/tag/v0.1
+    """Version of the SAS wrapped by this PGE, should be updated as needed"""
+
+    # TODO: these are hardcoded for now, need to determine if they will come
+    #       from product metadata
+    SOURCE = "S1"
+    SENSOR = "S1A"
+    SPACING = "30"
+
+    def __init__(self, pge_name, runconfig_path, **kwargs):
+        super().__init__(pge_name, runconfig_path, **kwargs)
+
+        self.rename_by_pattern_map = {
+            "*.nc": self._rtc_filename
+        }

--- a/src/opera/pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
+++ b/src/opera/pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
@@ -1,0 +1,177 @@
+#
+# Yamale schema for the RTC-S1 SAS Configuration
+#
+
+runconfig:
+  name: str()
+
+  groups:
+    pge_name_group:
+      pge_name: enum('RTC_S1_PGE')
+
+    input_file_group:
+      # Required. List of SAFE files (min=1)
+      safe_file_path: list(str(), min=1)
+      # Required. List of orbit (EOF) files
+      orbit_file_path: list(str(), min=1)
+      # Required. The unique burst ID to process, leave empty to process all bursts
+      burst_id : list(str(), min=1, required=False)
+
+    dynamic_ancillary_file_group:
+      # Digital Elevation Model.
+      dem_file: str(required=False)
+
+    product_path_group:
+      # Directory where PGE will place results
+      product_path: str()
+      # Directory where SAS can write temporary data
+      scratch_path: str()
+
+      # If option `mosaic_bursts` is not set, output files are saved to:
+      #     {output_dir}/{burst_id}/{product_id}{suffix}.{ext}
+      # If option `mosaic_bursts` is set, output files are saved to:
+      #     {output_dir}/{product_id}{suffix}.{ext}
+      # If the field `product_id` is left empty, the prefix "rtc_product"
+      # will be used instead.
+      # `suffix` is only used when there are multiple output files.
+      # `ext` is determined by geocoding_options.output_format.
+      output_dir: str()
+      product_id: str()
+      mosaic_bursts: bool(required=False)
+
+      # Format of output file
+      output_format: enum('HDF5', 'NETCDF', 'ENVI', 'GTiff', 'COG', required=False)
+
+    primary_executable:
+      product_type: enum('RTC_S1')
+
+    # This section includes parameters to tweak the workflow
+    processing: include('processing_options', required=False)
+
+    # Worker options (e.g. enable/disable GPU processing, select GPU device ID)
+    worker: include('worker_options', required=False)
+
+
+---
+geo2rdr_options:
+  # Convergence threshold for rdr2geo algorithm
+  threshold: num(min=0, required=False)
+  # Maximum number of iterations
+  numiter: int(min=1, required=False)
+
+# Group of processing options
+processing_options:
+  # Polarization to process, 3 modes below correspond to VV, VH, VV+VH
+  polarization: enum('co-pol', 'cross-pol', 'dual-pol', required=False)
+
+  # Options to run geo2rdr
+  geo2rdr: include('geo2rdr_options', required=False)
+  # Range split-spectrum options
+  range_split_spectrum: include('range_split_spectrum_options', required=False)
+
+  dem_interpolation_method: enum('sinc', 'bilinear', 'bicubic', 'nearest', 'biquintic', required=False)
+
+  # Apply absolute radiometric correction
+  apply_absolute_radiometric_correction: bool(required=False)
+
+  # Apply thermal noise correction
+  apply_thermal_noise_correction: bool(required=False)
+
+  # Apply RTC
+  apply_rtc: bool(required=False)
+
+  # Radiometric Terrain Correction (RTC)
+  rtc: include('rtc_options', required=False)
+
+  # Geocoding options
+  geocoding: include('geocoding_options', required=False)
+
+rtc_options:
+  # RTC output type: empty value to turn off the RTC
+  # The output_type defaults to "gamma0" if the key is absent
+  output_type: enum('gamma0', 'sigma0', required=False)
+
+  algorithm_type: enum('area_projection', 'bilinear_distribution', required=False)
+
+  input_terrain_radiometry: enum('beta0', 'sigma0', required=False)
+
+  # Minimum RTC area factor in dB
+  rtc_min_value_db: num(required=False)
+
+  # RTC DEM upsampling
+  dem_upsampling: int(min=1, required=False)
+
+
+geocoding_options:
+
+  # Algorithm type, area projection or interpolation: sinc, bilinear, bicubic, nearest, and biquintic
+  algorithm_type: enum('area_projection', 'sinc', 'bilinear', 'bicubic', 'nearest', 'biquintic', required=False)
+
+  # Memory mode
+  memory_mode: enum('auto', 'single_block', 'geogrid', 'geogrid_and_radargrid', required=False)
+
+  # Processing upsampling factor on top of the input geogrid
+  geogrid_upsampling: int(required=False)
+
+  # Save the incidence angle
+  save_incidence_angle: bool(required=False)
+
+  # Save the local-incidence angle
+  save_local_inc_angle: bool(required=False)
+
+  # Save the projection angle
+  save_projection_angle: bool(required=False)
+
+  # Save the RTC area normalization factor (ANF) computed with
+  # the projection angle method
+  save_rtc_anf_psi: bool(required=False)
+
+  # Save the range slope angle
+  save_range_slope: bool(required=False)
+
+  # Save the number of looks used to generate the RTC product
+  save_nlooks: bool(required=False)
+
+  # Save the RTC area normalization factor (ANF) used to generate
+  # the RTC product
+  save_rtc_anf: bool(required=False)
+
+  # Save the interpolated DEM used to generate the RTC product
+  save_dem: bool(required=False)
+
+  # OPTIONAL - Absolute radiometric correction
+  abs_rad_cal: num(required=False)
+
+  # Clip values above threshold
+  clip_max: num(required=False)
+
+  # Clip values below threshold
+  clip_min: num(required=False)
+
+  # Double SLC sampling in the range direction
+  upsample_radargrid: bool(required=False)
+
+  # Product EPSG code. Same as DEM if not provided
+  output_epsg: int(min=1024, max=32767, required=False)
+
+  # Product posting along X (same units as output_epsg)
+  x_posting: num(min=0, required=False)
+
+  # Product posting along Y (same units as output_epsg)
+  y_posting: num(min=0, required=False)
+
+  # Controls the product grid along X (same units as output_epsg)
+  x_snap: num(min=0, required=False)
+
+  # Controls the product grid along Y (same units as output_epsg)
+  y_snap: num(min=0, required=False)
+
+  # Top-left coordinates (same units as output_epsg)
+  top_left:
+    x: num(required=False)
+    y: num(required=False)
+
+  # Bottom-right coordinates (same units as output_epsg)
+  bottom_right:
+    x: num(required=False)
+    y: num(required=False)

--- a/src/opera/scripts/pge_main.py
+++ b/src/opera/scripts/pge_main.py
@@ -25,6 +25,7 @@ from opera.util.logger import PgeLogger, default_log_file_name
 PGE_NAME_MAP = {
     'CSLC_S1_PGE': ('opera.pge.cslc_s1.cslc_s1_pge', 'CslcS1Executor'),
     'DSWX_HLS_PGE': ('opera.pge.dswx_hls.dswx_hls_pge', 'DSWxHLSExecutor'),
+    'RTC_S1_PGE': ('opera.pge.rtc_s1.rtc_s1_pge', 'RtcS1Executor'),
     'BASE_PGE': ('opera.pge.base.base_pge', 'PgeExecutor')
 }
 """Mapping of PGE names specified by a RunConfig to the PGE module and class type to instantiate"""

--- a/src/opera/test/data/test_rtc_s1_config.yaml
+++ b/src/opera/test/data/test_rtc_s1_config.yaml
@@ -1,0 +1,176 @@
+RunConfig:
+    Name: OPERA-RTC-S1-PGE-TEST-CONFIG
+
+    Groups:
+        PGE:
+            PGENameGroup:
+                PGEName: RTC_S1_PGE
+
+            InputFilesGroup:
+                InputFilePaths:
+                    - rtc_s1_test/input_dir/SAFE.zip
+                    - rtc_s1_test/input_dir/ORBIT.EOF
+
+            DynamicAncillaryFilesGroup:
+                AncillaryFileMap:
+                    dem_file: rtc_s1_test/input_dir/dem.tif
+
+            ProductPathGroup:
+                OutputProductPath: rtc_s1_test/output_dir
+                ScratchPath: rtc_s1_test/scratch_dir
+
+            PrimaryExecutable:
+                ProductIdentifier: RTC_S1
+                ProductVersion: '1.0'
+                CompositeReleaseID: TestIdRtc
+                ProgramPath: mkdir
+                ProgramOptions:
+                    - '-p rtc_s1_test/output_dir/t069_147170_iw1/;'
+                    - '/bin/echo hello world > rtc_s1_test/output_dir/t069_147170_iw1/rtc_product.nc;'
+                    - '/bin/echo RTC-S1 invoked with RunConfig'
+                ErrorCodeBase: 300000
+                SchemaPath: pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
+                IsoTemplatePath:
+
+            QAExecutable:
+                Enabled: False
+                ProgramPath:
+                ProgramOptions: []
+
+            DebugLevelGroup:
+                DebugSwitch: False
+                ExecuteViaShell: True  # Must be set to True for test to work
+
+        SAS:
+            runconfig:
+                name: rtc_s1_workflow_default
+
+                groups:
+                    pge_name_group:
+                        pge_name: RTC_S1_PGE
+
+                    input_file_group:
+                        # Required. List of SAFE files (min=1)
+                        safe_file_path:
+                            - rtc_s1_test/input_dir/SAFE.zip
+                        # Required. List of orbit (EOF) files (min=1)
+                        orbit_file_path:
+                            - rtc_s1_test/input_dir/ORBIT.EOF
+                        # Burst to process. Empty to process all bursts
+                        burst_id:
+                            - t069_147170_iw1
+
+                    dynamic_ancillary_file_group:
+                        # Digital elevation model
+                        dem_file: rtc_s1_test/input_dir/dem.tif
+
+                    product_path_group:
+                        # Directory where PGE will place results
+                        product_path: rtc_s1_test/output_dir
+                        # Directory where SAS writes temporary data
+                        scratch_path: rtc_s1_test/scratch_dir
+                        # Intermediate file name. SAS writes the output to this file.
+                        # PGE may rename the product according to file naming convention
+                        output_dir: rtc_s1_test/output_dir
+                        product_id: rtc_product
+                        mosaic_bursts: False
+                        output_format: NETCDF
+
+                    primary_executable:
+                        product_type: RTC_S1
+
+                    processing:
+                        polarization: dual-pol
+
+                        # Apply absolute radiometric correction
+                        apply_absolute_radiometric_correction: True
+
+                        # Apply thermal noise correction
+                        apply_thermal_noise_correction: True
+
+                        # OPTIONAL - Apply RTC
+                        apply_rtc: True
+
+                        # OPTIONAL - to control behavior of RTC module
+                        # (only applicable if geocode.apply_rtc is True)
+                        rtc:
+                            # OPTIONAL - Choices:
+                            # "gamma0" (default)
+                            # "sigma0"
+                            output_type: gamma0
+
+                            # OPTIONAL - Choices:
+                            # "bilinear_distribution" (default)
+                            # "area_projection"
+                            algorithm_type: area_projection
+
+                            # OPTIONAL - Choices:
+                            # "beta0" (default)
+                            # "sigma0"
+                            input_terrain_radiometry: beta0
+
+                            # OPTIONAL - Minimum RTC area factor in dB
+                            rtc_min_value_db:
+
+                            # RTC DEM upsampling
+                            dem_upsampling: 1
+
+                        # OPTIONAL - Mechanism to specify output posting and DEM
+                        geocoding:
+                            # OPTIONAL -
+                            algorithm_type: area_projection
+
+                            # OPTIONAL - Choices: "single_block", "geogrid", "geogrid_radargrid", and "auto" (default)
+                            memory_mode: auto
+
+                            # OPTIONAL - Processing upsampling factor applied to input geogrid
+                            geogrid_upsampling: 1
+
+                            # Save the incidence angle
+                            save_incidence_angle: True
+
+                            # Save the local-incidence angle
+                            save_local_inc_angle: True
+
+                            # Save the projection angle
+                            save_projection_angle: False
+
+                            # Save the RTC ANF computed with the projection angle method
+                            save_rtc_anf_psi: False
+
+                            # Save the range slope angle
+                            save_range_slope: False
+
+                            # Save the number of looks used to compute GCOV
+                            save_nlooks: True
+
+                            # Save the RTC area factor used to compute GCOV
+                            save_rtc_anf: True
+
+                            # Save interpolated DEM used to compute GCOV
+                            save_dem: False
+
+                            # OPTIONAL - Absolute radiometric correction
+                            abs_rad_cal: 1
+
+                            # OPTIONAL - Clip values above threshold
+                            clip_max:
+
+                            # OPTIONAL - Clip values below threshold
+                            clip_min:
+
+                            # OPTIONAL - Double sampling of the radar-grid
+                            # input sampling in the range direction
+                            upsample_radargrid: False
+
+                            output_epsg:
+                            x_posting: 30
+                            y_posting: 30
+                            x_snap: 30
+                            y_snap: 30
+                            top_left:
+                                x:
+                                y:
+                            bottom_right:
+                                x:
+                                y:

--- a/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
+++ b/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+"""
+==================
+test_rtc_s1_pge.py
+==================
+
+Unit tests for the pge/rtc_s1/rtc_s1_pge.py module.
+"""
+
+import glob
+import json
+import os
+import re
+import shutil
+import tempfile
+import unittest
+from io import StringIO
+from os.path import abspath, join
+
+from pkg_resources import resource_filename
+
+from opera.pge import RunConfig
+from opera.pge.rtc_s1.rtc_s1_pge import RtcS1Executor
+from opera.util import PgeLogger
+
+
+class RtcS1PgeTestCase(unittest.TestCase):
+
+    starting_dir = None
+    working_dir = None
+    test_dir = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Set up directories and files for testing"""
+        cls.starting_dir = abspath(os.curdir)
+        cls.test_dir = resource_filename(__name__, "")
+        cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
+
+        os.chdir(cls.test_dir)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """At completion re-establish starting directory"""
+        os.chdir(cls.starting_dir)
+
+    def setUp(self) -> None:
+        """Use the temporary directory as the working directory"""
+        self.working_dir = tempfile.TemporaryDirectory(
+            prefix="test_rtc_s1_pge_", suffix="_temp", dir=os.curdir
+        )
+
+        # Create the input dir expected by the test RunConfig and add
+        # dummy input files with the names expected by the RunConfig
+        input_dir = join(self.working_dir.name, "rtc_s1_test/input_dir")
+        os.makedirs(input_dir, exist_ok=True)
+
+        os.system(f"touch {join(input_dir, 'SAFE.zip')}")
+
+        os.system(f"touch {join(input_dir, 'ORBIT.EOF')}")
+
+        os.system(f"touch {join(input_dir, 'dem.tif')}")
+
+        os.chdir(self.working_dir.name)
+
+    def tearDown(self) -> None:
+        """Return to test directory"""
+        os.chdir(self.test_dir)
+        self.working_dir.cleanup()
+
+    def test_rtc_s1_pge_execution(self):
+        """
+        Test execution of the RtcS1Executor class and its associated mixins
+        using a test RunConfig that creates dummy expected output files and
+        logs a message to be captured by PgeLogger.
+
+        """
+        runconfig_path = join(self.data_dir, 'test_rtc_s1_config.yaml')
+
+        pge = RtcS1Executor(pge_name="RtcS1PgeTest", runconfig_path=runconfig_path)
+
+        # Check that basic attributes were initialized
+        self.assertEqual(pge.name, "RTC")
+        self.assertEqual(pge.pge_name, "RtcS1PgeTest")
+        self.assertEqual(pge.runconfig_path, runconfig_path)
+
+        # Check that other objects have not been instantiated yet
+        self.assertIsNone(pge.runconfig)
+        self.assertIsNone(pge.logger)
+
+        # Kickoff execution of the RTC-S1 PGE
+        pge.run()
+
+        # Check that the runconfig and logger were instantiated
+        self.assertIsInstance(pge.runconfig, RunConfig)
+        self.assertIsInstance(pge.logger, PgeLogger)
+
+        # Check that directories were created according to RunConfig
+        self.assertTrue(os.path.isdir(pge.runconfig.output_product_path))
+        self.assertTrue(os.path.isdir(pge.runconfig.scratch_path))
+
+        # Check that an in-memory log was created
+        stream = pge.logger.get_stream_object()
+        self.assertIsInstance(stream, StringIO)
+
+        # Check that a RunConfig for the SAS was isolated within the scratch directory
+        expected_sas_config_file = join(pge.runconfig.scratch_path, 'test_rtc_s1_config_sas.yaml')
+        self.assertTrue(os.path.exists(expected_sas_config_file))
+
+        # Check that the catalog metadata file was created in the output directory
+        expected_catalog_metadata_file = join(
+            pge.runconfig.output_product_path, pge._catalog_metadata_filename()
+        )
+        self.assertTrue(os.path.exists(expected_catalog_metadata_file))
+
+        # Check that the log file was created and moved into the output directory
+        expected_log_file = pge.logger.get_file_name()
+        self.assertTrue(os.path.exists(expected_log_file))
+
+        # Lastly, check that the dummy output product(s) were created and renamed
+        expected_output_file = join(
+            pge.runconfig.output_product_path,
+            pge._rtc_filename(inter_filename='rtc_s1_test/output_dir/t069_147170_iw1/rtc_product.nc')
+        )
+        self.assertTrue(os.path.exists(expected_output_file))
+
+        # Open and read the log
+        with open(expected_log_file, 'r', encoding='utf-8') as infile:
+            log_contents = infile.read()
+
+        self.assertIn(f"RTC-S1 invoked with RunConfig {expected_sas_config_file}", log_contents)

--- a/src/opera/test/util/test_logger.py
+++ b/src/opera/test/util/test_logger.py
@@ -59,6 +59,8 @@ class LoggerTestCase(unittest.TestCase):
         cls.monotonic_regex = r'^\d*.\d*$'
         cls.logger = PgeLogger()
 
+        os.chdir(cls.test_dir)
+
     @classmethod
     def tearDownClass(cls) -> None:
         """At completion re-establish starting directory"""
@@ -73,8 +75,8 @@ class LoggerTestCase(unittest.TestCase):
         os.chdir(self.working_dir.name)
 
     def tearDown(self) -> None:
-        """Return to starting directory"""
-        os.chdir(self.starting_dir)
+        """Return to test directory"""
+        os.chdir(self.test_dir)
         self.working_dir.cleanup()
 
     def add_backframe(self, back_frames):


### PR DESCRIPTION
Initial addition of the stub implementation for the RTC-S1 PGE. 

Note that due to the specifics of how this PGE/SAS works, I also had to add a partial implementation of the file-naming conventions to ensure the PGE does not clobber the multiple per-burst outputs from the SAS.

I also took the liberty of refactoring some common code out of the build/test CI scripts into util.sh to keep things maintainable as we add more and more of these scrips.
