### PR TITLE
RTC-S1 Test Asset Refactor

### DIFF
--- a/.ci/scripts/process_metric_data.py
+++ b/.ci/scripts/process_metric_data.py
@@ -203,9 +203,10 @@ def make_lists(csv_file):
 def main():
     """Main program in process_metric_data.py"""
     container_info = sys.argv[1]
-    stats_file = sys.argv[2]
-    misc_file = sys.argv[3]
-    output_dir = sys.argv[4]
+    container_name = sys.argv[2]
+    stats_file = sys.argv[3]
+    misc_file = sys.argv[4]
+    output_dir = sys.argv[5]
 
     temp_stats = "temp_opera_docker_stats.csv"
     temp_misc = "temp_opera_misc_stats.csv"
@@ -217,8 +218,8 @@ def main():
     current_time = datetime.datetime.today().strftime('%Y%m%d_%H%M%S')
 
     # For now make two formatted files
-    docker_report_file = f"{output_dir}/docker_metrics_{container_info}_{current_time}.csv"
-    misc_report_file = f"{output_dir}/misc_metrics_{container_info}_{current_time}.csv"
+    docker_report_file = f"{output_dir}/docker_metrics_{container_info}_{container_name}_{current_time}.csv"
+    misc_report_file = f"{output_dir}/misc_metrics_{container_info}_{container_name}_{current_time}.csv"
 
     # read files into lists
     stats_list = make_lists(temp_stats)

--- a/.ci/scripts/run_metrics.sh
+++ b/.ci/scripts/run_metrics.sh
@@ -47,4 +47,4 @@ docker run --rm -w "${CONTAINER_HOME}" -u $UID:$(id -g) --name="${container_name
 docker_run_exit_code=$?
 echo "Docker run exited with code: " $docker_run_exit_code
 
-metrics_collection_end "$PGE_NAME" "$docker_run_exit_code" "$TEST_RESULTS_DIR"
+metrics_collection_end "$PGE_NAME" "$container_name" "$docker_run_exit_code" "$TEST_RESULTS_DIR"

--- a/.ci/scripts/test_int_cslc_s1.sh
+++ b/.ci/scripts/test_int_cslc_s1.sh
@@ -97,7 +97,7 @@ docker run --rm -u $UID:"$(id -g)" -w /home/compass_user --name $container_name 
 docker_exit_status=$?
 
 # End metrics collection
-metrics_collection_end "$PGE_NAME" "$docker_exit_status" "$TEST_RESULTS_DIR"
+metrics_collection_end "$PGE_NAME" "$container_name" "$docker_exit_status" "$TEST_RESULTS_DIR"
 
 if [ $docker_exit_status -ne 0 ]; then
     echo "docker exit indicates failure: ${docker_exit_status}"

--- a/.ci/scripts/test_int_dswx_hls.sh
+++ b/.ci/scripts/test_int_dswx_hls.sh
@@ -104,7 +104,7 @@ do
     docker_exit_status=$?
 
     # End metrics collection
-    metrics_collection_end "$PGE_NAME" "$docker_exit_status" "$TEST_RESULTS_DIR"
+    metrics_collection_end "$PGE_NAME" "$container_name" "$docker_exit_status" "$TEST_RESULTS_DIR"
 
     if [ $docker_exit_status -ne 0 ]; then
         echo "docker exit indicates failure: ${docker_exit_status}"

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -62,7 +62,7 @@ input_dir="${TMP_DIR}/${INPUT_DATA%.*}/input_dir"
 runconfig_dir="${TMP_DIR}/runconfig"
 
 # the testdata reference metadata contains this path so we use it here
-output_dir="${TMP_DIR}/output_cslc_s1"
+output_dir="${TMP_DIR}/output_rtc_s1"
 # make sure no output directory already exists
 if [ -d "$output_dir" ]; then
     echo "Output directory $output_dir already exists (and should not). Removing directory."

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -23,12 +23,13 @@ SAMPLE_TIME=15
 
 # defaults, test data and runconfig files should be updated as-needed to use
 # the latest available as defaults for use with the Jenkins pipeline call
