### PR TITLE
HLS Bounding Box Anti-meridian fix

### DIFF
--- a/src/opera/test/util/test_metadata_utils.py
+++ b/src/opera/test/util/test_metadata_utils.py
@@ -42,25 +42,35 @@ class MetadataUtilsTestCase(unittest.TestCase):
         """Reproduce ADT results from values provided with code"""
         lat_min, lat_max, lon_min, lon_max = get_geographic_boundaries_from_mgrs_tile('15SXR')
 
-        self.assertAlmostEqual(lat_min, 31.616027943130398)
-        self.assertAlmostEqual(lat_max, 32.6212369766609)
-        self.assertAlmostEqual(lon_min, -91.94552881416524)
-        self.assertAlmostEqual(lon_max, -90.76425651871281)
+        self.assertAlmostEqual(lat_min, 31.572733739486036)
+        self.assertAlmostEqual(lat_max, 32.577473659397235)
+        self.assertAlmostEqual(lon_min, -91.99766472766642)
+        self.assertAlmostEqual(lon_max, -90.81751155385777)
 
     @skipIf(not osr_is_available(), reason="osgeo.osr is not installed on the local instance")
     def test_get_geographic_boundaries_from_mgrs_tile_leading_T(self):
         """Test MGRS tile code conversion when code starts with T"""
         lat_min, lat_max, lon_min, lon_max = get_geographic_boundaries_from_mgrs_tile('T15SXR')
 
-        self.assertAlmostEqual(lat_min, 31.616027943130398)
-        self.assertAlmostEqual(lat_max, 32.6212369766609)
-        self.assertAlmostEqual(lon_min, -91.94552881416524)
-        self.assertAlmostEqual(lon_max, -90.76425651871281)
+        self.assertAlmostEqual(lat_min, 31.572733739486036)
+        self.assertAlmostEqual(lat_max, 32.577473659397235)
+        self.assertAlmostEqual(lon_min, -91.99766472766642)
+        self.assertAlmostEqual(lon_max, -90.81751155385777)
 
     @skipIf(not osr_is_available(), reason="osgeo.osr is not installed on the local instance")
     def test_get_geographic_boundaries_from_mgrs_tile_invalid_tile(self):
         """Test MGRS tile code conversion with an invalid code"""
         self.assertRaises(RuntimeError, get_geographic_boundaries_from_mgrs_tile, 'X15SXR')
+
+    @skipIf(not osr_is_available(), reason="osgeo.osr is not installed on the local instance")
+    def test_get_geographic_boundaries_from_mgrs_tile_nominal_antimeridian(self):
+        """Test MGRS tile code conversion with a tile that crosses the anti-meridian"""
+        lat_min, lat_max, lon_min, lon_max = get_geographic_boundaries_from_mgrs_tile('T60VXQ')
+
+        self.assertAlmostEqual(lat_min, 62.13198085489144)
+        self.assertAlmostEqual(lat_max, 63.16076767648831)
+        self.assertAlmostEqual(lon_min, 178.82637550795243)
+        self.assertAlmostEqual(lon_max, -179.06925552951074)
 
     def test_get_rtc_s1_product_metadata(self):
         """Test retrieval of product metadata from HDF5 files"""

--- a/src/opera/test/util/test_metadata_utils.py
+++ b/src/opera/test/util/test_metadata_utils.py
@@ -70,7 +70,7 @@ class MetadataUtilsTestCase(unittest.TestCase):
         self.assertAlmostEqual(lat_min, 62.13198085489144)
         self.assertAlmostEqual(lat_max, 63.16076767648831)
         self.assertAlmostEqual(lon_min, 178.82637550795243)
-        self.assertAlmostEqual(lon_max, -179.06925552951074)
+        self.assertAlmostEqual(lon_max, -178.93677941363356)
 
     def test_get_rtc_s1_product_metadata(self):
         """Test retrieval of product metadata from HDF5 files"""

--- a/src/opera/util/metadata_utils.py
+++ b/src/opera/util/metadata_utils.py
@@ -207,29 +207,15 @@ def get_geographic_boundaries_from_mgrs_tile(mgrs_tile_name):
             # The computation of min and max longitude values may be affected
             # by antimeridian crossing. Notice that: 179 degrees +
             # 2 degrees = -179 degrees
-            #
-            # The condition `abs(lon_min - lon) < 180`` tests if both longitude
-            # values are both at the same side of the dateline (either left
-            # or right).
-            #
-            # The conditions `> 100` and `< 100` are used to test if the
-            # longitude point is on the left side of the antimeridian crossing
-            # (`> 100`) or at the right side (`< 100`)
-            #
+
             # We also want to check if the point is at the west or east side of the tile.
             # Points at the west, i.e, where offset_x_multiplier == 0 may update `lon_min`
