### PR TITLE
281 DISP-S1 algorithm parameter schema validation

### DIFF
--- a/examples/disp_s1_sample_runconfig-v3.0.0-er.1.0.yaml
+++ b/examples/disp_s1_sample_runconfig-v3.0.0-er.1.0.yaml
@@ -34,6 +34,7 @@ RunConfig:
                     - --pge
                 ErrorCodeBase: 500000
                 SchemaPath: /home/mamba/opera/pge/disp_s1/schema/disp_s1_sas_schema.yaml
+                AlgorithmParametersSchemaPath: /home/mamba/opera/pge/disp_s1/schema/algor_param_s1_schema.yaml
                 IsoTemplatePath:
 
             QAExecutable:

--- a/src/opera/pge/base/runconfig.py
+++ b/src/opera/pge/base/runconfig.py
@@ -294,32 +294,25 @@ class RunConfig:
             )
 
     @property
-    def algorithm_parameters_config_path(self) -> str:
-        """Returns the path to the algorithm_parameter run configuration file for DSWX-S1"""
-        try:
-            algorithm_parameters_config_path = \
-                self._sas_config['runconfig']['groups']['dynamic_ancillary_file_group']['algorithm_parameters']
-            return (
-                algorithm_parameters_config_path
-                if isabs(algorithm_parameters_config_path)
-                else resource_filename('opera', algorithm_parameters_config_path)
-            )
-        except KeyError:
-            return None
-
-    @property
     def algorithm_parameters_file_config_path(self) -> str:
-        """Returns the path to the algorithm_parameter_file run configuration file for DISP-S1"""
+        """Returns the path to the algorithm parameters run configuration file"""
+        dynamic_ancillary_file_group = self._sas_config['runconfig']['groups']['dynamic_ancillary_file_group']
+
+        # ADT is inconsistent with how they define this location across different SAS,
+        # so check all known permutations
         try:
-            algorithm_parameters_file_config_path = \
-                self._sas_config['runconfig']['groups']['dynamic_ancillary_file_group']['algorithm_parameters_file']
-            return (
-                algorithm_parameters_file_config_path
-                if isabs(algorithm_parameters_file_config_path)
-                else resource_filename('opera', algorithm_parameters_file_config_path)
-            )
+            algorithm_parameters_file_config_path = dynamic_ancillary_file_group['algorithm_parameters_file']
         except KeyError:
-            return None
+            try:
+                algorithm_parameters_file_config_path = dynamic_ancillary_file_group['algorithm_parameters']
+            except KeyError:
+                return None
+
+        return (
+            algorithm_parameters_file_config_path
+            if isabs(algorithm_parameters_file_config_path)
+            else resource_filename('opera', algorithm_parameters_file_config_path)
+        )
 
     @property
     def iso_template_path(self) -> str:

--- a/src/opera/pge/base/runconfig.py
+++ b/src/opera/pge/base/runconfig.py
@@ -308,6 +308,20 @@ class RunConfig:
             return None
 
     @property
+    def algorithm_parameters_file_config_path(self) -> str:
+        """Returns the path to the algorithm_parameter_file run configuration file for DISP-S1"""
+        try:
+            algorithm_parameters_file_config_path = \
+                self._sas_config['runconfig']['groups']['dynamic_ancillary_file_group']['algorithm_parameters_file']
+            return (
+                algorithm_parameters_file_config_path
+                if isabs(algorithm_parameters_file_config_path)
+                else resource_filename('opera', algorithm_parameters_file_config_path)
+            )
+        except KeyError:
+            return None
+
+    @property
     def iso_template_path(self) -> str:
         """Returns the ISO Template Path for a Primary Executable"""
         iso_template_path = self._pge_config['PrimaryExecutable']['IsoTemplatePath']

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -11,6 +11,7 @@ from Sentinel-1 A/B (S1-A/B) data.
 from opera.pge.base.base_pge import PgeExecutor
 from opera.pge.base.base_pge import PostProcessorMixin
 from opera.pge.base.base_pge import PreProcessorMixin