-# TESTDATA should be the name of the test data archive in s3://operasds-dev-pge/${PGE_NAME}/
+# INPUT/OUTPUT_DATA should be the name of the test data archive in s3://operasds-dev-pge/${PGE_NAME}/
 # RUNCONFIG should be the name of the runconfig in s3://operasds-dev-pge/${PGE_NAME}/
 [ -z "${WORKSPACE}" ] && WORKSPACE="$(realpath "$(dirname "$(realpath "$0")")"/../..)"
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
-[ -z "${TESTDATA}" ] && TESTDATA="delivery_1_interface_0.1.zip"
-[ -z "${RUNCONFIG}" ] && RUNCONFIG="rtc_s1.yaml"
+[ -z "${INPUT_DATA}}" ] && INPUT_DADA="rtc_s1_delivery_2_beta_0.2_expected_input.zip"
+[ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="rtc_s1_delivery_2_beta_0.2_expected_output.zip"
+[ -z "${RUNCONFIG}" ] && RUNCONFIG="rtc_s1_delivery_2_beta_0.2_runconfig.yaml"
 
 # Create a temporary directory to hold test data
 test_int_setup_data_tmp_directory
@@ -40,10 +41,9 @@ test_int_setup_test_data
 trap test_int_trap_cleanup EXIT
 
 # Pull in product compare script from S3.
-compare_script=rtc_compare.py
-local_compare_script=${TMP_DIR}/${compare_script}
-echo "Downloading s3://operasds-dev-pge/${PGE_NAME}/${compare_script} to ${local_compare_script}"
-aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/${compare_script} "${local_compare_script}"
+local_compare_script=${TMP_DIR}/rtc_compare.py
+echo "Downloading s3://operasds-dev-pge/${PGE_NAME}/rtc_compare.py to ${local_compare_script}"
+aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/rtc_compare.py "${local_compare_script}"
 
 # overall_status values and their meaning
 # 0 - pass
@@ -51,11 +51,19 @@ aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/${compare_script} "${local_compare_s
 # 2 - product validation failure
 overall_status=0
 
-# There is only 1 expected output directory for RTC-S1
-expected_dir="$(pwd)/peru/expected_output_dir"
+data_set = 'peru'
+input_data_basename=$(basename -- "$INPUT_DATA")
+input_data_dir="${TMP_DIR}/${input_data_basename%.*}/${data_set}/input_dir"
+
+expected_data_basename=$(basename -- "$EXPECTED_DATA")
+expected_data_dir="${TMP_DIR}/${expected_data_basename%.*}/${data_set}/expected_output_dir"
+
+echo "Input data directory: ${input_data_dir}"
+echo "Expected data directory: ${expected_data_dir}"
 
 # the testdata reference metadata contains this path so we use it here
-output_dir="$(pwd)/output_rtc_s1"
+output_dir="${TMP_DIR}/rtc_s1_output/${data_set}/output_dir"
+
 # make sure no output directory already exists
 if [ -d "$output_dir" ]; then
     echo "Output directory $output_dir already exists (and should not). Removing directory..."
@@ -63,36 +71,35 @@ if [ -d "$output_dir" ]; then
 fi
 
 echo "Creating output directory $output_dir."
-mkdir "$output_dir"
+mkdir -p "$output_dir"
 
 # the testdata reference metadata contains this path so we use it here
-scratch_dir="$(pwd)/scratch_rtc_s1"
+scratch_dir="${TMP_DIR}/scratch_rtc_s1/${data_set}/scratch_dir"
 # make sure no scratch directory already exists
 if [ -d "$scratch_dir" ]; then
     echo "Scratch directory $scratch_dir already exists (and should not). Removing directory..."
     rm -rf "${scratch_dir}"
 fi
 echo "Creating scratch directory $scratch_dir."
-mkdir "$scratch_dir"
+mkdir -p --mode=777 "scratch_dir"
 
-container_name="${PGE_NAME}"
+container_name="${PGE_NAME}-${data_set}"
 
 # Start metrics collection
 metrics_collection_start "$PGE_NAME" "$container_name" "$TEST_RESULTS_DIR" "$SAMPLE_TIME"
 
-echo "Running Docker image ${PGE_IMAGE}:${PGE_TAG}"
-
+echo "Running Docker image ${PGE_IMAGE}:${PGE_TAG} for ${input_data_dir}"
 docker run --rm -u $UID:"$(id -g)" -w /home/rtc_user --name $container_name \
-           -v "$(pwd)":/home/rtc_user/runconfig:ro \
-           -v "$(pwd)"/peru:/home/rtc_user/input_dir:ro \
-           -v "${output_dir}":/home/rtc_user/output_dir \
-            -v "${scratch_dir}":/home/rtc_user/scratch_dir \
+           -v "${TMP_DIR}/runconfig":/home/rtc_user/runconfig:ro \
+           -v "$input_data_dir"/:/home/rtc_user/input_dir:ro \
+           -v "$output_dir":/home/rtc_user/output_dir \
+           -v "$scratch_dir":/home/rtc_user/scratch_dir \
            ${PGE_IMAGE}:"${PGE_TAG}" --file /home/rtc_user/runconfig/${RUNCONFIG}
 
 docker_exit_status=$?
 
 # End metrics collection
-metrics_collection_end "$PGE_NAME" "$docker_exit_status" "$TEST_RESULTS_DIR"
+metrics_collection_end "$PGE_NAME" "$container_name" "$docker_exit_status" "$TEST_RESULTS_DIR"
 
 if [ $docker_exit_status -ne 0 ]; then
     echo "docker exit indicates failure: ${docker_exit_status}"
@@ -129,17 +136,17 @@ else
 
     echo "<tr><th>Compare Result</th><th><ul><li>Expected file</li><li>Output file</li></ul></th><th>rtc_compare.py output</th></tr>" >> "$RESULTS_FILE"
     for burst_id in "${burst_ids[@]}"; do
-        echo "Comparing results for $burst_id"
+        echo "Comparing results for: $burst_id"
 
         burst_id_uppercase=${burst_id^^}
         burst_id_replace_underscores=${burst_id_uppercase//_/-}
         burst_id_pattern="*_${burst_id_replace_underscores}_*.nc"
         output_file=$(ls "$output_dir"/"$burst_id_pattern")
-        echo "$output_file"
-        expected_file=${expected_dir}/${burst_id}/rtc_product.nc
+        echo "output file: $output_file"
+        expected_file=${expected_data_dir}/${burst_id}/rtc_product.nc
         compare_output=$(python3 "${local_compare_script}" "${expected_file}" "${output_file}")
 
-        echo "$compare_output"
+        echo "Results of compare: $compare_output"
         if [[ "$compare_output" != *"FAILED"* ]]; then
             echo "Product validation was successful for $output_file"
             compare_result="PASS"

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -58,9 +58,7 @@ overall_status=0
 # There is only 1 expected output directory RTC-S1
 
 expected_dir="${TMP_DIR}/${EXPECTED_DATA%.*}/expected_output_dir"
-# Perhaps the unzipping accounts for the input_data directory?
-# input_dir="${TMP_DIR}/${INPUT_DATA%.*}/input_data"
-input_dir="${TMP_DIR}/${INPUT_DATA%.*}"
+input_dir="${TMP_DIR}/${INPUT_DATA%.*}/input_dir"
 runconfig_dir="${TMP_DIR}/runconfig"
 
 # the testdata reference metadata contains this path so we use it here
@@ -140,10 +138,10 @@ else
 
         burst_id_uppercase=${burst_id^^}
         burst_id_replace_underscores=${burst_id_uppercase//_/-}
-        burst_id_pattern="*_${burst_id_replace_underscores}_*.nc"
+        burst_id_pattern="*_${burst_id_replace_underscores}_*.h5"
         output_file=$(ls "$output_dir"/"$burst_id_pattern")
         echo "output file: $output_file"
-        expected_file=${expected_dir}/${burst_id}/rtc_product.nc
+        expected_file=${expected_dir}/${burst_id}/rtc_product_v0.2.h5
         compare_output=$(python3 "${local_compare_script}" "${expected_file}" "${output_file}")
 
         echo "Results of compare: $compare_output"

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -55,26 +55,19 @@ aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/rtc_compare.py "$local_compare_scrip
 # 2 - product validation failure
 overall_status=0
 
-# only one data set in rtc-s1 (peru)
-data_set='peru'
-input_data_basename=$(basename -- "$INPUT_DATA")
-input_data_dir="${TMP_DIR}/${input_data_basename%.*}/input_dir"
 
-expected_data_basename=$(basename -- "$EXPECTED_DATA")
-expected_data_dir="${TMP_DIR}/${expected_data_basename%.*}/expected_output_dir"
-
-echo "Input data directory: ${input_data_dir}"
-echo "Expected data directory: ${expected_data_dir}"
+# There is only 1 expected output directory RTC-S1
+expected_dir="${TMP_DIR}/${EXPECTED_DATA%.*}/expected_output_dir"
+input_dir="${TMP_DIR}/${INPUT_DATA%.*}/input_data"
+runconfig_dir="${TMP_DIR}/runconfig"
 
 # the testdata reference metadata contains this path so we use it here
-output_dir="${TMP_DIR}/rtc_s1_output/output_dir"
-
+output_dir="${TMP_DIR}/output_cslc_s1"
 # make sure no output directory already exists
 if [ -d "$output_dir" ]; then
-    echo "Output directory $output_dir already exists (and should not). Removing directory..."
+    echo "Output directory $output_dir already exists (and should not). Removing directory."
     rm -rf "${output_dir}"
 fi
-
 echo "Creating output directory $output_dir."
 mkdir -p "$output_dir"
 

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -103,34 +103,34 @@ if [ $docker_exit_status -ne 0 ]; then
     echo "docker exit indicates failure: ${docker_exit_status}"
     overall_status=1
 else
-    declare -a burst_ids=( "t069_147170_iw1"
-                           "t069_147170_iw3"
-                           "t069_147171_iw1"
-                           "t069_147171_iw2"
-                           "t069_147171_iw3"
-                           "t069_147172_iw1"
-                           "t069_147172_iw2"
-                           "t069_147172_iw3"
-                           "t069_147173_iw1"
-                           "t069_147173_iw2"
-                           "t069_147173_iw3"
-                           "t069_147174_iw1"
-                           "t069_147174_iw2"
-                           "t069_147174_iw3"
-                           "t069_147175_iw1"
-                           "t069_147175_iw2"
-                           "t069_147175_iw3"
-                           "t069_147176_iw1"
-                           "t069_147176_iw2"
-                           "t069_147176_iw3"
-                           "t069_147177_iw1"
-                           "t069_147177_iw2"
-                           "t069_147177_iw3"
-                           "t069_147178_iw1"
-                           "t069_147178_iw2"
-                           "t069_147178_iw3"
-                           "t069_147179_iw2"
-                           "t069_147179_iw3")
+    declare -a burst_ids=("t069_147169_iw3"
+                          "t069_147170_iw1"
+                          "t069_147170_iw2"
+                          "t069_147170_iw3"
+                          "t069_147171_iw1"
+                          "t069_147171_iw2"
+                          "t069_147171_iw3"
+                          "t069_147172_iw1"
+                          "t069_147172_iw2"
+                          "t069_147172_iw3"
+                          "t069_147173_iw1"
+                          "t069_147173_iw2"
+                          "t069_147173_iw3"
+                          "t069_147174_iw1"
+                          "t069_147174_iw2"
+                          "t069_147174_iw3"
+                          "t069_147175_iw1"
+                          "t069_147175_iw2"
+                          "t069_147175_iw3"
+                          "t069_147176_iw1"
+                          "t069_147176_iw2"
+                          "t069_147176_iw3"
+                          "t069_147177_iw1"
+                          "t069_147177_iw2"
+                          "t069_147177_iw3"
+                          "t069_147178_iw1"
+                          "t069_147178_iw2"
+                          "t069_147178_iw3")
 
     echo "<tr><th>Compare Result</th><th><ul><li>Expected file</li><li>Output file</li></ul></th><th>rtc_compare.py output</th></tr>" >> "$RESULTS_FILE"
     for burst_id in "${burst_ids[@]}"; do
@@ -139,7 +139,10 @@ else
         burst_id_uppercase=${burst_id^^}
         burst_id_replace_underscores=${burst_id_uppercase//_/-}
         burst_id_pattern="*_${burst_id_replace_underscores}_*.h5"
-        output_file=$(ls "$output_dir"/"$burst_id_pattern")
+
+        # shellcheck disable=SC2086
+        output_file=$(ls $output_dir/$burst_id_pattern)
+
         echo "output file: $output_file"
         expected_file=${expected_dir}/${burst_id}/rtc_product_v0.2.h5
         compare_output=$(python3 "${local_compare_script}" "${expected_file}" "${output_file}")

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -55,8 +55,8 @@ aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/rtc_compare.py "$local_compare_scrip
 # 2 - product validation failure
 overall_status=0
 
-
 # There is only 1 expected output directory RTC-S1
+
 expected_dir="${TMP_DIR}/${EXPECTED_DATA%.*}/expected_output_dir"
 input_dir="${TMP_DIR}/${INPUT_DATA%.*}/input_data"
 runconfig_dir="${TMP_DIR}/runconfig"
@@ -81,17 +81,17 @@ fi
 echo "Creating scratch directory $scratch_dir."
 mkdir -p --mode=777 "scratch_dir"
 
-container_name="${PGE_NAME}-${data_set}"
+container_name="${PGE_NAME}"
 
 # Start metrics collection
 metrics_collection_start "$PGE_NAME" "$container_name" "$TEST_RESULTS_DIR" "$SAMPLE_TIME"
 
-echo "Running Docker image ${PGE_IMAGE}:${PGE_TAG} for ${input_data_dir}"
+echo "Running Docker image ${PGE_IMAGE}:${PGE_TAG} for ${input_dir}"
 docker run --rm -u $UID:"$(id -g)" -w /home/rtc_user --name $container_name \
-           -v "${TMP_DIR}/runconfig":/home/rtc_user/runconfig:ro \
-           -v "$input_data_dir"/:/home/rtc_user/input_dir:ro \
-           -v "$output_dir":/home/rtc_user/output_dir \
-           -v "$scratch_dir":/home/rtc_user/scratch_dir \
+           -v "${runconfig_dir}":/home/rtc_user/runconfig:ro \
+           -v "${input_dir}"/:/home/rtc_user/input_dir:ro \
+           -v "${output_dir}":/home/rtc_user/output_dir \
+           -v "${scratch_dir}":/home/rtc_user/scratch_dir \
            ${PGE_IMAGE}:"${PGE_TAG}" --file /home/rtc_user/runconfig/${RUNCONFIG}
 
 docker_exit_status=$?
@@ -141,7 +141,7 @@ else
         burst_id_pattern="*_${burst_id_replace_underscores}_*.nc"
         output_file=$(ls "$output_dir"/"$burst_id_pattern")
         echo "output file: $output_file"
-        expected_file=${expected_data_dir}/${burst_id}/rtc_product.nc
+        expected_file=${expected_dir}/${burst_id}/rtc_product.nc
         compare_output=$(python3 "${local_compare_script}" "${expected_file}" "${output_file}")
 
         echo "Results of compare: $compare_output"

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -58,7 +58,9 @@ overall_status=0
 # There is only 1 expected output directory RTC-S1
 
 expected_dir="${TMP_DIR}/${EXPECTED_DATA%.*}/expected_output_dir"
-input_dir="${TMP_DIR}/${INPUT_DATA%.*}/input_data"
+# Perhaps the unzipping accounts for the input_data directory?
+# input_dir="${TMP_DIR}/${INPUT_DATA%.*}/input_data"
+input_dir="${TMP_DIR}/${INPUT_DATA%.*}"
 runconfig_dir="${TMP_DIR}/runconfig"
 
 # the testdata reference metadata contains this path so we use it here

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -27,9 +27,10 @@ SAMPLE_TIME=15
 # RUNCONFIG should be the name of the runconfig in s3://operasds-dev-pge/${PGE_NAME}/
 [ -z "${WORKSPACE}" ] && WORKSPACE="$(realpath "$(dirname "$(realpath "$0")")"/../..)"
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
-[ -z "${INPUT_DATA}}" ] && INPUT_DADA="rtc_s1_delivery_2_beta_0.2_expected_input.zip"
+[ -z "${INPUT_DATA}" ] && INPUT_DADA="rtc_s1_delivery_2_beta_0.2_expected_input.zip"
 [ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="rtc_s1_delivery_2_beta_0.2_expected_output.zip"
 [ -z "${RUNCONFIG}" ] && RUNCONFIG="rtc_s1_delivery_2_beta_0.2_runconfig.yaml"
+[ -z "${TMP_ROOT}" ] && TMP_ROOT="$DEFAULT_TMP_ROOT"
 
 # Create a temporary directory to hold test data
 test_int_setup_data_tmp_directory
@@ -43,7 +44,7 @@ trap test_int_trap_cleanup EXIT
 # Pull in product compare script from S3.
 local_compare_script=${TMP_DIR}/rtc_compare.py
 echo "Downloading s3://operasds-dev-pge/${PGE_NAME}/rtc_compare.py to ${local_compare_script}"
-aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/rtc_compare.py "${local_compare_script}"
+aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/rtc_compare.py "$local_compare_script"
 
 # overall_status values and their meaning
 # 0 - pass
@@ -51,18 +52,19 @@ aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/rtc_compare.py "${local_compare_scri
 # 2 - product validation failure
 overall_status=0
 
-data_set = 'peru'
+# only one data set in rtc-s1 (peru)
+data_set='peru'
 input_data_basename=$(basename -- "$INPUT_DATA")
-input_data_dir="${TMP_DIR}/${input_data_basename%.*}/${data_set}/input_dir"
+input_data_dir="${TMP_DIR}/${input_data_basename%.*}/input_dir"
 
 expected_data_basename=$(basename -- "$EXPECTED_DATA")
-expected_data_dir="${TMP_DIR}/${expected_data_basename%.*}/${data_set}/expected_output_dir"
+expected_data_dir="${TMP_DIR}/${expected_data_basename%.*}/expected_output_dir"
 
 echo "Input data directory: ${input_data_dir}"
 echo "Expected data directory: ${expected_data_dir}"
 
 # the testdata reference metadata contains this path so we use it here
-output_dir="${TMP_DIR}/rtc_s1_output/${data_set}/output_dir"
+output_dir="${TMP_DIR}/rtc_s1_output/output_dir"
 
 # make sure no output directory already exists
 if [ -d "$output_dir" ]; then
@@ -74,7 +76,7 @@ echo "Creating output directory $output_dir."
 mkdir -p "$output_dir"
 
 # the testdata reference metadata contains this path so we use it here
-scratch_dir="${TMP_DIR}/scratch_rtc_s1/${data_set}/scratch_dir"
+scratch_dir="${TMP_DIR}/scratch_rtc_s1"
 # make sure no scratch directory already exists
 if [ -d "$scratch_dir" ]; then
     echo "Scratch directory $scratch_dir already exists (and should not). Removing directory..."

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -32,6 +32,9 @@ SAMPLE_TIME=15
 [ -z "${RUNCONFIG}" ] && RUNCONFIG="rtc_s1_delivery_2_beta_0.2_runconfig.yaml"
 [ -z "${TMP_ROOT}" ] && TMP_ROOT="$DEFAULT_TMP_ROOT"
 
+# Create the test output directory in the work space
+test_int_setup_results_directory
+
 # Create a temporary directory to hold test data
 test_int_setup_data_tmp_directory
 

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -20,7 +20,7 @@ Integration Testing RTC-S1 PGE docker image...
 PGE_NAME="rtc_s1"
 PGE_IMAGE="opera_pge/${PGE_NAME}"
 SAMPLE_TIME=15
-q
+
 # defaults, test data and runconfig files should be updated as-needed to use
 # the latest available as defaults for use with the Jenkins pipeline call
 # INPUT/OUTPUT_DATA should be the name of the test data archive in s3://operasds-dev-pge/${PGE_NAME}/

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -20,14 +20,14 @@ Integration Testing RTC-S1 PGE docker image...
 PGE_NAME="rtc_s1"
 PGE_IMAGE="opera_pge/${PGE_NAME}"
 SAMPLE_TIME=15
-
+q
 # defaults, test data and runconfig files should be updated as-needed to use
 # the latest available as defaults for use with the Jenkins pipeline call
 # INPUT/OUTPUT_DATA should be the name of the test data archive in s3://operasds-dev-pge/${PGE_NAME}/
 # RUNCONFIG should be the name of the runconfig in s3://operasds-dev-pge/${PGE_NAME}/
 [ -z "${WORKSPACE}" ] && WORKSPACE="$(realpath "$(dirname "$(realpath "$0")")"/../..)"
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
-[ -z "${INPUT_DATA}" ] && INPUT_DADA="rtc_s1_delivery_2_beta_0.2_expected_input.zip"
+[ -z "${INPUT_DATA}" ] && INPUT_DATA="rtc_s1_delivery_2_beta_0.2_expected_input.zip"
 [ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="rtc_s1_delivery_2_beta_0.2_expected_output.zip"
 [ -z "${RUNCONFIG}" ] && RUNCONFIG="rtc_s1_delivery_2_beta_0.2_runconfig.yaml"
 [ -z "${TMP_ROOT}" ] && TMP_ROOT="$DEFAULT_TMP_ROOT"

--- a/.ci/scripts/util.sh
+++ b/.ci/scripts/util.sh
@@ -209,8 +209,9 @@ metrics_collection_start()
 metrics_collection_end()
 {
     local pge=$1
-    local exit_code=$2
-    local results_dir=$3
+    local container=$2
+    local exit_code=$3
+    local results_dir=$4
 
     local metrics_stats="${results_dir}/${pge}_metrics_stats.csv"
     local metrics_misc="${results_dir}/${pge}_metrics_misc.csv"
@@ -228,7 +229,7 @@ metrics_collection_end()
 
     if [[ $exit_code == 0 ]]
     then
-        python3 "$SCRIPT_DIR"/process_metric_data.py "$pge" "$metrics_stats" "$metrics_misc" "$results_dir"
+        python3 "$SCRIPT_DIR"/process_metric_data.py "$pge" "$container" "$metrics_stats" "$metrics_misc" "$results_dir"
         process_metrics_exit_code=$?
 
         if [[ $process_metrics_exit_code == 0 ]]


### PR DESCRIPTION
## Description
- This branch refactors the test_int_rtc_s1.sh script to support separate inputs for the expected input and expected output archives. The custom temp directory root argument is also now supported by the script.
- process_metric_data.py has been updated to include a `container_name` argument within its output file name convention.

## Affected Issues
- Resolves #233 

## Testing
- Updates to test_int_rtc_s1.sh have been tested both directly on the OPERA PGE CI machine, as well as within the Jenkins int test pipeline.
