### PR TITLE
Release 2.0.0 ER 5.1

### DIFF
--- a/.ci/scripts/build_rtc_s1.sh
+++ b/.ci/scripts/build_rtc_s1.sh
@@ -24,7 +24,7 @@ BUILD_DATE_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 # defaults, SAS image should be updated as necessary for new image releases from ADT
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath $(dirname $(realpath $0))/../..)
 [ -z "${TAG}" ] && TAG="${USER}-dev"
-[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/rtc:beta_0.2"
+[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/rtc:beta_0.2.1"
 
 echo "WORKSPACE: $WORKSPACE"
 echo "IMAGE: $IMAGE"

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -678,7 +678,10 @@ class RtcS1Executor(RtcS1PreProcessorMixin, RtcS1PostProcessorMixin, PgeExecutor
     LEVEL = "L2"
     """Processing Level for RTC-S1 Products"""
 
-    SAS_VERSION = "0.2"  # Beta release https://github.com/opera-adt/RTC/releases/tag/v0.2
+    PGE_VERSION = "2.0.0-er.5.1"
+    """Version of the PGE (overrides default from base_pge)"""
+
+    SAS_VERSION = "0.2.1"  # Beta release https://github.com/opera-adt/RTC/releases/tag/v0.2.1
     """Version of the SAS wrapped by this PGE, should be updated as needed"""
 
     SOURCE = "S1"


### PR DESCRIPTION
Engineering Release 5.1 for the RTC-S1 PGE. This version incorporates the v0.2.1 beta delivery of the corresponding SAS. The main change is a fix to the SAS that removes a unneeded check on EPSG codes when processing burst mosaics.