+from opera.util.input_validation import validate_algorithm_parameters_config
 
 
 class DispS1PreProcessorMixin(PreProcessorMixin):
@@ -41,6 +42,12 @@ class DispS1PreProcessorMixin(PreProcessorMixin):
 
         """
         super().run_preprocessor(**kwargs)
+
+        self.algorithm_parameters_runconfig = self.runconfig.algorithm_parameters_file_config_path
+        validate_algorithm_parameters_config(self.name,
+                                             self.runconfig.algorithm_parameters_schema_path,
+                                             self.runconfig.algorithm_parameters_file_config_path,
+                                             self.logger)
 
 
 class DispS1PostProcessorMixin(PostProcessorMixin):

--- a/src/opera/pge/disp_s1/schema/algor_param_disp_s1_schema.yaml
+++ b/src/opera/pge/disp_s1/schema/algor_param_disp_s1_schema.yaml
@@ -19,11 +19,11 @@ runconfig:
             # For single-reference network: Index of the reference image in the network.
             reference_idx: int()
             # Max `n` to form the nearest-`n` interferograms by index.
-            max_bandwidth: int()
+            max_bandwidth: any(int(), null())
             # Maximum temporal baseline of interferograms.
-            max_temporal_baseline: int()
+            max_temporal_baseline: any(int(), null())
             # For manual-index network: List of (ref_idx, sec_idx) defining the interferograms to form.
-            indexes: list()
+            indexes: list(list())
             # Type of interferogram network to create from phase-linking results.
             # Options: ['single-reference', 'manual-index', 'max-bandwidth', 'max-temporal-baseline'].
             network_type: enum('single-reference', 'manual-index', 'max-bandwidth', 'max-temporal-baseline')
@@ -39,15 +39,11 @@ runconfig:
             init_method: str()
         output_options:
             # Output (x, y) resolution (in units of input data).
-            output_resolution:
-                x: int(required=False)
-                y: int(required=False)
+            output_resolution: any(include('x_y_object'), null())
             # Alternative to specifying output resolution: Specify the (x, y) strides (decimation
             #   factor) to perform while processing input. For example, strides of [4, 2] would turn an
             #   input resolution of [5, 10] into an output resolution of [20, 20].
-            strides:
-                x: int(required=False)
-                y: int(required=False)
+            strides: any(include('x_y_object'), null())
             # Options for `create_dataset` with h5py.
             hdf5_creation_options:
                 chunks: list()
@@ -58,3 +54,7 @@ runconfig:
             gtiff_creation_options: list()
         # Name of the subdataset to use in the input NetCDF files.
         subdataset: str()
+---
+x_y_object:
+    x: int()
+    y: int()

--- a/src/opera/pge/dswx_s1/dswx_s1_pge.py
+++ b/src/opera/pge/dswx_s1/dswx_s1_pge.py
@@ -8,15 +8,15 @@ Module defining the implementation for the Dynamic Surface Water Extent (DSWx)
 from Sentinel-1 A/B (S1) PGE.
 """
 
-from os.path import abspath, exists, isfile, splitext
+from os.path import abspath, exists, splitext
 
-import yamale
 
 import opera.util.input_validation as input_validation
 from opera.pge.base.base_pge import PgeExecutor
 from opera.pge.base.base_pge import PostProcessorMixin
 from opera.pge.base.base_pge import PreProcessorMixin
 from opera.util.error_codes import ErrorCode
+from opera.util.input_validation import validate_algorithm_parameters_config
 from opera.util.input_validation import validate_dswx_inputs
 
 
