### PR TITLE
182 Develop utilities for NetCDF metadata extraction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 flake8
 flake8-docstrings
 flake8-import-order
+h5
 h5py
 Jinja2
 jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 flake8
 flake8-docstrings
 flake8-import-order
+h5py
 Jinja2
 jsonschema
 mgrs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flake8
 flake8-docstrings
 flake8-import-order
-h5
+hdf5
 h5py
 Jinja2
 jsonschema

--- a/src/opera/test/util/test_metadata_utils.py
+++ b/src/opera/test/util/test_metadata_utils.py
@@ -18,6 +18,7 @@ from unittest import skipIf
 from opera.util.metadata_utils import get_geographic_boundaries_from_mgrs_tile
 from opera.util.metadata_utils import get_rtc_s1_product_metadata
 
+
 def osr_is_available():
     """
     Helper function to check for a local installation of the Python bindings for

--- a/src/opera/test/util/test_metadata_utils.py
+++ b/src/opera/test/util/test_metadata_utils.py
@@ -9,11 +9,14 @@ Unit tests for the util/metadata_utils.py module.
 
 """
 
+import h5py
+import numpy as np
+import os
 import unittest
 from unittest import skipIf
 
 from opera.util.metadata_utils import get_geographic_boundaries_from_mgrs_tile
-
+from opera.util.metadata_utils import get_rtc_s1_product_metadata
 
 def osr_is_available():
     """
@@ -56,6 +59,44 @@ class MetadataUtilsTestCase(unittest.TestCase):
         """Test MGRS tile code conversion with an invalid code"""
         self.assertRaises(RuntimeError, get_geographic_boundaries_from_mgrs_tile, 'X15SXR')
 
+    def test_get_rtc_s1_product_metadata(self):
+        """Test retrieval of product metadata from HDF5 files"""
+        file_name = '/data/tmp/t_metadata_utils.hdf5'
+        with h5py.File(file_name, 'w') as f:
+
+            # create some metadata to be retrieved
+            frequencyA_grp = f.create_group("/science/CSAR/RTC/grids/frequencyA")
+            centerFrequency_dset = frequencyA_grp.create_dataset("centerFrequency", data=5405000454.33435, dtype='float64')
+            centerFrequency_dset.attrs['description'] = np.string_("Center frequency of the processed image in Hz")
+
+            orbit_grp = f.create_group("/science/CSAR/RTC/metadata/orbit")
+            orbitType_dset = orbit_grp.create_dataset("orbitType", data=b'POE')
+
+            processingInformation_inputs_grp = f.create_group("/science/CSAR/RTC/metadata/processingInformation/inputs")
+            demFiles_dset = processingInformation_inputs_grp.create_dataset("demFiles", data=np.array([b'dem.tif']))
+            auxcalFiles = np.array([b'calibration-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml',
+                                    b'noise-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml'])
+            auxcalFiles_dset = processingInformation_inputs_grp.create_dataset("auxcalFiles", data=auxcalFiles)
+
+            processingInformation_algorithms_grp = f.create_group("/science/CSAR/RTC/metadata/processingInformation/algorithms")
+            geocoding_dset = processingInformation_algorithms_grp.create_dataset("geocoding", data=b'area_projection')
+
+            identification_grp = f.create_group("/science/CSAR/identification")
+            trackNumber_dset = identification_grp.create_dataset("trackNumber", data=147170, dtype='int64')
+
+        product_output = get_rtc_s1_product_metadata(file_name)
+
+        self.assertAlmostEqual(product_output['frequencyA']['centerFrequency'], 5405000454.33435)
+        self.assertEqual(product_output['orbit']['orbitType'], "POE")
+        self.assertEqual(product_output['processingInformation']['inputs']['demFiles'], ['dem.tif'])
+        for po,eo in zip(product_output['processingInformation']['inputs']['auxcalFiles'],
+                         ['calibration-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml',
+                          'noise-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml']):
+            self.assertEqual(po, eo)
+        self.assertEqual(product_output['processingInformation']['algorithms']['geocoding'], 'area_projection')
+        self.assertEqual(product_output['identification']['trackNumber'], 147170)
+
+        os.remove(file_name)
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/opera/test/util/test_metadata_utils.py
+++ b/src/opera/test/util/test_metadata_utils.py
@@ -10,6 +10,7 @@ Unit tests for the util/metadata_utils.py module.
 """
 
 import h5py
