### PR TITLE
149 schema update

### DIFF
--- a/examples/cslc_s1_sample_runconfig-v2.0.0-er.2.0.yaml
+++ b/examples/cslc_s1_sample_runconfig-v2.0.0-er.2.0.yaml
@@ -54,6 +54,13 @@ RunConfig:
                 # this PGE
                 ProductIdentifier: CSLC_S1
 
+                # Product version specific to output products (TODO placeholder value)
+                ProductVersion: '8.8'
+
+                # Rolls up versions of all software/data used to generate versions
+                # from the data products (CRID) (TODO placeholder value)
+                CompositeReleaseID: TestIdCslc
+
                 # Path to the executable to run, path must be reachable from
                 # within the Docker container (i.e. findable with a "which" command)
                 ProgramPath: conda

--- a/examples/dswx_hls_sample_runconfig-v1.0.0-rc.4.0.yaml
+++ b/examples/dswx_hls_sample_runconfig-v1.0.0-rc.4.0.yaml
@@ -62,6 +62,13 @@ RunConfig:
                 # this PGE
                 ProductIdentifier: DSWX_HLS
 
+                # Product version specific to output products (TODO placeholder value)
+                ProductVersion: '7.7'
+
+                # Rolls up versions of all software/data used to generate versions
+                # from the data products (CRID) (TODO placeholder value)
+                CompositeReleaseID: TestIdDswx
+
                 # Path to the executable to run, path must be reachable from
                 # within the Docker container (i.e. findable with a "which" command)
                 ProgramPath: python3

--- a/src/opera/pge/base/runconfig.py
+++ b/src/opera/pge/base/runconfig.py
@@ -214,8 +214,18 @@ class RunConfig:
     # PrimaryExecutable
     @property
     def product_identifier(self) -> str:
-        """Returns the Product Identifier from a Primary Executable Category"""
+        """Returns the Product Identifier from the Primary Executable Category"""
         return self._pge_config['PrimaryExecutable']['ProductIdentifier']
+
+    @property
+    def product_version(self) -> str:
+        """Returns the Product Version from the Primary Executable Category"""
+        return self._pge_config['PrimaryExecutable']['ProductVersion']
+
+    @property
+    def composite_release_id(self) -> str:
+        """Returns the Composite Release ID (CRID) from the Primary Executable Category"""
+        return self._pge_config['PrimaryExecutable']['CompositeReleaseID']
 
     @property
     def sas_program_path(self) -> str:

--- a/src/opera/pge/base/schema/base_pge_schema.yaml
+++ b/src/opera/pge/base/schema/base_pge_schema.yaml
@@ -22,6 +22,8 @@ RunConfig:
 
       PrimaryExecutable:
         ProductIdentifier: str(required=False)
+        ProductVersion: str(required=False)
+        CompositeReleaseID: str(required=False)
         ProgramPath: str(required=True)
         ProgramOptions: list(str(), min=0, required=False)
         ErrorCodeBase: int(required=True)

--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -224,12 +224,17 @@ class CslcS1PostProcessorMixin(PostProcessorMixin):
         acquisition_time = get_time_for_filename(
             datetime.strptime(cslc_metadata['sensing_start'], '%Y-%m-%d %H:%M:%S.%f')
         )
-        product_version = self.SAS_VERSION  # TODO: may extract from cslc_metadata eventually
+
+        product_version = self.runconfig.product_version
+
+        if not product_version.startswith('v'):
+            product_version = f'v{product_version}'
+
         production_time = get_time_for_filename(self.production_datetime)
 
         self._cached_core_filename = (
             f"{self.PROJECT}_{self.LEVEL}_{self.NAME}_{sensor}_{mode}_{burst_id}_"
-            f"{pol}_{acquisition_time}Z_v{product_version}_{production_time}Z"
+            f"{pol}_{acquisition_time}Z_{product_version}_{production_time}Z"
         )
 
         return self._cached_core_filename