@@ -33,49 +33,6 @@ class DSWxS1PreProcessorMixin(PreProcessorMixin):
     """
 
     _pre_mixin_name = "DSWxS1PreProcessorMixin"
-
-    def _validate_algorithm_parameters_config(self):
-        """
-        The DSWx-S1 interface SAS uses two runconfig files; one for the main SAS,
-        and another for algorithm parameters.  This allows for independent modification
-        of algorithm parameters within it's own runconfig file. This method performs validation
-        of the 'algorithm parameters' runconfig file against its associated schema file. The SAS
-        section of the main runconfig defines the location within the container of the 'algorithm
-        parameters' runconfig file, under ['dynamic_ancillary_file_group']['algorithm_parameters'].
-        The schema file for the 'algorithm parameters' runconfig file is referenced under
-        ['PrimaryExecutable']['AlgorithmParametersSchemaPath'] in the PGE section of the runconfig file.
-        For compatibility with the other PGE 'AlgorithmParametersSchemaPath' is optional.
-
-        """
-        # Get the path to the optional 'algorithm_parameters_s1.schema.yaml' file
-        algorithm_parameters_schema_file_path = self.runconfig.algorithm_parameters_schema_path
-        #  If it was decided not to provide a path to the schema file, validation is impossible.
-        if algorithm_parameters_schema_file_path is None:
-            error_msg = "No algorithm_parameters_schema_path provided in runconfig file."
-            self.logger.info(self.name, ErrorCode.NO_ALGO_PARAM_SCHEMA_PATH, error_msg)
-            return
-        elif isfile(algorithm_parameters_schema_file_path):
-            # Load the 'algorithm parameters' schema
-            algorithm_parameters_schema = yamale.make_schema(algorithm_parameters_schema_file_path)
-        else:
-            raise RuntimeError(
-                f'Schema error: Could not validate algorithm_parameters schema file.  '
-                f'File: ({algorithm_parameters_schema_file_path}) not found.'
-            )
-
-        # Get the 'algorithm parameters' runconfig file
-        self.algorithm_parameters_runconfig = self.runconfig.algorithm_parameters_config_path
-        if isfile(self.algorithm_parameters_runconfig):
-            # Load the 'algorithm parameters' runconfig file
-            algorithm_parameters_config_data = yamale.make_data(self.algorithm_parameters_runconfig)
-        else:
-            raise RuntimeError(
-                f'Can not validate algorithm_parameters config file.  '
-                f'File: {self.algorithm_parameters_runconfig} not found.'
-            )
-
-        # Validate the algorithm parameter Runconfig against its schema file
-        yamale.validate(algorithm_parameters_schema, algorithm_parameters_config_data, strict=True)
 
     def _validate_ancillary_inputs(self):
         """
@@ -139,7 +96,11 @@ class DSWxS1PreProcessorMixin(PreProcessorMixin):
         validate_dswx_inputs(
             self.runconfig, self.logger, self.runconfig.pge_name, valid_extensions=(".tif", ".h5")
         )
-        self._validate_algorithm_parameters_config()
+        self.algorithm_parameters_runconfig = self.runconfig.algorithm_parameters_config_path
+        validate_algorithm_parameters_config(self.name,
+                                             self.runconfig.algorithm_parameters_schema_path,
+                                             self.runconfig.algorithm_parameters_config_path,
+                                             self.logger)
         self._validate_ancillary_inputs()
 
 

--- a/src/opera/pge/dswx_s1/dswx_s1_pge.py
+++ b/src/opera/pge/dswx_s1/dswx_s1_pge.py
@@ -96,10 +96,10 @@ class DSWxS1PreProcessorMixin(PreProcessorMixin):
         validate_dswx_inputs(
             self.runconfig, self.logger, self.runconfig.pge_name, valid_extensions=(".tif", ".h5")
         )
-        self.algorithm_parameters_runconfig = self.runconfig.algorithm_parameters_config_path
+        self.algorithm_parameters_runconfig = self.runconfig.algorithm_parameters_file_config_path
         validate_algorithm_parameters_config(self.name,
                                              self.runconfig.algorithm_parameters_schema_path,
-                                             self.runconfig.algorithm_parameters_config_path,
+                                             self.runconfig.algorithm_parameters_file_config_path,
                                              self.logger)
         self._validate_ancillary_inputs()
 

