### PR TITLE
209 tiff to tif

### DIFF
--- a/src/opera/pge/dswx_hls/dswx_hls_pge.py
+++ b/src/opera/pge/dswx_hls/dswx_hls_pge.py
@@ -318,7 +318,7 @@ class DSWxHLSPostProcessorMixin(PostProcessorMixin):
 
         The GeoTIFF filename for the DSWx-HLS PGE consists of:
 
-            <Core filename>_<Band Index>_<Band Name>.tiff
+            <Core filename>_<Band Index>_<Band Name>.tif
 
         Where <Core filename> is returned by DSWxHLSPostProcessorMixin._core_filename()
         and <Band Index> and <Band Name> are determined from the name of the
@@ -343,7 +343,7 @@ class DSWxHLSPostProcessorMixin(PostProcessorMixin):
         # of the filename before the extension, delimited by underscores
         band_idx, band_name = splitext(inter_filename)[0].split("_")[-2:]
 
-        return f"{core_filename}_{band_idx}_{band_name}.tiff"
+        return f"{core_filename}_{band_idx}_{band_name}.tif"
 
     def _browse_image_filename(self, inter_filename):
         """
@@ -391,7 +391,7 @@ class DSWxHLSPostProcessorMixin(PostProcessorMixin):
 
         for output_product in output_products:
             if (basename(output_product) in self.renamed_files.values() and
-                    basename(output_product).endswith("tiff")):
+                    basename(output_product).endswith("tif")):
                 representative_product = output_product
                 break
         else:

--- a/src/opera/test/pge/dswx_hls/test_dswx_hls_pge.py
+++ b/src/opera/test/pge/dswx_hls/test_dswx_hls_pge.py
@@ -136,7 +136,7 @@ class DSWxPgeTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(expected_log_file))
 
         # Lastly, check that at least one "image" file was created
-        image_files = glob.glob(join(pge.runconfig.output_product_path, "*.tiff"))
+        image_files = glob.glob(join(pge.runconfig.output_product_path, "*.tif"))
         self.assertGreater(len(image_files), 0)
 
         # Open and read the log
@@ -297,7 +297,7 @@ class DSWxPgeTestCase(unittest.TestCase):
 
         pge.run()
 
-        image_files = glob.glob(join(pge.runconfig.output_product_path, "*.tiff"))
+        image_files = glob.glob(join(pge.runconfig.output_product_path, "*.tif"))
 
         for image_file in image_files:
             file_name = pge._geotiff_filename(image_file)
@@ -308,7 +308,7 @@ class DSWxPgeTestCase(unittest.TestCase):
                               rf"\d{{8}}T\d{{6}}Z_\d{{8}}T\d{{6}}Z_" \
                               rf"{get_sensor_from_spacecraft_name(md['SPACECRAFT_NAME'])}_" \
                               rf"30_v{pge.runconfig.product_version}_" \
-                              rf"B\d{{2}}_\w+.tiff"
+                              rf"B\d{{2}}_\w+.tif"
             self.assertEqual(re.match(file_name_regex, file_name).group(), file_name)
 
     class CustomMockGdal(MockGdal):
@@ -365,8 +365,8 @@ class DSWxPgeTestCase(unittest.TestCase):
         pge = DSWxHLSExecutor(pge_name="DSWxPgeTest", runconfig_path=runconfig_path)
         pge.run_preprocessor()
 
-        test_file = join(abspath(pge.runconfig.output_product_path), 'test_file.tiff')
-        pge.renamed_files['test_file.tiff'] = os.path.basename(test_file)
+        test_file = join(abspath(pge.runconfig.output_product_path), 'test_file.tif')
+        pge.renamed_files['test_file.tif'] = os.path.basename(test_file)
         os.system(f'touch {test_file}')
 
         output_product_metadata = pge._collect_dswx_product_metadata()


### PR DESCRIPTION
## Description
- Changed ".tiff" to ".tif" in dswx_hls_pge.py and in test_dswx_hls_pge.py

## Testing
-  minor change to test_dswx_hls_pge.py

## Question
- in the future should we consider changing methods and variables with 'geotiff' in their names to 'geotif', to reinforce the new restrictions on the naming convention?