### PR TITLE
RTC-S1 ISO Metadata Creation

### DIFF
--- a/src/opera/pge/base/base_pge.py
+++ b/src/opera/pge/base/base_pge.py
@@ -473,7 +473,7 @@ class PostProcessorMixin:
         for file_pattern, rename_function in self.rename_by_pattern_map.items():
             if fnmatch(file_name, file_pattern):
                 final_filename = rename_function(input_filepath)
-                self.renamed_files[file_name] = final_filename
+                self.renamed_files[input_filepath] = final_filename
                 break
         else:
             msg = f'No rename function configured for file "{basename(input_filepath)}", skipping assignment'

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -20,6 +20,8 @@ from opera.pge.base.base_pge import PostProcessorMixin
 from opera.pge.base.base_pge import PreProcessorMixin
 from opera.util.error_codes import ErrorCode
 from opera.util.input_validation import validate_slc_s1_inputs
+from opera.util.metadata_utils import get_rtc_s1_product_metadata
+from opera.util.render_jinja2 import render_jinja2
 from opera.util.time import get_time_for_filename
 
 
@@ -318,6 +320,131 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
 
         """
         return self._ancillary_filename() + ".qa.log"
+
+    def _collect_rtc_product_metadata(self):
+        """
+        Gathers the available metadata from a representative RTC product created by
+        the RTC-S1 SAS. This metadata is then formatted for use with filling in
+        the ISO metadata template for the RTC-S1 PGE.
+
+        Returns
+        -------
+        output_product_metadata : dict
+            Dictionary containing RTC-S1 output product metadata, formatted for
+            use with the ISO metadata Jinja2 template.
+
+        """
+        output_products = self.runconfig.get_output_product_filenames()
+
+        # TODO: will need to support GeoTIFF/COG for later versions of SAS
+        nc_product = None
+
+        for output_product in output_products:
+            if output_product.endswith('.nc'):
+                nc_product = output_product
+                break
+        else:
+            msg = (f"Could not find a NetCDF format RTC product to extract "
+                   f"metadata from within {self.runconfig.output_product_path}")
+            self.logger.critical(self.name, ErrorCode.ISO_METADATA_RENDER_FAILED, msg)
+
+        output_product_metadata = get_rtc_s1_product_metadata(nc_product)
+
+        # Fill in some additional fields expected within the ISO
+        output_product_metadata['frequencyA']['frequencyAWidth'] = len(output_product_metadata['frequencyA']['xCoordinates'])
+        output_product_metadata['frequencyA']['frequencyALength'] = len(output_product_metadata['frequencyA']['yCoordinates'])
+
+        # TODO: the following fields seems to be missing in the interface delivery products,
+        #       but are documented, remove these kludges once they are actually available
+        if 'burst_polygon' not in output_product_metadata:
+            output_product_metadata['burst_polygon'] = "POLYGON ((399015 3859970, 398975 3860000, ..., 399015 3859970))"
+
+        if 'azimuthBandwidth' not in output_product_metadata['frequencyA']:
+            output_product_metadata['frequencyA']['azimuthBandwidth'] = 12345678.9
+
+        if 'noiseCorrectionFlag' not in output_product_metadata['frequencyA']:
+            output_product_metadata['frequencyA']['noiseCorrectionFlag'] = False
+
+        if 'productVersion' not in output_product_metadata['identification']:
+            output_product_metadata['identification']['productVersion'] = '1.0'
+
+        if 'plannedDatatakeId' not in output_product_metadata['identification']:
+            output_product_metadata['identification']['plannedDatatakeId'] = ['datatake1', 'datatake2']
+
+        if 'plannedObservationId' not in output_product_metadata['identification']:
+            output_product_metadata['identification']['plannedObservationId'] = ['obs1', 'obs2']
+        # TODO: end kludges
+
+        return output_product_metadata
+
+    def _create_custom_metadata(self):
+        """
+        Creates the "custom data" dictionary used with the ISO metadata rendering.
+
+        Custom data contains all metadata information needed for the ISO template
+        that is not found within any of the other metadata sources (such as the
+        RunConfig, output product(s), or catalog metadata).
+
+        Returns
+        -------
+        custom_metadata : dict
+            Dictionary containing the custom metadata as expected by the ISO
+            metadata Jinja2 template.
+
+        """
+        custom_metadata = {
+            'ISO_OPERA_FilePackageName': self._ancillary_filename(),
+            'ISO_OPERA_ProducerGranuleId': self._ancillary_filename(),
+            'MetadataProviderAction': "creation",
+            'GranuleFilename': self._ancillary_filename(),
+            'ISO_OPERA_ProjectKeywords': ['OPERA', 'JPL', 'RTC', 'Radiometric', 'Terrain', 'Corrected'],
+            'ISO_OPERA_PlatformKeywords': ['S1'],
+            'ISO_OPERA_InstrumentKeywords': ['Sentinel 1 A/B']
+        }
+
+        return custom_metadata
+
+    def _create_iso_metadata(self):
+        """
+        Creates a rendered version of the ISO metadata template for RTC-S1
+        output products using metadata from the following locations:
+
+            * RunConfig (in dictionary form)
+            * Output products (dictionaries extracted from NetCDF format)
+            * Catalog metadata
+            * "Custom" metadata (all metadata not found anywhere else)
+
+        Returns
+        -------
+        rendered_template : str
+            The ISO metadata template for RTC-S1 filled in with values from the
+            sourced metadata dictionaries.
+
+        """
+        runconfig_dict = self.runconfig.asdict()
+
+        product_output_dict = self._collect_rtc_product_metadata()
+
+        catalog_metadata_dict = self._create_catalog_metadata().asdict()
+
+        custom_data_dict = self._create_custom_metadata()
+
+        iso_metadata = {
+            'run_config': runconfig_dict,
+            'product_output': product_output_dict,
+            'catalog_metadata': catalog_metadata_dict,
+            'custom_data': custom_data_dict
+        }
+
+        iso_template_path = os.path.abspath(self.runconfig.iso_template_path)
+
+        if not os.path.exists(iso_template_path):
+            msg = f"Could not load ISO template {iso_template_path}, file does not exist"
+            self.logger.critical(self.name, ErrorCode.ISO_METADATA_TEMPLATE_NOT_FOUND, msg)
+
+        rendered_template = render_jinja2(iso_template_path, iso_metadata, self.logger)
+
+        return rendered_template
 
     def run_postprocessor(self, **kwargs):
         """

