### PR TITLE
183 input validation

### DIFF
--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from opera.pge.base.base_pge import PgeExecutor
 from opera.pge.base.base_pge import PostProcessorMixin
 from opera.pge.base.base_pge import PreProcessorMixin
+from opera.util.input_validation import validate_slc_s1_inputs
 from opera.util.time import get_time_for_filename
 
 
@@ -27,7 +28,7 @@ class RtcS1PreProcessorMixin(PreProcessorMixin):
 
     In addition to the base functionality inherited from PreProcessorMixin, this
     mixin adds an input validation step to ensure that input(s) defined by the
-    RunConfig exist and are valid (TODO).
+    RunConfig exist and are valid.
 
     """
 
@@ -39,7 +40,7 @@ class RtcS1PreProcessorMixin(PreProcessorMixin):
 
         The RtcS1PreProcessorMixin version of this class performs all actions of
         the base PreProcessorMixin class, and adds an input validation step for
-        the inputs defined within the RunConfig. (TODO)
+        the inputs defined within the RunConfig.
 
         Parameters
         ----------
@@ -49,7 +50,7 @@ class RtcS1PreProcessorMixin(PreProcessorMixin):
         """
         super().run_preprocessor(**kwargs)
 
-        # TODO: call input validation routine here
+        validate_slc_s1_inputs(self.runconfig, self.logger, self.name)
 
 
 class RtcS1PostProcessorMixin(PostProcessorMixin):

--- a/src/opera/test/pge/cslc_s1/test_cslc_s1_pge.py
+++ b/src/opera/test/pge/cslc_s1/test_cslc_s1_pge.py
@@ -213,7 +213,7 @@ class CslcS1PgeTestCase(unittest.TestCase):
         self.assertNotIn('!Not found!', iso_metadata)
 
     def test_cslc_s1_pge_input_validation(self):
-        """Test the input validation checks made by CslcS1PreProcessorMixin."""
+        """Test the input validation checks."""
         runconfig_path = join(self.data_dir, 'test_cslc_s1_config.yaml')
 
         test_runconfig_path = join(self.data_dir, 'invalid_cslc_s1_runconfig.yaml')