--- a/src/opera/test/data/test_disp_s1_algorithm_parameters.yaml
+++ b/src/opera/test/data/test_disp_s1_algorithm_parameters.yaml
@@ -1,0 +1,89 @@
+runconfig:
+    name: disp_s1_workflow_algorithm
+
+    processing:
+        ps_options:
+          # Amplitude dispersion threshold to consider a pixel a PS.
+          #   Type: number.
+          amp_dispersion_threshold: 0.25
+        phase_linking:
+          # Size of the ministack for sequential estimator.
+          #   Type: integer.
+          ministack_size: 1000
+          # Beta regularization parameter for correlation matrix inversion. 0 is no regularization.
+          #   Type: number.
+          beta: 0.01
+          half_window:
+            # Half window size (in pixels) for x direction.
+            #   Type: integer.
+            x: 11
+            # Half window size (in pixels) for y direction.
+            #   Type: integer.
+            y: 5
+        interferogram_network:
+          # For single-reference network: Index of the reference image in the network.
+          #   Type: integer.
+          reference_idx: 0
+          # Max `n` to form the nearest-`n` interferograms by index.
+          #   Type: integer.
+          max_bandwidth:
+          # Maximum temporal baseline of interferograms.
+          #   Type: integer.
+          max_temporal_baseline:
+          # For manual-index network: List of (ref_idx, sec_idx) defining the interferograms to form.
+          #   Type: array.
+          indexes:
+          - - 0
+            - -1
+          # Type of interferogram network to create from phase-linking results.
+          #   Type: string.
+          #   Options: ['single-reference', 'manual-index', 'max-bandwidth', 'max-temporal-baseline'].
+          network_type: single-reference
+        unwrap_options:
+          # Whether to run the unwrapping step after wrapped phase estimation.
+          #   Type: boolean.
+          run_unwrap: true
+          # Phase unwrapping method, passable to Tophu.
+          #   Type: string.
+          #   Options: ['snaphu', 'icu'].
+          unwrap_method: icu
+          # Number of tiles to split the unwrapping into (for Tophu).
+          #   Type: array.
+          tiles:
+          - 1
+          - 1
+          # Initialization method for SNAPHU.
+          #   Type: string.
+          init_method: mcf
+        output_options:
+          # Output (x, y) resolution (in units of input data).
+          #   Type: object.
+          output_resolution:
+          # Alternative to specifying output resolution: Specify the (x, y) strides (decimation
+          #   factor) to perform while processing input. For example, strides of [4, 2] would turn an
+          #   input resolution of [5, 10] into an output resolution of [20, 20].
+          #   Type: object.
+          strides:
+            x: 6
+            y: 3
+          # Options for `create_dataset` with h5py.
+          #   Type: object.
+          hdf5_creation_options:
+            chunks:
+            - 128
+            - 128
+            compression: gzip
+            compression_opts: 4
+            shuffle: true
+          # GDAL creation options for GeoTIFF files.
+          #   Type: array.
+          gtiff_creation_options:
+          - COMPRESS=DEFLATE
+          - ZLEVEL=4
+          - TILED=YES
+          - BLOCKXSIZE=128
+          - BLOCKYSIZE=128
+        # Name of the subdataset to use in the input NetCDF files.
+        #   Type: string.
+        subdataset: science/SENTINEL1/CSLC/grids/VV
+        

--- a/src/opera/test/data/test_disp_s1_config.yaml
+++ b/src/opera/test/data/test_disp_s1_config.yaml
@@ -27,6 +27,7 @@ RunConfig:
                     - '/bin/echo DISP-S1 invoked with RunConfig'
                 ErrorCodeBase: 500000
                 SchemaPath: pge/disp_s1/schema/disp_s1_sas_schema.yaml
+                AlgorithmParametersSchemaPath: pge/disp_s1/schema/algor_param_disp_s1_schema.yaml
                 IsoTemplatePath:
 
             QAExecutable:
@@ -56,7 +57,7 @@ RunConfig:
 
                     dynamic_ancillary_file_group:
                         # Path to file containing SAS algorithm parameters.
-                        algorithm_parameters_file: algorithm_parameters.yaml
+                        algorithm_parameters_file: test/data/test_disp_s1_algorithm_parameters.yaml
 
                         # Paths to existing Amplitude Dispersion files (1 per burst) for PS update calculation. If
                         # none provided, computed using the input SLC stack.