--- a/src/opera/pge/dswx_hls/dswx_hls_pge.py
+++ b/src/opera/pge/dswx_hls/dswx_hls_pge.py
@@ -23,7 +23,6 @@ from opera.util.error_codes import ErrorCode
 from opera.util.img_utils import get_geotiff_hls_dataset
 from opera.util.img_utils import get_geotiff_metadata
 from opera.util.img_utils import get_geotiff_processing_datetime
-from opera.util.img_utils import get_geotiff_product_version
 from opera.util.img_utils import get_geotiff_sensor_product_id
 from opera.util.img_utils import get_geotiff_spacecraft_name
 from opera.util.img_utils import get_hls_filename_fields
@@ -239,7 +238,7 @@ class DSWxHLSPostProcessorMixin(PostProcessorMixin):
         if not processing_time.endswith('Z'):
             processing_time = f'{processing_time}Z'
 
-        product_version = get_geotiff_product_version(inter_filename)
+        product_version = self.runconfig.product_version
 
         if not product_version.startswith('v'):
             product_version = f'v{product_version}'

--- a/src/opera/test/data/test_cslc_s1_config.yaml
+++ b/src/opera/test/data/test_cslc_s1_config.yaml
@@ -22,6 +22,8 @@ RunConfig:
 
             PrimaryExecutable:
                 ProductIdentifier: CSLC_S1
+                ProductVersion: '8.8'
+                CompositeReleaseID: TestIdCslc
                 ProgramPath: mkdir
                 ProgramOptions:
                     - '-p cslc_pge_test/output_dir/t64_iw2_b204/20220501/;'

--- a/src/opera/test/data/test_dswx_hls_config.yaml
+++ b/src/opera/test/data/test_dswx_hls_config.yaml
@@ -20,6 +20,8 @@ RunConfig:
 
             PrimaryExecutable:
                 ProductIdentifier: DSWX_HLS
+                ProductVersion: '7.7'
+                CompositeReleaseID: TestIdDswx
                 ProgramPath: /bin/echo
                 ProgramOptions:
                     - 'hello world > dswx_pge_test/output_dir/dswx_hls_v0.1_B01_WTR.tif;'

--- a/src/opera/test/pge/cslc_s1/test_cslc_s1_pge.py
+++ b/src/opera/test/pge/cslc_s1/test_cslc_s1_pge.py
@@ -174,7 +174,7 @@ class CslcS1PgeTestCase(unittest.TestCase):
                           rf"{cslc_metadata['platform_id']}_" \
                           rf"IW_{cslc_metadata['burst_id'].upper().replace('_', '-')}_" \
                           rf"{cslc_metadata['polarization']}_" \
-                          rf"\d{{8}}T\d{{6}}Z_v{pge.SAS_VERSION}_\d{{8}}T\d{{6}}Z.json"
+                          rf"\d{{8}}T\d{{6}}Z_v{pge.runconfig.product_version}_\d{{8}}T\d{{6}}Z.json"
 
         result = re.match(file_name_regex, file_name)
 

--- a/src/opera/test/pge/dswx_hls/test_dswx_hls_pge.py
+++ b/src/opera/test/pge/dswx_hls/test_dswx_hls_pge.py
@@ -307,7 +307,7 @@ class DSWxPgeTestCase(unittest.TestCase):
                               rf"{md['HLS_DATASET'].split('.')[2]}_" \
                               rf"\d{{8}}T\d{{6}}Z_\d{{8}}T\d{{6}}Z_" \
                               rf"{get_sensor_from_spacecraft_name(md['SPACECRAFT_NAME'])}_" \
-                              rf"30_v{md['PRODUCT_VERSION']}_" \
+                              rf"30_v{pge.runconfig.product_version}_" \
                               rf"B\d{{2}}_\w+.tiff"
             self.assertEqual(re.match(file_name_regex, file_name).group(), file_name)
 


### PR DESCRIPTION
Made the changes per ticket #149.  Slight schema change to add ProductVersion and CompositeReleaseID to base_pge_schema.yaml.
Minor changes to code and unit tests. Dummy values were added to runconfig files used for testing.  
Note: Currently we are not using or testing for CompositeReleaseID.