-            if (offset_x_multiplier == 0 and
-                    (lon_min is None or
-                     (abs(lon_min - lon) < 180 and lon_min > lon) or
-                     (lon > 100 and lon_min < -100))):
+            if (offset_x_multiplier == 0) and (lon_min is None or lon_min > lon):
                 lon_min = lon
 
             # Points at the east, i.e, where offset_x_multiplier == 1
             # may update `lon_max`
-            if (offset_x_multiplier == 1 and
-                    (lon_max is None or
-                     (abs(lon_min - lon) < 180 and lon_max < lon) or
-                     (lon < -100 and lon_max > 100))):
+            if (offset_x_multiplier == 1) and (lon_max is None or lon_max < lon):
                 lon_max = lon
 
     return lat_min, lat_max, lon_min, lon_max

--- a/src/opera/util/metadata_utils.py
+++ b/src/opera/util/metadata_utils.py
@@ -172,8 +172,9 @@ def get_geographic_boundaries_from_mgrs_tile(mgrs_tile_name):
     wgs84_coordinate_system.SetWellKnownGeogCS("WGS84")
 
     # create transformation of coordinates from UTM to geographic (lat/lon)
-    transformation = osr.CoordinateTransformation(utm_coordinate_system,
-                                                  wgs84_coordinate_system)
+    transformation = osr.CoordinateTransformation(
+        utm_coordinate_system, wgs84_coordinate_system
+    )
 
     # compute boundaries
     elevation = 0
@@ -185,17 +186,50 @@ def get_geographic_boundaries_from_mgrs_tile(mgrs_tile_name):
     for offset_x_multiplier in range(2):
         for offset_y_multiplier in range(2):
 
-            x = x_min + offset_x_multiplier * 109.8 * 1000
-            y = y_min + offset_y_multiplier * 109.8 * 1000
+            # We are using MGRS 100km x 100km tiles
+            # HLS tiles have 4.9 km of margin => width/length = 109.8 km
+            x = x_min - 4.9 * 1000 + offset_x_multiplier * 109.8 * 1000
+            y = y_min - 4.9 * 1000 + offset_y_multiplier * 109.8 * 1000
+
             lat, lon, z = transformation.TransformPoint(x, y, elevation)
+
+            # wrap longitude values within the range [-180, +180]
+            if lon < -180:
+                lon += 360
+            elif lon > 180:
+                lon -= 360
 
             if lat_min is None or lat_min > lat:
                 lat_min = lat
             if lat_max is None or lat_max < lat:
                 lat_max = lat
-            if lon_min is None or lon_min > lon:
+
+            # The computation of min and max longitude values may be affected
+            # by antimeridian crossing. Notice that: 179 degrees +
+            # 2 degrees = -179 degrees
+            #
+            # The condition `abs(lon_min - lon) < 180`` tests if both longitude
+            # values are both at the same side of the dateline (either left
+            # or right).
+            #
+            # The conditions `> 100` and `< 100` are used to test if the
+            # longitude point is on the left side of the antimeridian crossing
+            # (`> 100`) or at the right side (`< 100`)
+            #
+            # We also want to check if the point is at the west or east side of the tile.
+            # Points at the west, i.e, where offset_x_multiplier == 0 may update `lon_min`
+            if (offset_x_multiplier == 0 and
+                    (lon_min is None or
+                     (abs(lon_min - lon) < 180 and lon_min > lon) or
+                     (lon > 100 and lon_min < -100))):
                 lon_min = lon
-            if lon_max is None or lon_max < lon:
+
+            # Points at the east, i.e, where offset_x_multiplier == 1
+            # may update `lon_max`
+            if (offset_x_multiplier == 1 and
+                    (lon_max is None or
+                     (abs(lon_min - lon) < 180 and lon_max < lon) or
+                     (lon < -100 and lon_max > 100))):
                 lon_max = lon
 
     return lat_min, lat_max, lon_min, lon_max


### PR DESCRIPTION
## Description
- This branch addresses an issue in the`metadata_utils.get_geographic_boundaries_from_mgrs_tile` function for tiles that crossed the anti-meridian. The function has been updated with fixes that were applied to the PCM version of the function, which were originally provided by Gustavo Shiroma.

## Affected Issues
- Fixes #291 

## Testing
- The following unit test has been added to validate that the anti-meridian case is now handled correctly:

```python
    def test_get_geographic_boundaries_from_mgrs_tile_nominal_antimeridian(self):
        """Test MGRS tile code conversion with a tile that crosses the anti-meridian"""
        lat_min, lat_max, lon_min, lon_max = get_geographic_boundaries_from_mgrs_tile('T60VXQ')

        self.assertAlmostEqual(lat_min, 62.13198085489144)
        self.assertAlmostEqual(lat_max, 63.16076767648831)
        self.assertAlmostEqual(lon_min, 178.82637550795243)
        self.assertAlmostEqual(lon_max, -179.06925552951074)
```

Note that the lat/lon values differ slightly from the test case provided in the original bug report. This is because as part of this fix, 4.9km of margin is now added to the bounding box footprint to bring it in line with the HLS standard.