--- a/src/opera/test/pge/disp_s1/test_disp_s1_pge.py
+++ b/src/opera/test/pge/disp_s1/test_disp_s1_pge.py
@@ -11,8 +11,9 @@ import glob
 import os
 import tempfile
 import unittest
+import yaml
 from io import StringIO
-from os.path import abspath, join
+from os.path import abspath, join, exists
 
 from pkg_resources import resource_filename
 
@@ -66,6 +67,37 @@ class DispS1PgeTestCase(unittest.TestCase):
         self.input_file.close()
         self.working_dir.cleanup()
 
+    def _compare_algorithm_parameters_runconfig_to_expected(self, runconfig):
+        """
+        Helper method to check the properties of a parsed algorithm parameters runconfig against the
+        expected values as defined by the "valid" sample algorithm parameters runconfig files.
+        """
+        self.assertEqual(runconfig['name'], 'disp_s1_workflow_algorithm')
+        self.assertEqual(runconfig['processing']['ps_options']['amp_dispersion_threshold'], 0.25)
+        self.assertEqual(runconfig['processing']['phase_linking']['ministack_size'], 1000)
+        self.assertEqual(runconfig['processing']['phase_linking']['beta'], 0.01)
+        self.assertEqual(runconfig['processing']['phase_linking']['half_window']['x'], 11)
+        self.assertEqual(runconfig['processing']['phase_linking']['half_window']['y'], 5)
+        self.assertEqual(runconfig['processing']['interferogram_network']['reference_idx'], 0)
+        self.assertEqual(runconfig['processing']['interferogram_network']['max_bandwidth'], None)
+        self.assertEqual(runconfig['processing']['interferogram_network']['max_temporal_baseline'], None)
+        self.assertEqual(runconfig['processing']['interferogram_network']['indexes'], [[0, -1]])
+        self.assertEqual(runconfig['processing']['interferogram_network']['network_type'], 'single-reference')
+        self.assertEqual(runconfig['processing']['unwrap_options']['run_unwrap'], True)
+        self.assertEqual(runconfig['processing']['unwrap_options']['unwrap_method'], 'icu')
+        self.assertEqual(runconfig['processing']['unwrap_options']['tiles'], [1, 1])
+        self.assertEqual(runconfig['processing']['unwrap_options']['init_method'], 'mcf')
+        self.assertEqual(runconfig['processing']['output_options']['output_resolution'], None)
+        self.assertEqual(runconfig['processing']['output_options']['strides']['x'], 6)
+        self.assertEqual(runconfig['processing']['output_options']['strides']['y'], 3)
+        self.assertEqual(runconfig['processing']['output_options']['hdf5_creation_options']['chunks'], [128, 128])
+        self.assertEqual(runconfig['processing']['output_options']['hdf5_creation_options']['compression'], 'gzip')
+        self.assertEqual(runconfig['processing']['output_options']['hdf5_creation_options']['compression_opts'], 4)
+        self.assertEqual(runconfig['processing']['output_options']['hdf5_creation_options']['shuffle'], True)
+        self.assertEqual(runconfig['processing']['output_options']['gtiff_creation_options'],
+                         ['COMPRESS=DEFLATE', 'ZLEVEL=4', 'TILED=YES', 'BLOCKXSIZE=128', 'BLOCKYSIZE=128'])
+        self.assertEqual(runconfig['processing']['subdataset'], 'science/SENTINEL1/CSLC/grids/VV')
+
     def test_disp_s1_pge_execution(self):
         """
         Test execution of the DispS1Executor class and its associated mixins
@@ -118,6 +150,104 @@ class DispS1PgeTestCase(unittest.TestCase):
 
         self.assertIn(f"DISP-S1 invoked with RunConfig {expected_sas_config_file}", log_contents)
 
+    def test_disp_s1_pge_validate_algorithm_parameters_config(self):
+        """Test basic parsing and validation of an algorithm parameters RunConfig file"""
+        runconfig_path = join(self.data_dir, 'test_disp_s1_config.yaml')
+
+        self.runconfig = RunConfig(runconfig_path)
+
+        algorithm_parameters_runconfig_file = self.runconfig.algorithm_parameters_file_config_path
+
+        pge = DispS1Executor(pge_name="DispS1PgeTest", runconfig_path=runconfig_path)
+
+        # Kickoff execution of DISP-S1 PGE
+        pge.run()
+
+        self.assertEqual(algorithm_parameters_runconfig_file, pge.algorithm_parameters_runconfig)
+        # parse the run config file
+        runconfig_dict = self.runconfig._parse_algorithm_parameters_run_config_file(pge.algorithm_parameters_runconfig)
+        # Check the properties of the algorithm parameters RunConfig to ensure they match as expected
+        self._compare_algorithm_parameters_runconfig_to_expected(runconfig_dict)
+
+    def test_disp_s1_pge_bad_algorithm_parameters_schema_path(self):
+        """
+        Test for invalid path in the optional 'AlgorithmParametersSchemaPath'
+        section of in the PGE runconfig file.
+        section of the runconfig file.  Also test for no AlgorithmParametersSchemaPath
+        """
+        runconfig_path = join(self.data_dir, 'test_disp_s1_config.yaml')
+        test_runconfig_path = join(self.data_dir, 'invalid_disp_s1_config.yaml')
+
+        with open(runconfig_path, 'r', encoding='utf-8') as infile:
+            runconfig_dict = yaml.safe_load(infile)
+
+        runconfig_dict['RunConfig']['Groups']['PGE']['PrimaryExecutable']['AlgorithmParametersSchemaPath'] = \
+                       'test/data/test_algorithm_parameters_non_existent.yaml'  # noqa E211
+
+        with open(test_runconfig_path, 'w', encoding='utf-8') as outfile:
+            yaml.safe_dump(runconfig_dict, outfile, sort_keys=False)
+
+        try:
+            pge = DispS1Executor(pge_name="DispS1PgeTest", runconfig_path=test_runconfig_path)
+
+            with self.assertRaises(RuntimeError):
+                pge.run()
+
+        finally:
+            if exists(test_runconfig_path):
+                os.unlink(test_runconfig_path)
+
+        # Verify that None is returned if 'AlgorithmParametersSchemaPath' is None
+        with open(runconfig_path, 'r', encoding='utf-8') as infile:
+            runconfig_dict = yaml.safe_load(infile)
+
+        runconfig_dict['RunConfig']['Groups']['PGE']['PrimaryExecutable']['AlgorithmParametersSchemaPath'] = None
+
+        with open(test_runconfig_path, 'w', encoding='utf-8') as outfile:
+            yaml.safe_dump(runconfig_dict, outfile, sort_keys=False)
+
+        try:
+            pge = DispS1Executor(pge_name="DispS1PgeTest", runconfig_path=test_runconfig_path)
+
+            pge.run()
+
+            # Check that the log file was created and moved into the output directory
+            expected_log_file = pge.logger.get_file_name()
+            self.assertTrue(exists(expected_log_file))
+
+            # Open and read the log
+            with open(expected_log_file, 'r', encoding='utf-8') as infile:
+                log_contents = infile.read()
+
+            self.assertIn("No algorithm_parameters_schema_path provided in runconfig file", log_contents)
+
+        finally:
+            if exists(test_runconfig_path):
+                os.unlink(test_runconfig_path)
+
+    def test_disp_s1_pge_bad_algorithm_parameters_path(self):
+        """Test for invalid path to 'algorithm_parameters_file' in SAS runconfig file"""
+        runconfig_path = join(self.data_dir, 'test_disp_s1_config.yaml')
+        test_runconfig_path = join(self.data_dir, 'invalid_disp_s1_config.yaml')
+
+        with open(runconfig_path, 'r', encoding='utf-8') as infile:
+            runconfig_dict = yaml.safe_load(infile)
+
+        runconfig_dict['RunConfig']['Groups']['SAS']['runconfig']['groups']['dynamic_ancillary_file_group']\
+                      ['algorithm_parameters_file'] = 'test/data/test_algorithm_parameters_non_existent.yaml' # noqa E211
+
+        with open(test_runconfig_path, 'w', encoding='utf-8') as outfile:
+            yaml.safe_dump(runconfig_dict, outfile, sort_keys=False)
+
+        try:
+            pge = DispS1Executor(pge_name="DispS1PgeTest", runconfig_path=test_runconfig_path)
+
+            with self.assertRaises(RuntimeError):
+                pge.run()
+
+        finally:
+            if exists(test_runconfig_path):
+                os.unlink(test_runconfig_path)
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/opera/test/pge/dswx_s1/test_dswx_s1_pge.py
+++ b/src/opera/test/pge/dswx_s1/test_dswx_s1_pge.py
@@ -219,7 +219,7 @@ class DswxS1PgeTestCase(unittest.TestCase):
 
         self.runconfig = RunConfig(runconfig_path)
 
-        algorithm_parameters_runconfig = self.runconfig.algorithm_parameters_config_path
+        algorithm_parameters_runconfig = self.runconfig.algorithm_parameters_file_config_path
 
         pge = DSWxS1Executor(pge_name="DswxS1PgeTest", runconfig_path=runconfig_path)
 

--- a/src/opera/util/metadata_utils.py
+++ b/src/opera/util/metadata_utils.py
@@ -403,8 +403,9 @@ def get_cslc_s1_product_metadata(file_name):
         'identification': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/identification"),
         'grids': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/CSLC/grids"),
         'corrections': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/CSLC/corrections"),
-        'calibration_information': get_hdf5_group_as_dict(file_name,
-                                                          f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/calibration_information"),
+        'calibration_information':
+            get_hdf5_group_as_dict(file_name,
+                                   f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/calibration_information"),
         'noise_information': get_hdf5_group_as_dict(file_name,
                                                     f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/noise_information"),
         'processing_information': get_hdf5_group_as_dict(file_name,
@@ -460,13 +461,16 @@ def create_test_cslc_metadata_product(file_path):
         zero_doppler_time_spacing_dset = corrections_grp.create_dataset("zero_doppler_time_spacing",
                                                                         data=0.027999999991152436, dtype='float64')
 
-        calibration_information_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/calibration_information")
-        cal_basename_dset = calibration_information_grp.create_dataset("basename",
-                                                                       data=np.string_('calibration-s1a-iw1-slc-vv-20220501t015035-20220501t015102-043011-0522a4-004.xml'))
+        calibration_information_grp = outfile.create_group(
+            f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/calibration_information")
+        cal_basename_dset = calibration_information_grp.create_dataset(
+            "basename",
+            data=np.string_('calibration-s1a-iw1-slc-vv-20220501t015035-20220501t015102-043011-0522a4-004.xml'))
 
         noise_information_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/noise_information")
-        noise_basename_dset = noise_information_grp.create_dataset("basename",
-                                                                   data=np.string_('noise-s1a-iw1-slc-vv-20220501t015035-20220501t015102-043011-0522a4-004.xml'))
+        noise_basename_dset = noise_information_grp.create_dataset(
+            "basename",
+            data=np.string_('noise-s1a-iw1-slc-vv-20220501t015035-20220501t015102-043011-0522a4-004.xml'))
 
         processing_information_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/processing_information")
         algorithms_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/processing_information/algorithms")


### PR DESCRIPTION
## Description
- Updated example/test RunConfigs for DISP-S1 to include the new AlgorithmParametersSchemaPath field within the PrimaryExecutable section. This field should be set to the path to the algorithim parameters yamale schema for DISP-S1
- The existing _validate_algorithm_parameters_config() that was written for the DSWx-S1 pre-processor should also be sufficient for DISP-S1 (or any other PGE with an algo params config going forward), so the task should be to refactor this function into a utility within input_validation.py, then update both R3 PGE's to call the function in their respective pre-processors.
- Add unit tests to the DISP-S1 suite for valid/invalid validation

## Affected Issues
- #281 
- 
## Testing
- Added unit tests