+import tempfile
 import numpy as np
 import os
 import unittest
@@ -62,7 +63,7 @@ class MetadataUtilsTestCase(unittest.TestCase):
 
     def test_get_rtc_s1_product_metadata(self):
         """Test retrieval of product metadata from HDF5 files"""
-        file_name = '/data/tmp/t_metadata_utils.hdf5'
+        file_name = os.path.join(tempfile.gettempdir(), "test_metadata_file.hdf5")
         with h5py.File(file_name, 'w') as f:
 
             # create some metadata to be retrieved
@@ -85,19 +86,21 @@ class MetadataUtilsTestCase(unittest.TestCase):
             identification_grp = f.create_group("/science/CSAR/identification")
             trackNumber_dset = identification_grp.create_dataset("trackNumber", data=147170, dtype='int64')
 
-        product_output = get_rtc_s1_product_metadata(file_name)
+        try:
+            product_output = get_rtc_s1_product_metadata(file_name)
 
-        self.assertAlmostEqual(product_output['frequencyA']['centerFrequency'], 5405000454.33435)
-        self.assertEqual(product_output['orbit']['orbitType'], "POE")
-        self.assertEqual(product_output['processingInformation']['inputs']['demFiles'], ['dem.tif'])
-        for po,eo in zip(product_output['processingInformation']['inputs']['auxcalFiles'],
-                         ['calibration-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml',
-                          'noise-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml']):
-            self.assertEqual(po, eo)
-        self.assertEqual(product_output['processingInformation']['algorithms']['geocoding'], 'area_projection')
-        self.assertEqual(product_output['identification']['trackNumber'], 147170)
+            self.assertAlmostEqual(product_output['frequencyA']['centerFrequency'], 5405000454.33435)
+            self.assertEqual(product_output['orbit']['orbitType'], "POE")
+            self.assertEqual(product_output['processingInformation']['inputs']['demFiles'], ['dem.tif'])
+            for po,eo in zip(product_output['processingInformation']['inputs']['auxcalFiles'],
+                             ['calibration-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml',
+                              'noise-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml']):
+                self.assertEqual(po, eo)
+            self.assertEqual(product_output['processingInformation']['algorithms']['geocoding'], 'area_projection')
+            self.assertEqual(product_output['identification']['trackNumber'], 147170)
 
-        os.remove(file_name)
+        finally:
+            os.remove(file_name)
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/opera/util/metadata_utils.py
+++ b/src/opera/util/metadata_utils.py
@@ -13,6 +13,7 @@ from functools import lru_cache
 import h5py
 import numpy as np
 import mgrs
+from mgrs.core import MGRSError
 
 class MockOsr:  # pragma: no cover
     """

--- a/src/opera/util/metadata_utils.py
+++ b/src/opera/util/metadata_utils.py
@@ -225,6 +225,8 @@ def convert_h5py_group_to_dict(group_object):
     Returns HDF5 group variable data as a python dict for a given h5py group object.
     Recursively calls itself to process sub-groups.
     Group attributes are not included.
+    Byte sequences are converted to python strings which will probably cause issues
+    with non-text data.
 
     Parameters
     ----------
@@ -236,8 +238,6 @@ def convert_h5py_group_to_dict(group_object):
     converted_dict : dict
         python dict containing variable data from the group object.
         data is copied from the h5py group object to a python dict.
-        byte strings are converted python strings which will cause issues
-        with non-text data.
     """
     converted_dict = {}
     for key,val in group_object.items():