--- a/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
+++ b/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
@@ -9,12 +9,15 @@ Unit tests for the pge/rtc_s1/rtc_s1_pge.py module.
 """
 
 import os
+import shutil
 import tempfile
 import unittest
 from io import StringIO
 from os.path import abspath, join
 
 from pkg_resources import resource_filename
+
+import yaml
 
 from opera.pge import RunConfig
 from opera.pge.rtc_s1.rtc_s1_pge import RtcS1Executor
@@ -127,3 +130,73 @@ class RtcS1PgeTestCase(unittest.TestCase):
             log_contents = infile.read()
 
         self.assertIn(f"RTC-S1 invoked with RunConfig {expected_sas_config_file}", log_contents)
+
+    def test_cslc_s1_pge_input_validation(self):
+        """Test the input validation checks."""
+        runconfig_path = join(self.data_dir, 'test_rtc_s1_config.yaml')
+
+        test_runconfig_path = join(self.data_dir, 'invalid_cslc_s1_runconfig.yaml')
+
+        with open(runconfig_path, 'r', encoding='utf-8') as infile:
+            runconfig_dict = yaml.safe_load(infile)
+
+        input_files_group = runconfig_dict['RunConfig']['Groups']['SAS']['runconfig']['groups']['input_file_group']
+        # Test that a non-existent file is detected by pre-processor
+        input_files_group['safe_file_path'] = ['non_existent_file.zip']
+
+        with open(test_runconfig_path, 'w', encoding='utf-8') as outfile:
+            yaml.safe_dump(runconfig_dict, outfile, sort_keys=False)
+
+        try:
+            pge = RtcS1Executor(pge_name="RtcS1PgeTest", runconfig_path=test_runconfig_path)
+
+            with self.assertRaises(RuntimeError):
+                pge.run()
+
+            # Config validation occurs before the log is fully initialized, but the
+            # initial log file should still exist and contain details of the validation
+            # error
+            expected_log_file = pge.logger.get_file_name()
+            self.assertTrue(os.path.exists(expected_log_file))
+
+            # Open the log file, and check that the validation error details were captured
+            with open(expected_log_file, 'r', encoding='utf-8') as infile:
+                log_contents = infile.read()
+
+            self.assertIn(
+                "Could not locate specified input non_existent_file.zip",
+                log_contents
+            )
+            # Reload the valid runconfig for next test
+            with open(runconfig_path, 'r', encoding='utf-8') as infile:
+                runconfig_dict = yaml.safe_load(infile)
+
+            input_files_group = runconfig_dict['RunConfig']['Groups']['SAS']['runconfig']['groups']['input_file_group']
+
+            # Test that an unexpected file extension for an existing file is caught
+            new_name = join(input_files_group['safe_file_path'][0].replace('zip', 'tar'))
+            input_files_group['safe_file_path'] = [new_name]
+
+            os.system(f"touch {new_name}")
+
+            with open(test_runconfig_path, 'w', encoding='utf-8') as outfile:
+                yaml.safe_dump(runconfig_dict, outfile, sort_keys=False)
+
+            pge = RtcS1Executor(pge_name="RtcS1PgeTest", runconfig_path=test_runconfig_path)
+
+            with self.assertRaises(RuntimeError):
+                pge.run()
+
+            expected_log_file = pge.logger.get_file_name()
+            self.assertTrue(os.path.exists(expected_log_file))
+
+            with open(expected_log_file, 'r', encoding='utf-8') as infile:
+                log_contents = infile.read()
+
+            self.assertIn(
+                f"Input file {new_name} does not have an expected file extension.",
+                log_contents
+            )
+        finally:
+            if os.path.exists(test_runconfig_path):
+                os.unlink(test_runconfig_path)

--- a/src/opera/util/input_validation.py
+++ b/src/opera/util/input_validation.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+"""
+=================
+input_validation.py
+=================
+
+Common code used by some PGEs for input validation.
+
+"""
+
+from os.path import exists, splitext
+
+from opera.util.error_codes import ErrorCode
+
+
+def _check_input(input_object, logger, name, valid_extensions):
+    """
+    Called by _validate_inputs() to check individual files.
+    The input object is checked for existence and that it ends with
+    a valid file extension.
+
+    Parameters
+    ----------
+    input_object : str
+        Relative path the object to be validated
+    logger: PgeLogger
+        Logger passed by PGE
+    name: str
+        pge name
+    valid_extensions : iterable
+        Expected file extensions of the file being validated.
+
+    """
+    if not exists(input_object):
+        error_msg = f"Could not locate specified input {input_object}."
+        logger.critical(name, ErrorCode.INPUT_NOT_FOUND, error_msg)
+
+    ext = splitext(input_object)[-1]
+
+    if ext not in valid_extensions:
+        error_msg = f"Input file {input_object} does not have an expected file extension."
+        logger.critical(name, ErrorCode.INVALID_INPUT, error_msg)
+
+
+def validate_slc_s1_inputs(runconfig, logger, name):
+    """
+    Parameters
+    ----------
+    runconfig: file
+        Runconfig file passed by the calling PGE
+    logger: PgeLogger
+        Logger passed by the calling PGE
+    name:  str
+        pge name
+
+    This function is shared by the RTC-S1 and CLSC-S1 PGEs:
+    Evaluates the list of inputs from the RunConfig to ensure they are valid.
+    There are 2 required categories defined in the 'input_file_group':
+
+        - safe_file_path: list
+            List of SAFE files (min=1)
+        - orbit_file_path : list
+            List of orbit (EOF) files (min=1)
+
+    There is also an ancillary file contained in the input_dir
+        - dem_file : str
+
+    """
+    # Retrieve the input_file_group from the run config file
+    input_file_group_dict = runconfig.sas_config['runconfig']['groups']['input_file_group']
+
+    # Retrieve the dynamic_ancillary_file_group from the run config file
+    ancillary_file_group_dict = runconfig.sas_config['runconfig']['groups']['dynamic_ancillary_file_group']
+
+    # Merge the 2 dictionaries
+    input_file_group_dict = {**input_file_group_dict, **ancillary_file_group_dict}
+    for key, value in input_file_group_dict.items():
+        if key == 'safe_file_path':
+            for i in range(len(value)):
+                _check_input(value[i], logger, name,  valid_extensions=('.zip',))
+        elif key == 'orbit_file_path':
+            for i in range(len(value)):
+                _check_input(value[i], logger, name, valid_extensions=('.EOF',))
+        elif key == 'dem_file':
+            _check_input(value, logger, name, valid_extensions=('.tif', '.tiff', '.vrt'))
+        elif key == 'burst_id':
+            # burst_id is included in the SAS input paths, but is not
+            # actually a file, so skip it
+            continue
+        else:
+            error_msg = f"Unexpected input: {key}: {value}"
+            logger.critical(name, ErrorCode.INVALID_INPUT, error_msg)


### PR DESCRIPTION
Took validation code from cslc_s1 CslcS1PreProcessorMixin.
Parameterized and wrote the code to /opera/util/input_validation.py; then added the call back into CslcS1PreProcessorMixin.
Added call: validate_inputs(self.runconfig, self.logger, self.name) to run_preprocessor() in RtcS1PreProcessorMixin

Updated units for cslc-s1 and rtc-s1.  Ended up with 93% coverage for validate_inputs.py