### PR TITLE
208 Integrate standalone DSWx HLS compare script into test pipeline

### DIFF
--- a/.ci/scripts/dswx_compare_opera_pge.py
+++ b/.ci/scripts/dswx_compare_opera_pge.py
@@ -198,7 +198,7 @@ def _compare_dswx_hls_metadata(metadata_1, metadata_2, metadata_exclude_list=[])
                 else:
                     msg = f'* (fail) {msg}'
                     flag_same_metadata = False
-                    metadata_compare_message += msg + '\n' + PREFIX
+                metadata_compare_message += msg + '\n' + PREFIX
 
     return metadata_compare_message, flag_same_metadata
 

--- a/.ci/scripts/test_int_dswx_hls.sh
+++ b/.ci/scripts/test_int_dswx_hls.sh
@@ -155,9 +155,10 @@ do
                     docker_out=$(docker run --rm -u conda:conda \
                                      -v "${output_dir}":/out:ro \
                                      -v "${expected_data_dir}":/exp:ro \
+                                     -v "$SCRIPT_DIR":/scripts \
                                      --entrypoint python3 ${PGE_IMAGE}:"${PGE_TAG}" \
-                                     proteus-1.0.1/bin/dswx_compare.py \
-                                     /out/"${output_file}" /exp/"${expected_file}")
+                                     /scripts/dswx_compare_opera_pge.py \
+                                     /out/"${output_file}" /exp/"${expected_file}" --metadata_exclude_list PRODUCT_VERSION)
                     echo "$docker_out"
 
                     if [[ "$docker_out" == *"[FAIL]"* ]]; then


### PR DESCRIPTION
## Description
- This code change enables the integration test pipeline to use the new standalone version of the DSWx HLS compare script, dswx_compare_opera_pge.py

## Affected Issues
- #208

## Testing
- .ci/scripts/test_int_dswx_hls.sh passes