--- a/src/opera/util/metadata_utils.py
+++ b/src/opera/util/metadata_utils.py
@@ -9,9 +9,14 @@ ISO metadata utilities for use with OPERA PGEs.
 
 """
 
-import mgrs
-from mgrs.core import MGRSError
-
+from functools import lru_cache
+import h5py
+import numpy as np
+try:
+    import mgrs
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
+    # Mock implementation is not available at this time.
+    print("import mgrs failed. Module is not available in runtime environment.")
 
 class MockOsr:  # pragma: no cover
     """
@@ -187,3 +192,96 @@ def get_geographic_boundaries_from_mgrs_tile(mgrs_tile_name):
                 lon_max = lon
 
     return lat_min, lat_max, lon_min, lon_max
+
+
+@lru_cache
+def get_hdf5_group_as_dict(file_name, group_path):
+    """
+    Returns HDF5 group variable data as a python dict for a given file and group path.
+    Group attributes are not included.
+
+    Parameters
+    ----------
+    file_name : str
+        filestystem path and filename for the HDF5 file to use.
+    group_path : str
+        group path within the HDF5 file.
+
+    Returns
+    -------
+    group_dict : dict
+        python dict containing variable data from the group path location.
+    """
+    group_dict = {}
+    with h5py.File(file_name, 'r') as hf:
+        group_object = hf.get(group_path)
+        group_dict = convert_h5py_group_to_dict(group_object)
+
+    return group_dict
+
+
+def convert_h5py_group_to_dict(group_object):
+    """
+    Returns HDF5 group variable data as a python dict for a given h5py group object.
+    Recursively calls itself to process sub-groups.
+    Group attributes are not included.
+
+    Parameters
+    ----------
+    group_object : h5py._hl.group.Group
+        h5py Group object to be converted to a dict.
+
+    Returns
+    -------
+    converted_dict : dict
+        python dict containing variable data from the group object.
+        data is copied from the h5py group object to a python dict.
+        byte strings are converted python strings which will cause issues
+        with non-text data.
+    """
+    converted_dict = {}
+    for key,val in group_object.items():
+
+        if isinstance(val, h5py._hl.dataset.Dataset):
+            if type(val[()]) is np.ndarray:
+                if isinstance(val[0], bytes) or isinstance(val[0], np.bytes_):
+                    # decode bytes to str
+                    converted_dict[key] = val[()].astype(str)
+                else:
+                    converted_dict[key] = val[()]
+            else:
+                scalar_var = val[()]
+                if isinstance(scalar_var, bytes) or isinstance(scalar_var, np.bytes_):
+                    # decode bytes to str
+                    converted_dict[key] = scalar_var.decode()
+                else:
+                    converted_dict[key] = scalar_var
+        elif isinstance(val, h5py._hl.group.Group):
+            converted_dict[key] = convert_h5py_group_to_dict(val)
+
+    return converted_dict
+
+
+def get_rtc_s1_product_metadata(file_name):
+    """
+    Returns a python dict containing the RTC-S1 product_output metadata
+    which will be used with the ISO metadata template.
+
+    Parameters
+    ----------
+    file_name : the RTC-S1 product file to obtain metadata from.
+
+    Returns
+    -------
+    product_output : dict
+        python dict containing the HDF5 file metadata which is used in the
+        ISO template.
+    """
+    product_output = {
+        'frequencyA' : get_hdf5_group_as_dict(file_name, "/science/CSAR/RTC/grids/frequencyA"),
+        'processingInformation' : get_hdf5_group_as_dict(file_name, "/science/CSAR/RTC/metadata/processingInformation"),
+        'orbit' : get_hdf5_group_as_dict(file_name, "/science/CSAR/RTC/metadata/orbit"),
+        'identification' : get_hdf5_group_as_dict(file_name, "/science/CSAR/identification")
+    }
+
+    return product_output


### PR DESCRIPTION
## Description
- Implements get_rtc_s1_product_metadata() to retrieve RTC-S1 HDF5 product file metadata for use in ISO files.

## Affected Issues
- #182
- 
## Testing
- Added test_get_rtc_s1_product_metadata() to test_metadata_utils.py to validate h5py library usage.