--- a/src/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
+++ b/src/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
@@ -1151,7 +1151,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.frequencyA.radiometricTerrainCorrectedFlag }}{# ISO_OPERA_radiometricTerrainCorrectedFlag #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.frequencyA.radiometricTerrainCorrectionFlag }}{# ISO_OPERA_radiometricTerrainCorrectionFlag #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>

--- a/src/opera/test/data/test_rtc_s1_config.yaml
+++ b/src/opera/test/data/test_rtc_s1_config.yaml
@@ -26,11 +26,11 @@ RunConfig:
                 ProgramPath: mkdir
                 ProgramOptions:
                     - '-p rtc_s1_test/output_dir/t069_147170_iw1/;'
-                    - '/bin/echo hello world > rtc_s1_test/output_dir/t069_147170_iw1/rtc_product.nc;'
+                    - 'python3 -c "from opera.test.util.test_metadata_utils import create_test_rtc_nc_product; create_test_rtc_nc_product(\"rtc_s1_test/output_dir/t069_147170_iw1/rtc_product.nc\")";'
                     - '/bin/echo RTC-S1 invoked with RunConfig'
                 ErrorCodeBase: 300000
                 SchemaPath: pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
-                IsoTemplatePath:
+                IsoTemplatePath: pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
 
             QAExecutable:
                 Enabled: False

--- a/src/opera/test/data/test_rtc_s1_config.yaml
+++ b/src/opera/test/data/test_rtc_s1_config.yaml
@@ -26,7 +26,7 @@ RunConfig:
                 ProgramPath: mkdir
                 ProgramOptions:
                     - '-p rtc_s1_test/output_dir/t069_147170_iw1/;'
-                    - 'python3 -c "from opera.test.util.test_metadata_utils import create_test_rtc_nc_product; create_test_rtc_nc_product(\"rtc_s1_test/output_dir/t069_147170_iw1/rtc_product.nc\")";'
+                    - 'python3 -c "from opera.util.metadata_utils import create_test_rtc_nc_product; create_test_rtc_nc_product(\"rtc_s1_test/output_dir/t069_147170_iw1/rtc_product.nc\")";'
                     - '/bin/echo RTC-S1 invoked with RunConfig'
                 ErrorCodeBase: 300000
                 SchemaPath: pge/rtc_s1/schema/rtc_s1_sas_schema.yaml

--- a/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
+++ b/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
@@ -23,8 +23,8 @@ import yaml
 from opera.pge import RunConfig
 from opera.pge.rtc_s1.rtc_s1_pge import RtcS1Executor
 from opera.util import PgeLogger
+from opera.util.metadata_utils import create_test_rtc_nc_product
 from opera.util.metadata_utils import get_rtc_s1_product_metadata
-from opera.test.util.test_metadata_utils import create_test_rtc_nc_product
 
 
 class RtcS1PgeTestCase(unittest.TestCase):

--- a/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
+++ b/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
@@ -8,7 +8,9 @@ test_rtc_s1_pge.py
 Unit tests for the pge/rtc_s1/rtc_s1_pge.py module.
 """
 
+import glob
 import os
+import re
 import tempfile
 import unittest
 from io import StringIO
@@ -21,6 +23,7 @@ import yaml
 from opera.pge import RunConfig
 from opera.pge.rtc_s1.rtc_s1_pge import RtcS1Executor
 from opera.util import PgeLogger
+from opera.util.metadata_utils import get_rtc_s1_product_metadata
 from opera.test.util.test_metadata_utils import create_test_rtc_nc_product
 
 
@@ -120,8 +123,7 @@ class RtcS1PgeTestCase(unittest.TestCase):
 
         # Lastly, check that the dummy output product(s) were created and renamed
         expected_output_file = join(
-            pge.runconfig.output_product_path,
-            pge._rtc_filename(inter_filename='rtc_s1_test/output_dir/t069_147170_iw1/rtc_product.nc')
+            pge.runconfig.output_product_path, list(pge.renamed_files.values())[0]
         )
         self.assertTrue(os.path.exists(expected_output_file))
 
@@ -130,6 +132,36 @@ class RtcS1PgeTestCase(unittest.TestCase):
             log_contents = infile.read()
 
         self.assertIn(f"RTC-S1 invoked with RunConfig {expected_sas_config_file}", log_contents)
+
+    def test_filename_application(self):
+        """Test the filename convention applied to CSLC output products"""
+        runconfig_path = join(self.data_dir, 'test_rtc_s1_config.yaml')
+
+        pge = RtcS1Executor(pge_name="RtcPgeTest", runconfig_path=runconfig_path)
+
+        pge.run()
+
+        # Grab the metadata generated from the PGE run, as it is used to generate
+        # the final filename for output products
+        output_files = glob.glob(join(pge.runconfig.output_product_path, "*.nc"))
+
+        self.assertEqual(len(output_files), 1)
+
+        output_file = output_files[0]
+
+        rtc_metadata = get_rtc_s1_product_metadata(output_file)
+
+        file_name_regex = rf"{pge.PROJECT}_{pge.LEVEL}_{pge.NAME}-{pge.SOURCE}_" \
+                          rf"\w{{4}}-\w{{6}}-\w{{3}}_" \
+                          rf"\d{{8}}T\d{{6}}Z_\d{{8}}T\d{{6}}Z_" \
+                          rf"{rtc_metadata['identification']['missionId']}_" \
+                          rf"{int(rtc_metadata['frequencyA']['xCoordinateSpacing'])}_" \
+                          rf"v{pge.runconfig.product_version}.nc"
+
+        result = re.match(file_name_regex, os.path.basename(output_file))
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.group(), os.path.basename(output_file))
 
     def test_iso_metadata_creation(self):
         """

--- a/src/opera/test/util/test_metadata_utils.py
+++ b/src/opera/test/util/test_metadata_utils.py
@@ -33,6 +33,66 @@ def osr_is_available():
         return False
 
 
+def create_test_rtc_nc_product(file_path):
+    """Creates a dummy RTC NetCDF product with expected metadata fields"""
+    with h5py.File(file_path, 'w') as f:
+        frequencyA_grp = f.create_group("/science/CSAR/RTC/grids/frequencyA")
+        centerFrequency_dset = frequencyA_grp.create_dataset("centerFrequency", data=5405000454.33435, dtype='float64')
+        centerFrequency_dset.attrs['description'] = np.string_("Center frequency of the processed image in Hz")
+        xCoordinateSpacing_dset = frequencyA_grp.create_dataset("xCoordinateSpacing", data=30.0, dtype='float64')
+        xCoordinates_dset = frequencyA_grp.create_dataset("xCoordinates", data=np.zeros((10,)), dtype='float64')
+        yCoordinateSpacing_dset = frequencyA_grp.create_dataset("yCoordinateSpacing", data=30.0, dtype='float64')
+        yCoordinates_dset = frequencyA_grp.create_dataset("yCoordinates", data=np.zeros((10,)), dtype='float64')
+        listOfPolarizations_dset = frequencyA_grp.create_dataset("listOfPolarizations", data=np.array([b'VV', b'VH']))
+        rangeBandwidth_dset = frequencyA_grp.create_dataset('rangeBandwidth', data=56500000.0, dtype='float64')
+        azimuthBandwidth_dset = frequencyA_grp.create_dataset('azimuthBandwidth', data=56500000.0, dtype='float64')
+        slantRangeSpacing_dset = frequencyA_grp.create_dataset('slantRangeSpacing', data=2.32956, dtype='float64')
+        zeroDopplerTimeSpacing_dset = frequencyA_grp.create_dataset('zeroDopplerTimeSpacing', data=0.002055, dtype='float64')
+        faradayRotationFlag_dset = frequencyA_grp.create_dataset('faradayRotationFlag', data=True, dtype='bool')
+        noiseCorrectionFlag_dset = frequencyA_grp.create_dataset('noiseCorrectionFlag', data=True, dtype='bool')
+        polarizationOrientationFlag_dset = frequencyA_grp.create_dataset('polarizationOrientationFlag', data=True, dtype='bool')
+        radiometricTerrainCorrectionFlag_dset = frequencyA_grp.create_dataset('radiometricTerrainCorrectionFlag', data=True, dtype='bool')
+
+        orbit_grp = f.create_group("/science/CSAR/RTC/metadata/orbit")
+        orbitType_dset = orbit_grp.create_dataset("orbitType", data=b'POE')
+
+        processingInformation_inputs_grp = f.create_group("/science/CSAR/RTC/metadata/processingInformation/inputs")
+        demFiles_dset = processingInformation_inputs_grp.create_dataset("demFiles", data=np.array([b'dem.tif']))
+        auxcalFiles = np.array([b'calibration-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml',
+                                b'noise-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml'])
+        auxcalFiles_dset = processingInformation_inputs_grp.create_dataset("auxcalFiles", data=auxcalFiles)
+        configFiles_dset = processingInformation_inputs_grp.create_dataset("configFiles", data=b'rtc_s1.yaml')
+        l1SlcGranules = np.array([b'S1B_IW_SLC__1SDV_20180504T104507_20180504T104535_010770_013AEE_919F.zip'])
+        l1SlcGranules_dset = processingInformation_inputs_grp.create_dataset("l1SlcGranules", data=l1SlcGranules)
+        orbitFiles = np.array([b'S1B_OPER_AUX_POEORB_OPOD_20180524T110543_V20180503T225942_20180505T005942.EOF'])
+        orbitFiles_dset = processingInformation_inputs_grp.create_dataset("orbitFiles", data=orbitFiles)
+
+        processingInformation_algorithms_grp = f.create_group(
+            "/science/CSAR/RTC/metadata/processingInformation/algorithms")
+        demInterpolation_dset = processingInformation_algorithms_grp.create_dataset("demInterpolation", data=b'biquintic')
+        geocoding_dset = processingInformation_algorithms_grp.create_dataset("geocoding", data=b'area_projection')
+        radiometricTerrainCorrection_dset = processingInformation_algorithms_grp.create_dataset("radiometricTerrainCorrection", data=b'area_projection')
+        isceVersion_dset = processingInformation_algorithms_grp.create_dataset("ISCEVersion", data=b'0.8.0-dev')
+
+        identification_grp = f.create_group("/science/CSAR/identification")
+        absoluteOrbitNumber_dset = identification_grp.create_dataset("absoluteOrbitNumber", data=10770, dtype='int64')
+        diagnosticModeFlag_dset = identification_grp.create_dataset("diagnosticModeFlag", data=False, dtype='bool')
+        isGeocodedFlag = identification_grp.create_dataset("isGeocoded", data=True, dtype='bool')
+        isUrgentObservation_dset = identification_grp.create_dataset("isUrgentObservation", data=np.array([False, True]), dtype='bool')
+        lookDirection_dset = identification_grp.create_dataset("lookDirection", data=b'Right')
+        listOfFrequencies_dset = identification_grp.create_dataset("listOfFrequencies", data=np.array([b'A']))
+        missionId_dest = identification_grp.create_dataset("missionId", data=b'S1B')
+        orbitPassDirection_dset = identification_grp.create_dataset("orbitPassDirection", data=b'Descending')
+        plannedDatatakeId_dset = identification_grp.create_dataset("plannedDatatakeId", data=np.array([b'datatake1', b'datatake2']))
+        plannedObservationId_dset = identification_grp.create_dataset("plannedObservationId", data=np.array([b'obs1', b'obs2']))
+        processingType_dset = identification_grp.create_dataset("processingType", data=b'UNDEFINED')
+        productType_dset = identification_grp.create_dataset("productType", data=b'SLC')
+        productVersion_dset = identification_grp.create_dataset("productVersion", data=b'1.0')
+        trackNumber_dset = identification_grp.create_dataset("trackNumber", data=147170, dtype='int64')
+        zeroDopplerEndTime_dset = identification_grp.create_dataset("zeroDopplerEndTime", data=b'2018-05-04T10:45:11.501279')
+        zeroDopplerStartTime_dset = identification_grp.create_dataset("zeroDopplerStartTime", data=b'2018-05-04T10:45:08.436445')
+
+
 class MetadataUtilsTestCase(unittest.TestCase):
     """Unit test Metadata Utilities"""
 
@@ -64,27 +124,7 @@ class MetadataUtilsTestCase(unittest.TestCase):
     def test_get_rtc_s1_product_metadata(self):
         """Test retrieval of product metadata from HDF5 files"""
         file_name = os.path.join(tempfile.gettempdir(), "test_metadata_file.hdf5")
-        with h5py.File(file_name, 'w') as f:
-
-            # create some metadata to be retrieved
-            frequencyA_grp = f.create_group("/science/CSAR/RTC/grids/frequencyA")
-            centerFrequency_dset = frequencyA_grp.create_dataset("centerFrequency", data=5405000454.33435, dtype='float64')
-            centerFrequency_dset.attrs['description'] = np.string_("Center frequency of the processed image in Hz")
-
-            orbit_grp = f.create_group("/science/CSAR/RTC/metadata/orbit")
-            orbitType_dset = orbit_grp.create_dataset("orbitType", data=b'POE')
-
-            processingInformation_inputs_grp = f.create_group("/science/CSAR/RTC/metadata/processingInformation/inputs")
-            demFiles_dset = processingInformation_inputs_grp.create_dataset("demFiles", data=np.array([b'dem.tif']))
-            auxcalFiles = np.array([b'calibration-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml',
-                                    b'noise-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml'])
-            auxcalFiles_dset = processingInformation_inputs_grp.create_dataset("auxcalFiles", data=auxcalFiles)
-
-            processingInformation_algorithms_grp = f.create_group("/science/CSAR/RTC/metadata/processingInformation/algorithms")
-            geocoding_dset = processingInformation_algorithms_grp.create_dataset("geocoding", data=b'area_projection')
-
-            identification_grp = f.create_group("/science/CSAR/identification")
-            trackNumber_dset = identification_grp.create_dataset("trackNumber", data=147170, dtype='int64')
+        create_test_rtc_nc_product(file_name)
 
         try:
             product_output = get_rtc_s1_product_metadata(file_name)
@@ -101,6 +141,7 @@ class MetadataUtilsTestCase(unittest.TestCase):
 
         finally:
             os.remove(file_name)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/opera/test/util/test_metadata_utils.py
+++ b/src/opera/test/util/test_metadata_utils.py
@@ -9,13 +9,12 @@ Unit tests for the util/metadata_utils.py module.
 
 """
 
-import h5py
 import tempfile
-import numpy as np
 import os
 import unittest
 from unittest import skipIf
 
+from opera.util.metadata_utils import create_test_rtc_nc_product
 from opera.util.metadata_utils import get_geographic_boundaries_from_mgrs_tile
 from opera.util.metadata_utils import get_rtc_s1_product_metadata
 
@@ -31,66 +30,6 @@ def osr_is_available():
         return True
     except (ImportError, ModuleNotFoundError):
         return False
-
-
-def create_test_rtc_nc_product(file_path):
-    """Creates a dummy RTC NetCDF product with expected metadata fields"""
-    with h5py.File(file_path, 'w') as f:
-        frequencyA_grp = f.create_group("/science/CSAR/RTC/grids/frequencyA")
-        centerFrequency_dset = frequencyA_grp.create_dataset("centerFrequency", data=5405000454.33435, dtype='float64')
-        centerFrequency_dset.attrs['description'] = np.string_("Center frequency of the processed image in Hz")
-        xCoordinateSpacing_dset = frequencyA_grp.create_dataset("xCoordinateSpacing", data=30.0, dtype='float64')
-        xCoordinates_dset = frequencyA_grp.create_dataset("xCoordinates", data=np.zeros((10,)), dtype='float64')
-        yCoordinateSpacing_dset = frequencyA_grp.create_dataset("yCoordinateSpacing", data=30.0, dtype='float64')
-        yCoordinates_dset = frequencyA_grp.create_dataset("yCoordinates", data=np.zeros((10,)), dtype='float64')
-        listOfPolarizations_dset = frequencyA_grp.create_dataset("listOfPolarizations", data=np.array([b'VV', b'VH']))
-        rangeBandwidth_dset = frequencyA_grp.create_dataset('rangeBandwidth', data=56500000.0, dtype='float64')
-        azimuthBandwidth_dset = frequencyA_grp.create_dataset('azimuthBandwidth', data=56500000.0, dtype='float64')
-        slantRangeSpacing_dset = frequencyA_grp.create_dataset('slantRangeSpacing', data=2.32956, dtype='float64')
-        zeroDopplerTimeSpacing_dset = frequencyA_grp.create_dataset('zeroDopplerTimeSpacing', data=0.002055, dtype='float64')
-        faradayRotationFlag_dset = frequencyA_grp.create_dataset('faradayRotationFlag', data=True, dtype='bool')
-        noiseCorrectionFlag_dset = frequencyA_grp.create_dataset('noiseCorrectionFlag', data=True, dtype='bool')
-        polarizationOrientationFlag_dset = frequencyA_grp.create_dataset('polarizationOrientationFlag', data=True, dtype='bool')
-        radiometricTerrainCorrectionFlag_dset = frequencyA_grp.create_dataset('radiometricTerrainCorrectionFlag', data=True, dtype='bool')
-
-        orbit_grp = f.create_group("/science/CSAR/RTC/metadata/orbit")
-        orbitType_dset = orbit_grp.create_dataset("orbitType", data=b'POE')
-
-        processingInformation_inputs_grp = f.create_group("/science/CSAR/RTC/metadata/processingInformation/inputs")
-        demFiles_dset = processingInformation_inputs_grp.create_dataset("demFiles", data=np.array([b'dem.tif']))
-        auxcalFiles = np.array([b'calibration-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml',
-                                b'noise-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml'])
-        auxcalFiles_dset = processingInformation_inputs_grp.create_dataset("auxcalFiles", data=auxcalFiles)
-        configFiles_dset = processingInformation_inputs_grp.create_dataset("configFiles", data=b'rtc_s1.yaml')
-        l1SlcGranules = np.array([b'S1B_IW_SLC__1SDV_20180504T104507_20180504T104535_010770_013AEE_919F.zip'])
-        l1SlcGranules_dset = processingInformation_inputs_grp.create_dataset("l1SlcGranules", data=l1SlcGranules)
-        orbitFiles = np.array([b'S1B_OPER_AUX_POEORB_OPOD_20180524T110543_V20180503T225942_20180505T005942.EOF'])
-        orbitFiles_dset = processingInformation_inputs_grp.create_dataset("orbitFiles", data=orbitFiles)
-
-        processingInformation_algorithms_grp = f.create_group(
-            "/science/CSAR/RTC/metadata/processingInformation/algorithms")
-        demInterpolation_dset = processingInformation_algorithms_grp.create_dataset("demInterpolation", data=b'biquintic')
-        geocoding_dset = processingInformation_algorithms_grp.create_dataset("geocoding", data=b'area_projection')
-        radiometricTerrainCorrection_dset = processingInformation_algorithms_grp.create_dataset("radiometricTerrainCorrection", data=b'area_projection')
-        isceVersion_dset = processingInformation_algorithms_grp.create_dataset("ISCEVersion", data=b'0.8.0-dev')
-
-        identification_grp = f.create_group("/science/CSAR/identification")
-        absoluteOrbitNumber_dset = identification_grp.create_dataset("absoluteOrbitNumber", data=10770, dtype='int64')
-        diagnosticModeFlag_dset = identification_grp.create_dataset("diagnosticModeFlag", data=False, dtype='bool')
-        isGeocodedFlag = identification_grp.create_dataset("isGeocoded", data=True, dtype='bool')
-        isUrgentObservation_dset = identification_grp.create_dataset("isUrgentObservation", data=np.array([False, True]), dtype='bool')
-        lookDirection_dset = identification_grp.create_dataset("lookDirection", data=b'Right')
-        listOfFrequencies_dset = identification_grp.create_dataset("listOfFrequencies", data=np.array([b'A']))
-        missionId_dest = identification_grp.create_dataset("missionId", data=b'S1B')
-        orbitPassDirection_dset = identification_grp.create_dataset("orbitPassDirection", data=b'Descending')
-        plannedDatatakeId_dset = identification_grp.create_dataset("plannedDatatakeId", data=np.array([b'datatake1', b'datatake2']))
-        plannedObservationId_dset = identification_grp.create_dataset("plannedObservationId", data=np.array([b'obs1', b'obs2']))
-        processingType_dset = identification_grp.create_dataset("processingType", data=b'UNDEFINED')
-        productType_dset = identification_grp.create_dataset("productType", data=b'SLC')
-        productVersion_dset = identification_grp.create_dataset("productVersion", data=b'1.0')
-        trackNumber_dset = identification_grp.create_dataset("trackNumber", data=147170, dtype='int64')
-        zeroDopplerEndTime_dset = identification_grp.create_dataset("zeroDopplerEndTime", data=b'2018-05-04T10:45:11.501279')
-        zeroDopplerStartTime_dset = identification_grp.create_dataset("zeroDopplerStartTime", data=b'2018-05-04T10:45:08.436445')
 
 
 class MetadataUtilsTestCase(unittest.TestCase):

--- a/src/opera/util/metadata_utils.py
+++ b/src/opera/util/metadata_utils.py
@@ -285,3 +285,73 @@ def get_rtc_s1_product_metadata(file_name):
     }
 
     return product_output
+
+
+def create_test_rtc_nc_product(file_path):
+    """
+    Creates a dummy RTC NetCDF product with expected metadata fields.
+    This function is intended for use with unit tests, but is included in this
+    module, so it will be importable from within a built container.
+
+    Parameters
+    ----------
+    file_path : str
+        Full path to write the dummy RTC NetCDF product to.
+
+    """
+    with h5py.File(file_path, 'w') as outfile:
+        frequencyA_grp = outfile.create_group("/science/CSAR/RTC/grids/frequencyA")
+        centerFrequency_dset = frequencyA_grp.create_dataset("centerFrequency", data=5405000454.33435, dtype='float64')
+        centerFrequency_dset.attrs['description'] = np.string_("Center frequency of the processed image in Hz")
+        xCoordinateSpacing_dset = frequencyA_grp.create_dataset("xCoordinateSpacing", data=30.0, dtype='float64')
+        xCoordinates_dset = frequencyA_grp.create_dataset("xCoordinates", data=np.zeros((10,)), dtype='float64')
+        yCoordinateSpacing_dset = frequencyA_grp.create_dataset("yCoordinateSpacing", data=30.0, dtype='float64')
+        yCoordinates_dset = frequencyA_grp.create_dataset("yCoordinates", data=np.zeros((10,)), dtype='float64')
+        listOfPolarizations_dset = frequencyA_grp.create_dataset("listOfPolarizations", data=np.array([b'VV', b'VH']))
+        rangeBandwidth_dset = frequencyA_grp.create_dataset('rangeBandwidth', data=56500000.0, dtype='float64')
+        azimuthBandwidth_dset = frequencyA_grp.create_dataset('azimuthBandwidth', data=56500000.0, dtype='float64')
+        slantRangeSpacing_dset = frequencyA_grp.create_dataset('slantRangeSpacing', data=2.32956, dtype='float64')
+        zeroDopplerTimeSpacing_dset = frequencyA_grp.create_dataset('zeroDopplerTimeSpacing', data=0.002055, dtype='float64')
+        faradayRotationFlag_dset = frequencyA_grp.create_dataset('faradayRotationFlag', data=True, dtype='bool')
+        noiseCorrectionFlag_dset = frequencyA_grp.create_dataset('noiseCorrectionFlag', data=True, dtype='bool')
+        polarizationOrientationFlag_dset = frequencyA_grp.create_dataset('polarizationOrientationFlag', data=True, dtype='bool')
+        radiometricTerrainCorrectionFlag_dset = frequencyA_grp.create_dataset('radiometricTerrainCorrectionFlag', data=True, dtype='bool')
+
+        orbit_grp = outfile.create_group("/science/CSAR/RTC/metadata/orbit")
+        orbitType_dset = orbit_grp.create_dataset("orbitType", data=b'POE')
+
+        processingInformation_inputs_grp = outfile.create_group("/science/CSAR/RTC/metadata/processingInformation/inputs")
+        demFiles_dset = processingInformation_inputs_grp.create_dataset("demFiles", data=np.array([b'dem.tif']))
+        auxcalFiles = np.array([b'calibration-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml',
+                                b'noise-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml'])
+        auxcalFiles_dset = processingInformation_inputs_grp.create_dataset("auxcalFiles", data=auxcalFiles)
+        configFiles_dset = processingInformation_inputs_grp.create_dataset("configFiles", data=b'rtc_s1.yaml')
+        l1SlcGranules = np.array([b'S1B_IW_SLC__1SDV_20180504T104507_20180504T104535_010770_013AEE_919F.zip'])
+        l1SlcGranules_dset = processingInformation_inputs_grp.create_dataset("l1SlcGranules", data=l1SlcGranules)
+        orbitFiles = np.array([b'S1B_OPER_AUX_POEORB_OPOD_20180524T110543_V20180503T225942_20180505T005942.EOF'])
+        orbitFiles_dset = processingInformation_inputs_grp.create_dataset("orbitFiles", data=orbitFiles)
+
+        processingInformation_algorithms_grp = outfile.create_group(
+            "/science/CSAR/RTC/metadata/processingInformation/algorithms")
+        demInterpolation_dset = processingInformation_algorithms_grp.create_dataset("demInterpolation", data=b'biquintic')
+        geocoding_dset = processingInformation_algorithms_grp.create_dataset("geocoding", data=b'area_projection')
+        radiometricTerrainCorrection_dset = processingInformation_algorithms_grp.create_dataset("radiometricTerrainCorrection", data=b'area_projection')
+        isceVersion_dset = processingInformation_algorithms_grp.create_dataset("ISCEVersion", data=b'0.8.0-dev')
+
+        identification_grp = outfile.create_group("/science/CSAR/identification")
+        absoluteOrbitNumber_dset = identification_grp.create_dataset("absoluteOrbitNumber", data=10770, dtype='int64')
+        diagnosticModeFlag_dset = identification_grp.create_dataset("diagnosticModeFlag", data=False, dtype='bool')
+        isGeocodedFlag = identification_grp.create_dataset("isGeocoded", data=True, dtype='bool')
+        isUrgentObservation_dset = identification_grp.create_dataset("isUrgentObservation", data=np.array([False, True]), dtype='bool')
+        lookDirection_dset = identification_grp.create_dataset("lookDirection", data=b'Right')
+        listOfFrequencies_dset = identification_grp.create_dataset("listOfFrequencies", data=np.array([b'A']))
+        missionId_dest = identification_grp.create_dataset("missionId", data=b'S1B')
+        orbitPassDirection_dset = identification_grp.create_dataset("orbitPassDirection", data=b'Descending')
+        plannedDatatakeId_dset = identification_grp.create_dataset("plannedDatatakeId", data=np.array([b'datatake1', b'datatake2']))
+        plannedObservationId_dset = identification_grp.create_dataset("plannedObservationId", data=np.array([b'obs1', b'obs2']))
+        processingType_dset = identification_grp.create_dataset("processingType", data=b'UNDEFINED')
+        productType_dset = identification_grp.create_dataset("productType", data=b'SLC')
+        productVersion_dset = identification_grp.create_dataset("productVersion", data=b'1.0')
+        trackNumber_dset = identification_grp.create_dataset("trackNumber", data=147170, dtype='int64')
+        zeroDopplerEndTime_dset = identification_grp.create_dataset("zeroDopplerEndTime", data=b'2018-05-04T10:45:11.501279')
+        zeroDopplerStartTime_dset = identification_grp.create_dataset("zeroDopplerStartTime", data=b'2018-05-04T10:45:08.436445')


### PR DESCRIPTION
## Description
- This branch provides an implementation for creation of the RTC-S1 ISO metadata, using the NetCDF metadata extraction utilities combined with the Jinja2 template. This branch also updates the file name conventions application to provide all fields for RTC-S1 output products.

## Affected Issues
- Resolves #197 

## Testing
- Unit tests have been added for ISO metadata creation, as well as application of the file name conventions
