### PR TITLE
R2 SAS CalVal Release Integration

### DIFF
--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -35,6 +35,27 @@ pipeline {
                 }
             }
         }
+        stage('Install local conda env') {
+            steps {
+                script {
+                    echo "Creating conda env"
+                    sh label: 'Installing int test conda environment',
+                       script: '''#!/bin/bash
+                         /usr/local/anaconda3/bin/conda create -n int_test_env python=3.9 pip
+                         /usr/local/anaconda3/bin/conda init bash
+                    '''
+
+                    sh label: 'Installing dependencies to int test conda environment',
+                       script: '''#!/bin/bash
+                       . /var/lib/jenkins/.bashrc
+                       conda activate int_test_env
+                       pip install -r ./requirements.txt
+                       conda uninstall -q poppler
+                       conda install -c conda-forge gdal poppler h5py matplotlib pandas numpy
+                       '''
+                }
+            }
+        }
         stage('Integration Test OPERA PGE Docker image(s)') {
             steps {
                 script {
@@ -45,7 +66,11 @@ pipeline {
                         echo "Integration testing Docker image ${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_SUFFIX}:${DOCKER_TAG}"
 
                         def statusCode = sh label: "Running Integration Test for image ${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_SUFFIX}:${DOCKER_TAG}", returnStatus:true,
-                           script: ".ci/scripts/test_int_${DOCKER_IMAGE_SUFFIX}.sh --tag ${DOCKER_TAG}"
+                           script: """#!/bin/bash
+                           . /var/lib/jenkins/.bashrc
+                           conda activate int_test_env
+                           .ci/scripts/test_int_${DOCKER_IMAGE_SUFFIX}.sh --tag ${DOCKER_TAG}
+                           """
 
                         echo "Test returned code ${statusCode}"
 
@@ -84,6 +109,9 @@ pipeline {
         always {
             echo "Cleaning up Docker images from local host"
             sh ".ci/scripts/cleanup.sh ${DOCKER_TAG}"
+            echo "Removing int test conda environment"
+            sh "/usr/local/anaconda3/bin/conda env remove --name int_test_env"
+            sh "/usr/local/anaconda3/bin/conda init --reverse"
             deleteDir()
         }
         success {

--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -76,6 +76,7 @@ pipeline {
                 archiveArtifacts artifacts: 'test_results/**/test_int_*_results.html'
                 archiveArtifacts artifacts: 'test_results/**/docker_metrics_*.png'
                 archiveArtifacts artifacts: 'test_results/**/*.csv'
+                archiveArtifacts artifacts: 'test_results/**/*.log'
             }
         }
     }

--- a/.ci/scripts/build_cslc_s1.sh
+++ b/.ci/scripts/build_cslc_s1.sh
@@ -24,7 +24,7 @@ BUILD_DATE_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 # defaults, SAS image should be updated as necessary for new image releases from ADT
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath $(dirname $(realpath $0))/../..)
 [ -z "${TAG}" ] && TAG="${USER}-dev"
-[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/cslc_s1:gamma_0.2.1"
+[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/cslc_s1:calval_0.3.1"
 
 echo "WORKSPACE: $WORKSPACE"
 echo "IMAGE: $IMAGE"

--- a/.ci/scripts/build_rtc_s1.sh
+++ b/.ci/scripts/build_rtc_s1.sh
@@ -24,7 +24,7 @@ BUILD_DATE_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 # defaults, SAS image should be updated as necessary for new image releases from ADT
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath $(dirname $(realpath $0))/../..)
 [ -z "${TAG}" ] && TAG="${USER}-dev"
-[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/rtc:gamma_0.3.1"
+[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/rtc:calval_0.4.0"
 
 echo "WORKSPACE: $WORKSPACE"
 echo "IMAGE: $IMAGE"

--- a/.ci/scripts/test_int_cslc_s1.sh
+++ b/.ci/scripts/test_int_cslc_s1.sh
@@ -105,6 +105,10 @@ docker_exit_status=$?
 # End metrics collection
 metrics_collection_end "$PGE_NAME" "$container_name" "$docker_exit_status" "$TEST_RESULTS_DIR"
 
+# Copy the PGE/SAS log file(s) to the test results directory so it can be archived
+# by Jenkins with the other results
+cp "${output_dir}"/*.log "${TEST_RESULTS_DIR}"
+
 if [ $docker_exit_status -ne 0 ]; then
     echo "docker exit indicates failure: ${docker_exit_status}"
     overall_status=1

--- a/.ci/scripts/test_int_cslc_s1.sh
+++ b/.ci/scripts/test_int_cslc_s1.sh
@@ -26,9 +26,9 @@ SAMPLE_TIME=15
 # Test data should be uploaded to  s3://operasds-dev-pge/${PGE_NAME}/
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../..)
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
-[ -z "${INPUT_DATA}" ] && INPUT_DATA="delivery_cslc_s1_gamma_0.1_expected_input_data.zip"
-[ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="delivery_cslc_s1_gamma_0.2_expected_output.zip"
-[ -z "${RUNCONFIG}" ] && RUNCONFIG="opera_pge_cslc_s1_delivery_4.1_gamma_runconfig.yaml"
+[ -z "${INPUT_DATA}" ] && INPUT_DATA="delivery_cslc_s1_calval_0.3.1_expected_input_data.zip"
+[ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="delivery_cslc_s1_calval_0.3.1_expected_output.zip"
+[ -z "${RUNCONFIG}" ] && RUNCONFIG="opera_pge_cslc_s1_delivery_5.0_calval_runconfig.yaml"
 [ -z "${TMP_ROOT}" ] && TMP_ROOT="$DEFAULT_TMP_ROOT"
 
 # Create the test output directory in the workspace
@@ -168,7 +168,7 @@ else
 
         static_layers_compare_result="PENDING"
 
-        burst_id_pattern="*_${burst_id_replace_underscores}_*_static_layers.h5"
+        burst_id_pattern="*_${burst_id_replace_underscores}_*_Static.h5"
         output_file=`ls $output_dir/$burst_id_pattern`
         echo "Output static layers file matching burst id is $output_file"
 

--- a/.ci/scripts/test_int_dswx_hls.sh
+++ b/.ci/scripts/test_int_dswx_hls.sh
@@ -106,6 +106,10 @@ do
     # End metrics collection
     metrics_collection_end "$PGE_NAME" "$container_name" "$docker_exit_status" "$TEST_RESULTS_DIR"
 
+    # Copy the PGE/SAS log file(s) to the test results directory so it can be archived
+    # by Jenkins with the other results
+    cp "${output_dir}"/*.log "${TEST_RESULTS_DIR}"
+
     if [ $docker_exit_status -ne 0 ]; then
         echo "docker exit indicates failure: ${docker_exit_status}"
         overall_status=1

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -64,6 +64,7 @@ runconfig_dir="${TMP_DIR}/runconfig"
 
 # the testdata reference metadata contains this path so we use it here
 output_dir="${TMP_DIR}/output_rtc_s1"
+
 # make sure no output directory already exists
 if [ -d "$output_dir" ]; then
     echo "Output directory $output_dir already exists (and should not). Removing directory."
@@ -99,6 +100,10 @@ docker_exit_status=$?
 
 # End metrics collection
 metrics_collection_end "$PGE_NAME" "$container_name" "$docker_exit_status" "$TEST_RESULTS_DIR"
+
+# Copy the PGE/SAS log file(s) to the test results directory so it can be archived
+# by Jenkins with the other results
+cp "${output_dir}"/*.log "${TEST_RESULTS_DIR}"
 
 if [ $docker_exit_status -ne 0 ]; then
     echo "docker exit indicates failure: ${docker_exit_status}"

--- a/.ci/scripts/test_int_rtc_s1.sh
+++ b/.ci/scripts/test_int_rtc_s1.sh
@@ -27,9 +27,9 @@ SAMPLE_TIME=15
 # RUNCONFIG should be the name of the runconfig in s3://operasds-dev-pge/${PGE_NAME}/
 [ -z "${WORKSPACE}" ] && WORKSPACE="$(realpath "$(dirname "$(realpath "$0")")"/../..)"
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
-[ -z "${INPUT_DATA}" ] && INPUT_DATA="rtc_s1_delivery_3_gamma_0.3_expected_input.zip"
-[ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="rtc_s1_delivery_3_gamma_0.3_expected_output.zip"
-[ -z "${RUNCONFIG}" ] && RUNCONFIG="rtc_s1_sample_runconfig-v2.0.0-rc.1.0.yaml"
+[ -z "${INPUT_DATA}" ] && INPUT_DATA="rtc_s1_delivery_4_calval_0.4_expected_input.zip"
+[ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="rtc_s1_delivery_4_calval_0.4_expected_output.zip"
+[ -z "${RUNCONFIG}" ] && RUNCONFIG="opera_pge_rtc_s1_delivery_4.0_calval_runconfig.yaml"
 [ -z "${TMP_ROOT}" ] && TMP_ROOT="$DEFAULT_TMP_ROOT"
 
 # Create the test output directory in the work space
@@ -75,13 +75,15 @@ mkdir -p "$output_dir"
 
 # the testdata reference metadata contains this path so we use it here
 scratch_dir="${TMP_DIR}/scratch_rtc_s1"
+
 # make sure no scratch directory already exists
 if [ -d "$scratch_dir" ]; then
     echo "Scratch directory $scratch_dir already exists (and should not). Removing directory..."
     rm -rf "${scratch_dir}"
 fi
+
 echo "Creating scratch directory $scratch_dir."
-mkdir -p --mode=777 "scratch_dir"
+mkdir -p --mode=777 "$scratch_dir"
 
 container_name="${PGE_NAME}"
 
@@ -110,32 +112,14 @@ if [ $docker_exit_status -ne 0 ]; then
     overall_status=1
 else
     declare -a burst_ids=("t069_147169_iw3"
-                          "t069_147170_iw1"
-                          "t069_147170_iw2"
                           "t069_147170_iw3"
-                          "t069_147171_iw1"
-                          "t069_147171_iw2"
                           "t069_147171_iw3"
-                          "t069_147172_iw1"
-                          "t069_147172_iw2"
                           "t069_147172_iw3"
-                          "t069_147173_iw1"
-                          "t069_147173_iw2"
                           "t069_147173_iw3"
-                          "t069_147174_iw1"
-                          "t069_147174_iw2"
                           "t069_147174_iw3"
-                          "t069_147175_iw1"
-                          "t069_147175_iw2"
                           "t069_147175_iw3"
-                          "t069_147176_iw1"
-                          "t069_147176_iw2"
                           "t069_147176_iw3"
-                          "t069_147177_iw1"
-                          "t069_147177_iw2"
                           "t069_147177_iw3"
-                          "t069_147178_iw1"
-                          "t069_147178_iw2"
                           "t069_147178_iw3")
 
     echo "<tr><th>Compare Result</th><th><ul><li>Expected file</li><li>Output file</li></ul></th><th>rtc_compare.py output</th></tr>" >> "$RESULTS_FILE"
@@ -144,15 +128,13 @@ else
 
         burst_id_uppercase=${burst_id^^}
         burst_id_replace_underscores=${burst_id_uppercase//_/-}
-        burst_id_remove_T=${burst_id_replace_underscores//T/}
         burst_id_pattern="*_${burst_id_replace_underscores}_*.h5"
-        expected_burst_id_pattern="*_${burst_id_remove_T}_*.h5"
 
         # shellcheck disable=SC2086
         output_file=$(ls ${output_dir}/${burst_id_pattern})
 
         # shellcheck disable=SC2086
-        expected_file=$(ls ${expected_dir}/${burst_id}/${expected_burst_id_pattern})
+        expected_file=$(ls ${expected_dir}/${burst_id}/${burst_id_pattern})
 
         echo "output file: $output_file"
         echo "expected_file: $expected_file"

--- a/src/opera/pge/base/runconfig.py
+++ b/src/opera/pge/base/runconfig.py
@@ -324,6 +324,11 @@ class RunConfig:
             else resource_filename('opera', iso_template_path)
         )
 
+    @property
+    def data_validity_start_time(self) -> str:
+        """Returns the DataValidityStartTime value for the Primary Executable"""
+        return self._pge_config['PrimaryExecutable'].get('DataValidityStartTime', None)
+
     # QAExecutable
     @property
     def qa_enabled(self) -> bool:

--- a/src/opera/pge/base/schema/base_pge_schema.yaml
+++ b/src/opera/pge/base/schema/base_pge_schema.yaml
@@ -30,6 +30,7 @@ RunConfig:
         SchemaPath: str(required=True)
         AlgorithmParametersSchemaPath: str(required=False)
         IsoTemplatePath: str(required=False)
+        DataValidityStartTime: regex(r'\d{8}T\d{6}', name='YYYYMMDDTHHmmss datetime', required=False)
 
       QAExecutable:
         Enabled: bool(required=True)

--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -219,7 +219,7 @@ class CslcS1PostProcessorMixin(PostProcessorMixin):
 
             self._burst_metadata_cache[burst_id] = cslc_metadata
 
-        burst_metadata = cslc_metadata['processing_information']['s1_burst_metadata']
+        burst_metadata = cslc_metadata['processing_information']['input_burst_metadata']
 
         sensor = burst_metadata['platform_id']
         mode = 'IW'  # fixed to Interferometric Wide (IW) for all S1-based CSLC products
@@ -416,7 +416,7 @@ class CslcS1PostProcessorMixin(PostProcessorMixin):
         # a representative
         cslc_metadata = list(self._burst_metadata_cache.values())[0]
 
-        burst_metadata = cslc_metadata['processing_information']['s1_burst_metadata']
+        burst_metadata = cslc_metadata['processing_information']['input_burst_metadata']
 
         sensor = burst_metadata['platform_id']
         mode = 'IW'  # fixed for all S1-based CSLC products
@@ -546,20 +546,22 @@ class CslcS1PostProcessorMixin(PostProcessorMixin):
         output_product_metadata = get_cslc_s1_product_metadata(metadata_product)
 
         # Fill in some additional fields expected within the ISO
-        output_product_metadata['grids']['width'] = len(output_product_metadata['grids']['x_coordinates'])
-        output_product_metadata['grids']['length'] = len(output_product_metadata['grids']['y_coordinates'])
+        output_product_metadata['data']['width'] = len(output_product_metadata['data']['x_coordinates'])
+        output_product_metadata['data']['length'] = len(output_product_metadata['data']['y_coordinates'])
 
         # Remove some of the larger arrays from the metadata, so we don't use
         # too much memory when caching the metadata for each burst
-        for key in ['VV', 'VH', 'HH', 'HV', 'x_coordinates', 'y_coordinates']:
-            array = output_product_metadata['grids'].pop(key, None)
+        for key in ['azimuth_carrier_phase', 'flattening_phase',
+                    'VV', 'VH', 'HH', 'HV',
+                    'x_coordinates', 'y_coordinates']:
+            array = output_product_metadata['data'].pop(key, None)
 
             if array is not None:
                 del array
 
         # Parse the burst center coordinate to conform with gml schema
         # sample: {ndarray: (2,)} [-118.30363047, 33.8399832]
-        burst_center = output_product_metadata['processing_information']['s1_burst_metadata']['center']
+        burst_center = output_product_metadata['processing_information']['input_burst_metadata']['center']
         burst_center_str = f"{burst_center[0]} {burst_center[1]}"
         output_product_metadata['burst_center'] = burst_center_str
 

--- a/src/opera/pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
+++ b/src/opera/pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
@@ -82,10 +82,10 @@
                         <gmd:MD_DimensionNameTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/gmxCodelists.xml#MD_DimensionNameTypeCode" codeListValue="row">row</gmd:MD_DimensionNameTypeCode>
                     </gmd:dimensionName>
                     <gmd:dimensionSize>
-                        <gco:Integer>{{ product_output.grids.width }}{# ISO_OPERA_rangeCount #}</gco:Integer>
+                        <gco:Integer>{{ product_output.data.width }}{# ISO_OPERA_rangeCount #}</gco:Integer>
                     </gmd:dimensionSize>
                     <gmd:resolution>
-                        <gco:Length uom="meter">{{ product_output.grids.x_spacing }}{# ISO_OPERA_rangePixelSize #}</gco:Length>
+                        <gco:Length uom="meter">{{ product_output.data.x_spacing }}{# ISO_OPERA_rangePixelSize #}</gco:Length>
                     </gmd:resolution>
                 </gmd:MD_Dimension>
             </gmd:axisDimensionProperties>
@@ -95,10 +95,10 @@
                         <gmd:MD_DimensionNameTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/gmxCodelists.xml#MD_DimensionNameTypeCode" codeListValue="column">column</gmd:MD_DimensionNameTypeCode>
                     </gmd:dimensionName>
                     <gmd:dimensionSize>
-                        <gco:Integer>{{ product_output.grids.length }}{# ISO_OPERA_azimuthCount #}</gco:Integer>
+                        <gco:Integer>{{ product_output.data.length }}{# ISO_OPERA_azimuthCount #}</gco:Integer>
                     </gmd:dimensionSize>
                     <gmd:resolution>
-                        <gco:Length uom="meter">{{ product_output.grids.y_spacing }}{# ISO_OPERA_azimuthPixelSize #}</gco:Length>
+                        <gco:Length uom="meter">{{ product_output.data.y_spacing }}{# ISO_OPERA_azimuthPixelSize #}</gco:Length>
                     </gmd:resolution>
                 </gmd:MD_Dimension>
             </gmd:axisDimensionProperties>
@@ -122,7 +122,7 @@
                         </gmd:CI_Citation>
                     </gmd:authority>
                     <gmd:code>
-                        <gco:CharacterString>{{ product_output.grids.projection }}{# ISO_OPERA_epsgCode #}</gco:CharacterString>
+                        <gco:CharacterString>{{ product_output.data.projection }}{# ISO_OPERA_epsgCode #}</gco:CharacterString>
                     </gmd:code>
                 </gmd:MD_Identifier>
             </gmd:referenceSystemIdentifier>
@@ -604,6 +604,30 @@
                                                 <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="instrumentInformation">instrumentInformation</eos:EOS_AdditionalAttributeTypeCode>
                                             </eos:type>
                                             <eos:name>
+                                                <gco:CharacterString>InstrumentName</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Instrument name</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:parameterUnitsOfMeasure>
+                                                <gco:CharacterString>Unitless</gco:CharacterString>
+                                            </eos:parameterUnitsOfMeasure>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.instrument_name }}{# ISO_OPERA_instrument_name #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="instrumentInformation">instrumentInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
                                                 <gco:CharacterString>IsGeocoded</gco:CharacterString>
                                             </eos:name>
                                             <eos:description>
@@ -697,6 +721,102 @@
                                     <eos:reference>
                                         <eos:EOS_AdditionalAttributeDescription>
                                             <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>ProcessingCenter</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Processing center</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:parameterUnitsOfMeasure>
+                                                <gco:CharacterString>Unitless</gco:CharacterString>
+                                            </eos:parameterUnitsOfMeasure>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.processing_center }}{# ISO_OPERA_processingCenter #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>ProcessingDateTime</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Processing date time</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:parameterUnitsOfMeasure>
+                                                <gco:CharacterString>Unitless</gco:CharacterString>
+                                            </eos:parameterUnitsOfMeasure>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.processing_date_time }}{# ISO_OPERA_processingDateTime #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>ProductLevel</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Product level. L0A: Unprocessed instrument data; L0B: Reformatted, unprocessed instrument data; L1: Processed instrument data in radar coordinates system; and L2: Processed instrument data in geocoded coordinates system</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:parameterUnitsOfMeasure>
+                                                <gco:CharacterString>Unitless</gco:CharacterString>
+                                            </eos:parameterUnitsOfMeasure>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.product_level }}{# ISO_OPERA_productLevel #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>ProductSpecificationVersion</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Product specification version which represents the schema of this product</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:parameterUnitsOfMeasure>
+                                                <gco:CharacterString>Unitless</gco:CharacterString>
+                                            </eos:parameterUnitsOfMeasure>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.product_specification_version }}{# ISO_OPERA_productSpecificationVersion #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
                                                 <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="instrumentInformation">instrumentInformation</eos:EOS_AdditionalAttributeTypeCode>
                                             </eos:type>
                                             <eos:name>
@@ -739,6 +859,30 @@
                                     </eos:reference>
                                     <eos:value>
                                         <gco:CharacterString>{{ product_output.identification.product_version }}{# ISO_OPERA_productVersion #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="instrumentInformation">instrumentInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>RadarBand</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Acquired frequency band</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:parameterUnitsOfMeasure>
+                                                <gco:CharacterString>Unitless</gco:CharacterString>
+                                            </eos:parameterUnitsOfMeasure>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.radar_band }}{# ISO_OPERA_radarBand #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -814,54 +958,6 @@
                                                 <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
                                             </eos:type>
                                             <eos:name>
-                                                <gco:CharacterString>CalibrationBasename</gco:CharacterString>
-                                            </eos:name>
-                                            <eos:parameterUnitsOfMeasure>
-                                                <gco:CharacterString>Unitless</gco:CharacterString>
-                                            </eos:parameterUnitsOfMeasure>
-                                            <eos:description>
-                                                <gco:CharacterString>Calibration file name</gco:CharacterString>
-                                            </eos:description>
-                                            <eos:dataType>
-                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
-                                            </eos:dataType>
-                                        </eos:EOS_AdditionalAttributeDescription>
-                                    </eos:reference>
-                                    <eos:value>
-                                        <gco:CharacterString>{{ product_output.calibration_information.basename }}{# ISO_OPERA_calibrationBasename #}</gco:CharacterString>
-                                    </eos:value>
-                                </eos:AdditionalAttribute>
-                                <eos:AdditionalAttribute>
-                                    <eos:reference>
-                                        <eos:EOS_AdditionalAttributeDescription>
-                                            <eos:type>
-                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
-                                            </eos:type>
-                                            <eos:name>
-                                                <gco:CharacterString>NoiseBasename</gco:CharacterString>
-                                            </eos:name>
-                                            <eos:parameterUnitsOfMeasure>
-                                                <gco:CharacterString>Unitless</gco:CharacterString>
-                                            </eos:parameterUnitsOfMeasure>
-                                            <eos:description>
-                                                <gco:CharacterString>Noise calibration file name</gco:CharacterString>
-                                            </eos:description>
-                                            <eos:dataType>
-                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
-                                            </eos:dataType>
-                                        </eos:EOS_AdditionalAttributeDescription>
-                                    </eos:reference>
-                                    <eos:value>
-                                        <gco:CharacterString>{{ product_output.noise_information.basename }}{# ISO_OPERA_noiseBasename #}</gco:CharacterString>
-                                    </eos:value>
-                                </eos:AdditionalAttribute>
-                                <eos:AdditionalAttribute>
-                                    <eos:reference>
-                                        <eos:EOS_AdditionalAttributeDescription>
-                                            <eos:type>
-                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
-                                            </eos:type>
-                                            <eos:name>
                                                 <gco:CharacterString>CompassVersion</gco:CharacterString>
                                             </eos:name>
                                             <eos:description>
@@ -925,10 +1021,10 @@
                                                 <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
                                             </eos:type>
                                             <eos:name>
-                                                <gco:CharacterString>GeocodingInterpolator</gco:CharacterString>
+                                                <gco:CharacterString>ComplexDataGeocodingInterpolator</gco:CharacterString>
                                             </eos:name>
                                             <eos:description>
-                                                <gco:CharacterString>Geocoding interpolation algorithm algorithm</gco:CharacterString>
+                                                <gco:CharacterString>Complex Data Geocoding interpolation algorithm algorithm</gco:CharacterString>
                                             </eos:description>
                                             <eos:dataType>
                                                 <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
@@ -936,7 +1032,28 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.algorithms.geocoding_interpolator }}{# ISO_OPERA_geocodingInterpolator #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.algorithms.complex_data_geocoding_interpolator }}{# ISO_OPERA_complexDataGeocodingInterpolator #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>FloatDataGeocodingInterpolator</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Floating Point Data Geocoding interpolation algorithm algorithm</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.algorithms.float_data_geocoding_interpolator }}{# ISO_OPERA_floatDataGeocodingInterpolator #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -958,6 +1075,363 @@
                                     </eos:reference>
                                     <eos:value>
                                         <gco:CharacterString>{{ product_output.processing_information.algorithms.s1Reader_version }}{# ISO_OPERA_s1ReaderVersion #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>BurstLocationIndex</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Index of the burst within the SLC archive</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="integer">integer</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.inputs.burst_location_parameters.burst_index }}{# ISO_OPERA_burstIndex #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>BurstLocationFirstValidLine</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>First valid line of the input burst</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="integer">integer</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.inputs.burst_location_parameters.first_valid_line }}{# ISO_OPERA_burstLocationFirstValidLine #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>BurstLocationFirstValidSample</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>First valid sample of the input burst</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="integer">integer</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.inputs.burst_location_parameters.first_valid_sample }}{# ISO_OPERA_burstLocationFirstValidSample #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>BurstLocationLastValidLine</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Last valid line of the input burst</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="integer">integer</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.inputs.burst_location_parameters.last_valid_line }}{# ISO_OPERA_burstLocationLastValidLine #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>BurstLocationLastValidSample</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Last valid sample of the input burst</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="integer">integer</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.inputs.burst_location_parameters.last_valid_sample }}{# ISO_OPERA_burstLocationLastValidSample #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>BurstLocationTiffPath</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Path to the Tiff file for the processed burst</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.inputs.burst_location_parameters.tiff_path }}{# ISO_OPERA_burstLocationLastValidSample #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>AzimuthFMRateApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag indicating whether the Azimuth FM Rate was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.parameters.azimuth_fm_rate_applied }}{# ISO_OPERA_azimuthFmRateApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>AzimuthSolidEarthTidesApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag indicating whether the Azimuth Solid Earth Tides was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.parameters.azimuth_solid_earth_tides_applied }}{# ISO_OPERA_azimuthSolidEarthTidesApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>BistaticDelayApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag indicating whether Bistatic Delay was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.parameters.bistatic_delay_applied }}{# ISO_OPERA_bistaticDelayApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>DryTroposphereWeatherModelApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag indicating whether the Dry Troposphere Weather Model was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.parameters.dry_troposphere_weather_model_applied }}{# ISO_OPERA_dryTroposphereWeatherModelApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>EllipsoidalFlatteningApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag indicating whether Ellipsoidal Flattening was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.parameters.ellipsoidal_flattening_applied }}{# ISO_OPERA_ellipsoidalFlatteningApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>GeometryDopplerApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag indicating whether Geometry Doppler was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.parameters.geometry_doppler_applied }}{# ISO_OPERA_geometryDopplerApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>IonosphereTecApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag indicating whether the Ionosphere TEC was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.parameters.ionosphere_tec_applied }}{# ISO_OPERA_ionosphereTecApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>LOSSolidEarthTidesApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag indicating whether the LOS Solid Earth Tides correction was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.parameters.los_solid_earth_tides_applied }}{# ISO_OPERA_losSolidEarthTidesApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>StaticTroposphereApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag indicating whether the Static Troposphere correction was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.parameters.static_troposphere_applied }}{# ISO_OPERA_staticTroposphereApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>TopographicFlatteningApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag indicating whether Topographic Flattening was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.parameters.topographic_flattening_applied }}{# ISO_OPERA_topographicFlatteningApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>WetTroposphereWeatherModelApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag indicating whether Wet Troposphere Weather Model was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.parameters.wet_troposphere_weather_model_applied }}{# ISO_OPERA_wetTroposphereWeatherModelApplied #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1086,7 +1560,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.radar_center_frequency }}{# ISO_OPERA_radarCenterFrequency #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.radar_center_frequency }}{# ISO_OPERA_radarCenterFrequency #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1110,7 +1584,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.wavelength }}{# ISO_OPERA_wavelength #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.wavelength }}{# ISO_OPERA_wavelength #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1134,7 +1608,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.azimuth_steering_rate }}{# ISO_OPERA_azimuthSteerRate #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.azimuth_steering_rate }}{# ISO_OPERA_azimuthSteerRate #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1158,7 +1632,70 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.azimuth_time_interval }}{# ISO_OPERA_azimuthTimeInterval #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.azimuth_time_interval }}{# ISO_OPERA_azimuthTimeInterval #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="instrumentInformation">instrumentInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>SensingStart</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Sensing start time</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.sensing_start }}{# ISO_OPERA_sensingStart #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="instrumentInformation">instrumentInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>SensingStop</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Sensing stop time</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.sensing_stop }}{# ISO_OPERA_sensingStop #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="instrumentInformation">instrumentInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>Shape</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Input burst image shape</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.shape|string }}{# ISO_OPERA_shape #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1182,7 +1719,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.slant_range_time }}{# ISO_OPERA_slantRangeTime #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.slant_range_time }}{# ISO_OPERA_slantRangeTime #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1206,7 +1743,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.starting_range }}{# ISO_OPERA_startingRange #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.starting_range }}{# ISO_OPERA_startingRange #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1230,7 +1767,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.range_sampling_rate }}{# ISO_OPERA_rangeSamplingRate #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.range_sampling_rate }}{# ISO_OPERA_rangeSamplingRate #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1254,7 +1791,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.range_pixel_spacing }}{# ISO_OPERA_rangePixelSpacing #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.range_pixel_spacing }}{# ISO_OPERA_rangePixelSpacing #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1278,7 +1815,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.range_bandwidth }}{# ISO_OPERA_rangeBandwidth #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.range_bandwidth }}{# ISO_OPERA_rangeBandwidth #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1302,7 +1839,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.range_chirp_rate }}{# ISO_OPERA_rangeChirpRate #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.range_chirp_rate }}{# ISO_OPERA_rangeChirpRate #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1323,7 +1860,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.azimuth_fm_rate.order }}{# ISO_OPERA_azimuthFmRateOrder #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.azimuth_fm_rate.order }}{# ISO_OPERA_azimuthFmRateOrder #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1344,7 +1881,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.azimuth_fm_rate.mean }}{# ISO_OPERA_azimuthFmRateMean #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.azimuth_fm_rate.mean }}{# ISO_OPERA_azimuthFmRateMean #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1365,7 +1902,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.azimuth_fm_rate.std }}{# ISO_OPERA_azimuthFmRateStd #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.azimuth_fm_rate.std }}{# ISO_OPERA_azimuthFmRateStd #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1386,7 +1923,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.azimuth_fm_rate.coeffs|string }}{# ISO_OPERA_azimuthFmRateCoeffs #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.azimuth_fm_rate.coeffs|string }}{# ISO_OPERA_azimuthFmRateCoeffs #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1407,7 +1944,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.doppler.order }}{# ISO_OPERA_dopplerOrder #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.doppler.order }}{# ISO_OPERA_dopplerOrder #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1428,7 +1965,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.doppler.mean }}{# ISO_OPERA_dopplerMean #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.doppler.mean }}{# ISO_OPERA_dopplerMean #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1449,7 +1986,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.doppler.std }}{# ISO_OPERA_dopplerStd #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.doppler.std }}{# ISO_OPERA_dopplerStd #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1470,7 +2007,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.doppler.coeffs|string }}{# ISO_OPERA_dopplerCoeffs #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.doppler.coeffs|string }}{# ISO_OPERA_dopplerCoeffs #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1491,7 +2028,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.ipf_version }}{# ISO_OPERA_ipfVersion #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.ipf_version }}{# ISO_OPERA_ipfVersion #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1515,7 +2052,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.iw2_mid_range }}{# ISO_OPERA_iw2MidRange #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.iw2_mid_range }}{# ISO_OPERA_iw2MidRange #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1539,7 +2076,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.prf_raw_data }}{# ISO_OPERA_prfRawData #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.prf_raw_data }}{# ISO_OPERA_prfRawData #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1560,7 +2097,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.polarization }}{# ISO_OPERA_polarization #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.polarization }}{# ISO_OPERA_polarization #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1581,7 +2118,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.platform_id }}{# ISO_OPERA_platformID #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.platform_id }}{# ISO_OPERA_platformID #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1602,7 +2139,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.range_window_type }}{# ISO_OPERA_rangeWindowType #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.range_window_type }}{# ISO_OPERA_rangeWindowType #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1623,7 +2160,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.range_window_coefficient }}{# ISO_OPERA_rangeWindowType #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.range_window_coefficient }}{# ISO_OPERA_rangeWindowCoefficient #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1644,7 +2181,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.s1_burst_metadata.rank }}{# ISO_OPERA_rank #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.rank }}{# ISO_OPERA_rank #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>

--- a/src/opera/pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
+++ b/src/opera/pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
@@ -2006,6 +2006,20 @@
                         </gmd:LI_Source>
                     </gmd:source>
                     {%- endfor %}
+                    <gmd:source>
+                        <gmd:LI_Source>
+                            <gmd:description>
+                                <gco:CharacterString>Ionosphere Correction - {{ run_config.Groups.SAS.runconfig.groups.dynamic_ancillary_file_group.tec_file }}{# ISO_OPERA_ionosphereFile #}</gco:CharacterString>
+                            </gmd:description>
+                        </gmd:LI_Source>
+                    </gmd:source>
+                    <gmd:source>
+                        <gmd:LI_Source>
+                            <gmd:description>
+                                <gco:CharacterString>Burst Database - {{ run_config.Groups.SAS.runconfig.groups.static_ancillary_file_group.burst_database_file }}{# ISO_OPERA_burstDatabaseFile #}</gco:CharacterString>
+                            </gmd:description>
+                        </gmd:LI_Source>
+                    </gmd:source>
                 </gmd:LI_Lineage>
             </gmd:lineage>
         </gmd:DQ_DataQuality>

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -240,7 +240,7 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
         sensor = get_sensor_from_spacecraft_name(product_metadata['identification']['platform'])
 
         # Spacing is assumed to be identical in both X and Y direction
-        spacing = int(product_metadata['frequencyA']['xCoordinateSpacing'])
+        spacing = int(product_metadata['data']['xCoordinateSpacing'])
 
         product_version = str(self.runconfig.product_version)
 
@@ -434,7 +434,7 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
         sensor = get_sensor_from_spacecraft_name(product_metadata['identification']['platform'])
 
         # Spacing is assumed to be identical in both X and Y direction
-        spacing = int(product_metadata['frequencyA']['xCoordinateSpacing'])
+        spacing = int(product_metadata['data']['xCoordinateSpacing'])
 
         production_time = get_time_for_filename(self.production_datetime)
         product_version = str(self.runconfig.product_version)
@@ -554,10 +554,10 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
         output_product_metadata = get_rtc_s1_product_metadata(metadata_product)
 
         # Fill in some additional fields expected within the ISO
-        output_product_metadata['frequencyA']['frequencyAWidth'] = len(output_product_metadata['frequencyA']
-                                                                       ['xCoordinates'])
-        output_product_metadata['frequencyA']['frequencyALength'] = len(output_product_metadata['frequencyA']
-                                                                        ['yCoordinates'])
+        output_product_metadata['data']['width'] = len(output_product_metadata['data']
+                                                        ['xCoordinates'])
+        output_product_metadata['data']['length'] = len(output_product_metadata['data']
+                                                        ['yCoordinates'])
 
         return output_product_metadata
 

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -171,7 +171,7 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
 
         return self._cached_core_filename
 
-    def _rtc_filename(self, inter_filename):
+    def _rtc_filename(self, inter_filename, use_validity_start_time=False):
         """
         Returns the base file name to use for RTC products produced by this PGE.
 
@@ -187,11 +187,21 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
             The intermediate filename of the output product to generate
             a filename for. This parameter may be used to inspect the file
             in order to derive any necessary components of the returned filename.
+        use_validity_start_time : bool, optional
+            If True, use the DataValidityStartTime value from the RunConfig in
+            lieu of an acquisition time from the product metadata. Defaults to
+            False.
 
         Returns
         -------
         rtc_filename : str
             The file name to assign to RTC product(s) created by this PGE.
+
+        Raises
+        ------
+        ValueError
+            If use_validity_start_time is True and no value was specified for
+            DataValidityStartTime within the RunConfig.
 
         """
         core_filename = self._core_filename(inter_filename)
@@ -225,16 +235,25 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
 
         production_time = get_time_for_filename(self.production_datetime)
 
-        # Use doppler start time as the acq time and convert it to our format
-        # used for file naming
-        acquisition_time = product_metadata['identification']['zeroDopplerStartTime']
+        if use_validity_start_time:
+            acquisition_time = self.runconfig.data_validity_start_time
 
-        if not acquisition_time.endswith('Z'):
-            acquisition_time += 'Z'
+            if acquisition_time is None:
+                raise ValueError(
+                    'use_validity_start_time was requested, but no value was provided '
+                    'for DataValidityStartTime within the RunConfig'
+                )
+        else:
+            # Use doppler start time as the acq time and convert it to our format
+            # used for file naming
+            acquisition_time = product_metadata['identification']['zeroDopplerStartTime']
 
-        acquisition_time = get_time_for_filename(
-            datetime.strptime(acquisition_time, "%Y-%m-%dT%H:%M:%S.%fZ")
-        )
+            if not acquisition_time.endswith('Z'):
+                acquisition_time += 'Z'
+
+            acquisition_time = get_time_for_filename(
+                datetime.strptime(acquisition_time, "%Y-%m-%dT%H:%M:%S.%fZ")
+            )
 
         # Get the sensor (should be either S1A or S1B)
         sensor = get_sensor_from_spacecraft_name(product_metadata['identification']['platform'])
@@ -269,7 +288,7 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
 
         The filename for static layer RTC products consists of:
 
-            <RTC filename>_<Static layer name>.tif
+            <RTC filename>_static_<Static layer name>.tif
 
         Where <RTC filename> is returned by RtcS1PostProcessorMixin._rtc_filename(),
         and <Static layer name> is the identifier for the specific static layer
@@ -302,9 +321,9 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
 
         static_layer_name = filename.split(product_version)[-1]
 
-        rtc_filename = self._rtc_filename(inter_filename)
+        rtc_filename = self._rtc_filename(inter_filename, use_validity_start_time=True)
 
-        static_layer_filename = f"{rtc_filename}{static_layer_name}.tif"
+        static_layer_filename = f"{rtc_filename}_static{static_layer_name}.tif"
 
         return static_layer_filename
 
@@ -772,7 +791,7 @@ class RtcS1Executor(RtcS1PreProcessorMixin, RtcS1PostProcessorMixin, PgeExecutor
             "*_HV.tif": self._rtc_geotiff_filename,
             "*_VV+VH.tif": self._rtc_geotiff_filename,
             "*_HH+HV.tif": self._rtc_geotiff_filename,
-            "*_rtc_anf.tif": self._static_layer_filename,
+            "*_rtc_anf*.tif": self._static_layer_filename,
             "*_nlooks.tif": self._static_layer_filename,
             "*_local_incidence_angle.tif": self._static_layer_filename,
             "*_layover_shadow_mask.tif": self._static_layer_filename,

--- a/src/opera/pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
+++ b/src/opera/pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
@@ -22,7 +22,7 @@ runconfig:
       dem_file: str(required=False)
 
       # Digital elevation model description
-      dem_description: str(required=False)
+      dem_file_description: str(required=False)
 
     static_ancillary_file_group:
 
@@ -73,7 +73,7 @@ runconfig:
       # Save browse image(s)
       save_browse: bool(required=False)
 
-      output_imagery_format: enum('HDF5', 'NETCDF', 'ENVI', 'GTiff', 'COG', required=False)
+      output_imagery_format: enum('HDF5', 'NETCDF', 'GTiff', 'COG', 'ENVI', required=False)
       output_imagery_compression: str(required=False)
       output_imagery_nbits: int(min=1, required=False)
 
@@ -131,6 +131,15 @@ processing_options:
   # Apply thermal noise correction
   apply_thermal_noise_correction: bool(required=False)
 
+  # Compute geolocation correction LUTs and apply it
+  apply_correction_luts: bool(required=False)
+
+  # slant range spacing of the correction LUT in meters
+  correction_lut_range_spacing_in_meters: num(required=False)
+
+  # Azimuth time spacing of the correction LUT in meters
+  correction_lut_azimuth_spacing_in_meters: num(required=False)
+
   # Apply RTC
   apply_rtc: bool(required=False)
 
@@ -145,6 +154,9 @@ processing_options:
 
   # Geocoding options
   geocoding: include('geocoding_options', required=False)
+
+  # Mosaicking options
+  mosaicking: include('mosaicking_options', required=False)
 
   # Browse image
   browse_image_group: include('browse_image_options', required=False)
@@ -177,7 +189,11 @@ geocoding_options:
   # OPTIONAL - Apply shadow masking
   apply_shadow_masking: bool(required=False)
 
-  # Algorithm type, area projection or interpolation: sinc, bilinear, bicubic, nearest, and biquintic
+  # Skip geocoding already processed, which is tested by the existence of the output files
+  skip_if_output_files_exist: bool(required=False)
+
+  # Geocoding algorithm type, area projection or interpolation:
+  # sinc, bilinear, bicubic, nearest, and biquintic
   algorithm_type: enum('area_projection', 'sinc', 'bilinear', 'bicubic', 'nearest', 'biquintic', required=False)
 
   # Memory mode
@@ -212,8 +228,11 @@ geocoding_options:
   # Save the interpolated DEM used to generate the RTC product
   save_dem: bool(required=False)
 
-  # Save layover shadow mask
+  # Save layover/shadow mask
   save_layover_shadow_mask: bool(required=False)
+
+  # Layover/shadow mask dilation size of shadow pixels
+  shadow_dilation_size: int(min=0, required=False)
 
   # OPTIONAL - Absolute radiometric correction
   abs_rad_cal: num(required=False)
@@ -227,7 +246,25 @@ geocoding_options:
   # Double SLC sampling in the range direction
   upsample_radargrid: bool(required=False)
 
-  # Product EPSG code. Same as DEM if not provided
+  # Bursts geographic grid
+  bursts_geogrid: include('output_grid_options', required=False)
+
+
+mosaicking_options:
+
+  # Mosaic mode
+  mosaic_mode: enum('average', 'first', 'bursts_center', required=False)
+
+  # Mosaic geographic grid
+  mosaic_geogrid: include('output_grid_options', required=False)
+
+
+output_grid_options:
+  # Product EPSG code. If not provided, `output_epsg` will
+  # be determined based on the scene center:
+  # - If center_lat >= 75.0: 3413
+  # - If center_lat <= -75.0: 3031
+  # - Otherwise: EPSG code associated with the closest UTM zone
   output_epsg: int(min=1024, max=32767, required=False)
 
   # Product posting along X (same units as output_epsg)

--- a/src/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
+++ b/src/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
@@ -82,10 +82,10 @@
                         <gmd:MD_DimensionNameTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/gmxCodelists.xml#MD_DimensionNameTypeCode" codeListValue="row">row</gmd:MD_DimensionNameTypeCode>
                     </gmd:dimensionName>
                     <gmd:dimensionSize>
-                        <gco:Integer>{{ product_output.frequencyA.frequencyAWidth }}{# ISO_OPERA_frequencyAWidth #}</gco:Integer>
+                        <gco:Integer>{{ product_output.data.width }}{# ISO_OPERA_width #}</gco:Integer>
                     </gmd:dimensionSize>
                     <gmd:resolution>
-                        <gco:Length uom="meter">{{ product_output.frequencyA.xCoordinateSpacing }}{# ISO_OPERA_xCoordinateSpacing #}</gco:Length>
+                        <gco:Length uom="meter">{{ product_output.data.xCoordinateSpacing }}{# ISO_OPERA_xCoordinateSpacing #}</gco:Length>
                     </gmd:resolution>
                 </gmd:MD_Dimension>
             </gmd:axisDimensionProperties>
@@ -95,10 +95,10 @@
                         <gmd:MD_DimensionNameTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/gmxCodelists.xml#MD_DimensionNameTypeCode" codeListValue="column">column</gmd:MD_DimensionNameTypeCode>
                     </gmd:dimensionName>
                     <gmd:dimensionSize>
-                        <gco:Integer>{{ product_output.frequencyA.frequencyALength }}{# ISO_OPERA_frequencyALength #}</gco:Integer>
+                        <gco:Integer>{{ product_output.data.length }}{# ISO_OPERA_length #}</gco:Integer>
                     </gmd:dimensionSize>
                     <gmd:resolution>
-                        <gco:Length uom="meter">{{ product_output.frequencyA.yCoordinateSpacing }}{# ISO_OPERA_yCoordinateSpacing #}</gco:Length>
+                        <gco:Length uom="meter">{{ product_output.data.yCoordinateSpacing }}{# ISO_OPERA_yCoordinateSpacing #}</gco:Length>
                     </gmd:resolution>
                 </gmd:MD_Dimension>
             </gmd:axisDimensionProperties>
@@ -122,7 +122,7 @@
                         </gmd:CI_Citation>
                     </gmd:authority>
                     <gmd:code>
-                        <gco:CharacterString>{{ product_output.frequencyA.projection }}{# ISO_OPERA_projection #}</gco:CharacterString>
+                        <gco:CharacterString>{{ product_output.data.projection }}{# ISO_OPERA_projection #}</gco:CharacterString>
                     </gmd:code>
                 </gmd:MD_Identifier>
             </gmd:referenceSystemIdentifier>
@@ -617,6 +617,27 @@
                                                 <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="instrumentInformation">instrumentInformation</eos:EOS_AdditionalAttributeTypeCode>
                                             </eos:type>
                                             <eos:name>
+                                                <gco:CharacterString>BoundingBox</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Bounding box of the product, in order of xmin, ymin, xmax, ymax</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.boundingBox|string }}{# ISO_OPERA_boundingBox #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="instrumentInformation">instrumentInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
                                                 <gco:CharacterString>BurstID</gco:CharacterString>
                                             </eos:name>
                                             <eos:description>
@@ -677,6 +698,48 @@
                                     </eos:reference>
                                     <eos:value>
                                         <gco:CharacterString>{{ product_output.identification.productType }}{# ISO_OPERA_productType #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="contentInformation">contentInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>Project</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Project name</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.project }}{# ISO_OPERA_project #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="instrumentInformation">instrumentInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>RadarBand</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Acquired frequency band</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.radarBand }}{# ISO_OPERA_radarBand #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -812,48 +875,6 @@
                                                 <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="contentInformation">contentInformation</eos:EOS_AdditionalAttributeTypeCode>
                                             </eos:type>
                                             <eos:name>
-                                                <gco:CharacterString>IsUrgentObservation</gco:CharacterString>
-                                            </eos:name>
-                                            <eos:description>
-                                                <gco:CharacterString>List of booleans indicating if datatakes are nominal or urgent</gco:CharacterString>
-                                            </eos:description>
-                                            <eos:dataType>
-                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
-                                            </eos:dataType>
-                                        </eos:EOS_AdditionalAttributeDescription>
-                                    </eos:reference>
-                                    <eos:value>
-                                        <gco:CharacterString>{{ product_output.identification.isUrgentObservation|string }}{# ISO_OPERA_isUrgentObservation #}</gco:CharacterString>
-                                    </eos:value>
-                                </eos:AdditionalAttribute>
-                                <eos:AdditionalAttribute>
-                                    <eos:reference>
-                                        <eos:EOS_AdditionalAttributeDescription>
-                                            <eos:type>
-                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="contentInformation">contentInformation</eos:EOS_AdditionalAttributeTypeCode>
-                                            </eos:type>
-                                            <eos:name>
-                                                <gco:CharacterString>ListOfFrequencies</gco:CharacterString>
-                                            </eos:name>
-                                            <eos:description>
-                                                <gco:CharacterString>List of frequency layers available in the product</gco:CharacterString>
-                                            </eos:description>
-                                            <eos:dataType>
-                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
-                                            </eos:dataType>
-                                        </eos:EOS_AdditionalAttributeDescription>
-                                    </eos:reference>
-                                    <eos:value>
-                                        <gco:CharacterString>{{ product_output.identification.listOfFrequencies|string }}{# ISO_OPERA_listOfFrequencies #}</gco:CharacterString>
-                                    </eos:value>
-                                </eos:AdditionalAttribute>
-                                <eos:AdditionalAttribute>
-                                    <eos:reference>
-                                        <eos:EOS_AdditionalAttributeDescription>
-                                            <eos:type>
-                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="contentInformation">contentInformation</eos:EOS_AdditionalAttributeTypeCode>
-                                            </eos:type>
-                                            <eos:name>
                                                 <gco:CharacterString>DiagnosticModeFlag</gco:CharacterString>
                                             </eos:name>
                                             <eos:description>
@@ -866,6 +887,48 @@
                                     </eos:reference>
                                     <eos:value>
                                         <gco:CharacterString>{{ product_output.identification.diagnosticModeFlag }}{# ISO_OPERA_diagnosticModeFlag #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="contentInformation">contentInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>Institution</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Institution name</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.institution }}{# ISO_OPERA_institution #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="instrumentInformation">instrumentInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>InstrumentName</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Name of the instrument used to collect the remote sensing data provided in this product</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.instrumentName }}{# ISO_OPERA_instrumentName #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -935,13 +998,13 @@
                                     <eos:reference>
                                         <eos:EOS_AdditionalAttributeDescription>
                                             <eos:type>
-                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="contentInformation">contentInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
                                             </eos:type>
                                             <eos:name>
-                                                <gco:CharacterString>ListOfPolarizations</gco:CharacterString>
+                                                <gco:CharacterString>ProductID</gco:CharacterString>
                                             </eos:name>
                                             <eos:description>
-                                                <gco:CharacterString>List of processed polarization layers with frequencyA</gco:CharacterString>
+                                                <gco:CharacterString>Product Identifier</gco:CharacterString>
                                             </eos:description>
                                             <eos:dataType>
                                                 <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
@@ -949,7 +1012,70 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.frequencyA.listOfPolarizations|string }}{# ISO_OPERA_listOfPolarizations #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.identification.productID }}{# ISO_OPERA_productID #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>ProductLevel</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Product level. L0A: Unprocessed instrument data; L0B: Reformatted, unprocessed instrument data; L1: Processed instrument data in radar coordinates system; and L2: Processed instrument data in geocoded coordinates system</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.productLevel }}{# ISO_OPERA_productLevel #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>ProductSpecificationVersion</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Product specification version which represents the schema of this product</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.identification.productSpecificationVersion }}{# ISO_OPERA_productSpecificationVersion #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="contentInformation">contentInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>ListOfPolarizations</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>List of processed polarization layers</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.data.listOfPolarizations|string }}{# ISO_OPERA_listOfPolarizations #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -973,7 +1099,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.frequencyA.yCoordinateSpacing }}{# ISO_OPERA_yCoordinateSpacing #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.data.yCoordinateSpacing }}{# ISO_OPERA_yCoordinateSpacing #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -997,103 +1123,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.frequencyA.xCoordinateSpacing }}{# ISO_OPERA_xCoordinateSpacing #}</gco:CharacterString>
-                                    </eos:value>
-                                </eos:AdditionalAttribute>
-                                <eos:AdditionalAttribute>
-                                    <eos:reference>
-                                        <eos:EOS_AdditionalAttributeDescription>
-                                            <eos:type>
-                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingParameter">processingParameter</eos:EOS_AdditionalAttributeTypeCode>
-                                            </eos:type>
-                                            <eos:name>
-                                                <gco:CharacterString>RangeBandwidth</gco:CharacterString>
-                                            </eos:name>
-                                            <eos:description>
-                                                <gco:CharacterString>Processed range bandwidth in Hz</gco:CharacterString>
-                                            </eos:description>
-                                            <eos:parameterUnitsOfMeasure>
-                                                <gco:CharacterString>Hertz</gco:CharacterString>
-                                            </eos:parameterUnitsOfMeasure>
-                                            <eos:dataType>
-                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="float">float</eos:EOS_AdditionalAttributeDataTypeCode>
-                                            </eos:dataType>
-                                        </eos:EOS_AdditionalAttributeDescription>
-                                    </eos:reference>
-                                    <eos:value>
-                                        <gco:CharacterString>{{ product_output.frequencyA.rangeBandwidth }}{# ISO_OPERA_rangeBandwidth #}</gco:CharacterString>
-                                    </eos:value>
-                                </eos:AdditionalAttribute>
-                                <eos:AdditionalAttribute>
-                                    <eos:reference>
-                                        <eos:EOS_AdditionalAttributeDescription>
-                                            <eos:type>
-                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingParameter">processingParameter</eos:EOS_AdditionalAttributeTypeCode>
-                                            </eos:type>
-                                            <eos:name>
-                                                <gco:CharacterString>CenterFrequency</gco:CharacterString>
-                                            </eos:name>
-                                            <eos:description>
-                                                <gco:CharacterString>Center frequency of the processed image in Hz</gco:CharacterString>
-                                            </eos:description>
-                                            <eos:parameterUnitsOfMeasure>
-                                                <gco:CharacterString>Hertz</gco:CharacterString>
-                                            </eos:parameterUnitsOfMeasure>
-                                            <eos:dataType>
-                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="float">float</eos:EOS_AdditionalAttributeDataTypeCode>
-                                            </eos:dataType>
-                                        </eos:EOS_AdditionalAttributeDescription>
-                                    </eos:reference>
-                                    <eos:value>
-                                        <gco:CharacterString>{{ product_output.frequencyA.centerFrequency }}{# ISO_OPERA_centerFrequency #}</gco:CharacterString>
-                                    </eos:value>
-                                </eos:AdditionalAttribute>
-                                <eos:AdditionalAttribute>
-                                    <eos:reference>
-                                        <eos:EOS_AdditionalAttributeDescription>
-                                            <eos:type>
-                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingParameter">processingParameter</eos:EOS_AdditionalAttributeTypeCode>
-                                            </eos:type>
-                                            <eos:name>
-                                                <gco:CharacterString>SlantRangeSpacing</gco:CharacterString>
-                                            </eos:name>
-                                            <eos:description>
-                                                <gco:CharacterString>Slant range spacing of grid. Same as difference between consecutive samples in slantRange array</gco:CharacterString>
-                                            </eos:description>
-                                            <eos:parameterUnitsOfMeasure>
-                                                <gco:CharacterString>Meters</gco:CharacterString>
-                                            </eos:parameterUnitsOfMeasure>
-                                            <eos:dataType>
-                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="float">float</eos:EOS_AdditionalAttributeDataTypeCode>
-                                            </eos:dataType>
-                                        </eos:EOS_AdditionalAttributeDescription>
-                                    </eos:reference>
-                                    <eos:value>
-                                        <gco:CharacterString>{{ product_output.frequencyA.slantRangeSpacing }}{# ISO_OPERA_slantRangeSpacing #}</gco:CharacterString>
-                                    </eos:value>
-                                </eos:AdditionalAttribute>
-                                <eos:AdditionalAttribute>
-                                    <eos:reference>
-                                        <eos:EOS_AdditionalAttributeDescription>
-                                            <eos:type>
-                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="contentInformation">contentInformation</eos:EOS_AdditionalAttributeTypeCode>
-                                            </eos:type>
-                                            <eos:name>
-                                                <gco:CharacterString>ZeroDopplerTimeSpacing</gco:CharacterString>
-                                            </eos:name>
-                                            <eos:description>
-                                                <gco:CharacterString>Time interval in the along track direction for raster layers. This is same as the spacing between consecutive entries in the zeroDopplerTime array</gco:CharacterString>
-                                            </eos:description>
-                                            <eos:parameterUnitsOfMeasure>
-                                                <gco:CharacterString>Seconds</gco:CharacterString>
-                                            </eos:parameterUnitsOfMeasure>
-                                            <eos:dataType>
-                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="float">float</eos:EOS_AdditionalAttributeDataTypeCode>
-                                            </eos:dataType>
-                                        </eos:EOS_AdditionalAttributeDescription>
-                                    </eos:reference>
-                                    <eos:value>
-                                        <gco:CharacterString>{{ product_output.frequencyA.zeroDopplerTimeSpacing }}{# ISO_OPERA_zeroDopplerTimeSpacing #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.data.xCoordinateSpacing }}{# ISO_OPERA_xCoordinateSpacing #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1114,7 +1144,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.frequencyA.projection }}{# ISO_OPERA_projection #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.data.projection }}{# ISO_OPERA_projection #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1124,10 +1154,10 @@
                                                 <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingParameter">processingParameter</eos:EOS_AdditionalAttributeTypeCode>
                                             </eos:type>
                                             <eos:name>
-                                                <gco:CharacterString>RadiometricTerrainCorrectedFlag</gco:CharacterString>
+                                                <gco:CharacterString>BistaticDelayCorrectedApplied</gco:CharacterString>
                                             </eos:name>
                                             <eos:description>
-                                                <gco:CharacterString>Flag to indicate if Radiometric Terrain correction was applied</gco:CharacterString>
+                                                <gco:CharacterString>Flag to indicate if Bi-static Delay correction was applied</gco:CharacterString>
                                             </eos:description>
                                             <eos:dataType>
                                                 <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
@@ -1135,7 +1165,112 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.frequencyA.radiometricTerrainCorrectionFlag }}{# ISO_OPERA_radiometricTerrainCorrectionFlag #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processingInformation.parameters.bistaticDelayCorrectionApplied }}{# ISO_OPERA_bistaticDelayCorrectionApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingParameter">processingParameter</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>DryTroposphericGeolocationCorrectedApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag to indicate if the Dry Tropospheric Geolocation correction was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processingInformation.parameters.dryTroposphericGeolocationCorrectionApplied }}{# ISO_OPERA_dryTroposphericGeolocationCorrectionApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingParameter">processingParameter</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>NoiseCorrectedApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag to indicate if the Noise correction was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processingInformation.parameters.noiseCorrectionApplied }}{# ISO_OPERA_noiseCorrectionApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingParameter">processingParameter</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>PostProcessingFilteringApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag to indicate if Post Processing Filtering was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processingInformation.parameters.postProcessingFilteringApplied }}{# ISO_OPERA_postProcessingFilteringApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingParameter">processingParameter</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>RadiometricTerrainCorrectionApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag to indicate if Radiometric Terrain Correction was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processingInformation.parameters.radiometricTerrainCorrectionApplied }}{# ISO_OPERA_radiometricTerrainCorrectionApplied #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingParameter">processingParameter</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>WetTroposphericGeolocationCorrectionApplied</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Flag to indicate if the Wet Tropospheric Geolocation Correction was applied</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="boolean">boolean</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processingInformation.parameters.wetTroposphericGeolocationCorrectionApplied }}{# ISO_OPERA_wetTroposphericGeolocationCorrectionApplied #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1187,6 +1322,48 @@
                                                 <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
                                             </eos:type>
                                             <eos:name>
+                                                <gco:CharacterString>GeocodingAlgorithmReference</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Geocoding algorithm reference document</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processingInformation.algorithms.geocodingAlgorithmReference }}{# ISO_OPERA_geocodingAlgorithmReference #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>NoiseCorrectionAlgorithmReference</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Noise correction algorithm reference document</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processingInformation.algorithms.noiseCorrectionAlgorithmReference }}{# ISO_OPERA_noiseCorrectionAlgorithmReference #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
                                                 <gco:CharacterString>RadiometricTerrainCorrection</gco:CharacterString>
                                             </eos:name>
                                             <eos:description>
@@ -1208,6 +1385,27 @@
                                                 <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
                                             </eos:type>
                                             <eos:name>
+                                                <gco:CharacterString>RadiometricTerrainCorrectionAlgorithmReference</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Radiometric terrain correction algorithm reference document</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processingInformation.algorithms.radiometricTerrainCorrectionAlgorithmReference }}{# ISO_OPERA_radiometricTerrainCorrectionAlgorithmReference #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
                                                 <gco:CharacterString>S1ReaderVersion</gco:CharacterString>
                                             </eos:name>
                                             <eos:description>
@@ -1219,7 +1417,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processingInformation.algorithms.S1ReaderVersion }}{# ISO_OPERA_S1ReaderVersion #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processingInformation.algorithms.s1ReaderVersion }}{# ISO_OPERA_S1ReaderVersion #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1240,7 +1438,28 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processingInformation.algorithms.ISCEVersion }}{# ISO_OPERA_ISCEVersion #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processingInformation.algorithms.isce3Version }}{# ISO_OPERA_ISCEVersion #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>SoftwareVersion</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Software version used for processing</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processingInformation.algorithms.softwareVersion }}{# ISO_OPERA_softwareVersion #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>

--- a/src/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
+++ b/src/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
@@ -1539,6 +1539,13 @@
                         </gmd:LI_Source>
                     </gmd:source>
                     {%- endfor %}
+                    <gmd:source>
+                        <gmd:LI_Source>
+                            <gmd:description>
+                                <gco:CharacterString>Burst Database - {{ run_config.Groups.SAS.runconfig.groups.static_ancillary_file_group.burst_database_file }}{# ISO_OPERA_burstDatabaseFile #}</gco:CharacterString>
+                            </gmd:description>
+                        </gmd:LI_Source>
+                    </gmd:source>
                 </gmd:LI_Lineage>
             </gmd:lineage>
         </gmd:DQ_DataQuality>

--- a/src/opera/test/data/invalid_runconfig.yaml
+++ b/src/opera/test/data/invalid_runconfig.yaml
@@ -25,6 +25,7 @@ RunConfig:
         ErrorCodeBase: 100000
         SchemaPath: test/data/sample_sas_schema.yaml
         IsoTemplatePath: sample_iso_template.xml.jinja2
+        DataValidityStartTime: 2001-01-01 00:00:00  # Invalid expected datetime format
 
       QAExecutable:
         Enabled: True

--- a/src/opera/test/data/test_cslc_s1_config.yaml
+++ b/src/opera/test/data/test_cslc_s1_config.yaml
@@ -37,6 +37,7 @@ RunConfig:
                 ErrorCodeBase: 200000
                 SchemaPath: pge/cslc_s1/schema/cslc_s1_sas_schema.yaml
                 IsoTemplatePath: pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
+                DataValidityStartTime: 20000101T000000
 
             QAExecutable:
                 Enabled: False

--- a/src/opera/test/data/test_rtc_s1_config.yaml
+++ b/src/opera/test/data/test_rtc_s1_config.yaml
@@ -127,14 +127,15 @@ RunConfig:
                             clip_min:
                             upsample_radargrid: False
 
-                            output_epsg:
-                            x_posting: 30
-                            y_posting: 30
-                            x_snap: 30
-                            y_snap: 30
-                            top_left:
-                                x:
-                                y:
-                            bottom_right:
-                                x:
-                                y:
+                            bursts_geogrid:
+                                output_epsg:
+                                x_posting: 30
+                                y_posting: 30
+                                x_snap: 30
+                                y_snap: 30
+                                top_left:
+                                    x:
+                                    y:
+                                bottom_right:
+                                    x:
+                                    y:

--- a/src/opera/test/data/test_rtc_s1_config.yaml
+++ b/src/opera/test/data/test_rtc_s1_config.yaml
@@ -48,6 +48,7 @@ RunConfig:
                 ErrorCodeBase: 300000
                 SchemaPath: pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
                 IsoTemplatePath: pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
+                DataValidityStartTime: 20000101T000000
 
             QAExecutable:
                 Enabled: False

--- a/src/opera/test/data/valid_runconfig_full.yaml
+++ b/src/opera/test/data/valid_runconfig_full.yaml
@@ -29,6 +29,7 @@ RunConfig:
         ErrorCodeBase: 100000
         SchemaPath: test/data/sample_sas_schema.yaml
         IsoTemplatePath: sample_iso_template.xml.jinja2
+        DataValidityStartTime: 20010101T000000
 
       QAExecutable:
         Enabled: True

--- a/src/opera/test/data/valid_runconfig_no_sas.yaml
+++ b/src/opera/test/data/valid_runconfig_no_sas.yaml
@@ -29,6 +29,7 @@ RunConfig:
         ErrorCodeBase: 100000
         SchemaPath: test/data/sample_sas_schema.yaml
         IsoTemplatePath: sample_iso_template.xml.jinja2
+        DataValidityStartTime: 20010101T000000
 
       QAExecutable:
         Enabled: True

--- a/src/opera/test/pge/base/test_runconfig.py
+++ b/src/opera/test/pge/base/test_runconfig.py
@@ -56,6 +56,7 @@ class RunconfigTestCase(unittest.TestCase):
         self.assertListEqual(runconfig.qa_program_options, ["--debug"])
         self.assertEqual(runconfig.debug_switch, False)
         self.assertListEqual(runconfig.get_ancillary_filenames(), ["input/input_dem.vrt"])
+        self.assertEqual(runconfig.data_validity_start_time, "20010101T000000")
 
     def test_full_pge_config_parse_and_validate(self):
         """
@@ -76,7 +77,7 @@ class RunconfigTestCase(unittest.TestCase):
         self._compare_runconfig_to_expected(runconfig)
 
         # Make sure something was parsed for SAS section, not concerned with
-        # the internals though as its just an example SAS schema being used for
+        # the internals though as it's just an example SAS schema being used for
         # this test
         self.assertIsInstance(runconfig.sas_config, dict)
 
@@ -149,6 +150,8 @@ class RunconfigTestCase(unittest.TestCase):
             self.assertIn("RunConfig.Groups.PGE.PrimaryExecutable.ProgramOptions: '--debug --restart' is not a list.",
                           str(err))
             self.assertIn("RunConfig.Groups.PGE.QAExecutable.ProgramOptions: '--debug' is not a list.", str(err))
+            self.assertIn("RunConfig.Groups.PGE.PrimaryExecutable.DataValidityStartTime: '2001-01-01 00:00:00' is "
+                          "not a YYYYMMDDTHHmmss datetime.", str(err))
 
 
 if __name__ == "__main__":

--- a/src/opera/test/pge/cslc_s1/test_cslc_s1_pge.py
+++ b/src/opera/test/pge/cslc_s1/test_cslc_s1_pge.py
@@ -209,12 +209,18 @@ class CslcS1PgeTestCase(unittest.TestCase):
                           rf"{burst_metadata['platform_id']}_IW_" \
                           rf"{cslc_metadata['identification']['burst_id'].upper().replace('_', '-')}_" \
                           rf"{burst_metadata['polarization']}_" \
-                          rf"\d{{8}}T\d{{6}}Z_v{pge.runconfig.product_version}_\d{{8}}T\d{{6}}Z_static_layers.h5"
+                          rf"\d{{8}}T\d{{6}}Z_v{pge.runconfig.product_version}_\d{{8}}T\d{{6}}Z_Static.h5"
 
         result = re.match(file_name_regex, file_name)
 
         self.assertIsNotNone(result)
         self.assertEqual(result.group(), file_name)
+
+        # Ensure the DataValidityStartTime value was used in the naming convention
+        # for the static layers product
+        expected_data_validity_start_time = pge.runconfig.data_validity_start_time
+
+        self.assertIn(expected_data_validity_start_time, file_name)
 
         file_name = pge._browse_filename(
             inter_filename='cslc_pge_test/output_dir/t064_135518_iw1/20220501/t064_135518_iw1_20220501.png'

--- a/src/opera/test/pge/cslc_s1/test_cslc_s1_pge.py
+++ b/src/opera/test/pge/cslc_s1/test_cslc_s1_pge.py
@@ -182,7 +182,7 @@ class CslcS1PgeTestCase(unittest.TestCase):
         metadata_file = metadata_files[0]
 
         cslc_metadata = get_cslc_s1_product_metadata(metadata_file)
-        burst_metadata = cslc_metadata['processing_information']['s1_burst_metadata']
+        burst_metadata = cslc_metadata['processing_information']['input_burst_metadata']
 
         # Compare the filename returned by the PGE for JSON metadata files
         # to a regex which should match each component of the final filename

--- a/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
+++ b/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
@@ -173,7 +173,7 @@ class RtcS1PgeTestCase(unittest.TestCase):
                           rf"\w{{4}}-\w{{6}}-\w{{3}}_" \
                           rf"\d{{8}}T\d{{6}}Z_\d{{8}}T\d{{6}}Z_" \
                           rf"{sensor}_" \
-                          rf"{int(rtc_metadata['frequencyA']['xCoordinateSpacing'])}_" \
+                          rf"{int(rtc_metadata['data']['xCoordinateSpacing'])}_" \
                           rf"v{pge.runconfig.product_version}.h5"
 
         result = re.match(file_name_regex, os.path.basename(output_file))

--- a/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
+++ b/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
@@ -186,7 +186,7 @@ class RtcS1PgeTestCase(unittest.TestCase):
 
         output_files = glob.glob(join(pge.runconfig.output_product_path, f"{core_filename}*.tif"))
 
-        self.assertEqual(len(output_files), 8)
+        self.assertEqual(len(output_files), 6)
 
         output_files = list(map(os.path.basename, output_files))
 
@@ -196,8 +196,25 @@ class RtcS1PgeTestCase(unittest.TestCase):
         self.assertIn(f"{core_filename}_HV.tif", output_files)
         self.assertIn(f"{core_filename}_VV+VH.tif", output_files)
         self.assertIn(f"{core_filename}_HH+HV.tif", output_files)
-        self.assertIn(f"{core_filename}_nlooks.tif", output_files)
-        self.assertIn(f"{core_filename}_layover_shadow_mask.tif", output_files)
+
+        # Check that the static layer files had conventions applied
+        static_output_files = glob.glob(join(pge.runconfig.output_product_path, f"*static*.tif"))
+
+        self.assertEqual(len(static_output_files), 2)
+
+        static_output_files = list(map(os.path.basename, static_output_files))
+
+        core_static_filename = os.path.basename(static_output_files[0]).split('_static')[0]
+
+        self.assertIn(f"{core_static_filename}_static_nlooks.tif", static_output_files)
+        self.assertIn(f"{core_static_filename}_static_layover_shadow_mask.tif", static_output_files)
+
+        # Ensure the DataValidityStartTime was used in the filenames for the
+        # static layer products
+        expected_data_validity_start_time = pge.runconfig.data_validity_start_time
+
+        for static_output_file in static_output_files:
+            self.assertIn(expected_data_validity_start_time, static_output_file)
 
         # Finally, ensure file name was applied to the png browse image
         output_files = glob.glob(join(pge.runconfig.output_product_path, f"{core_filename}*.png"))

--- a/src/opera/test/util/test_metadata_utils.py
+++ b/src/opera/test/util/test_metadata_utils.py
@@ -102,9 +102,8 @@ class MetadataUtilsTestCase(unittest.TestCase):
 
             self.assertEqual(product_metadata['identification']['absolute_orbit_number'], 43011)
             self.assertEqual(product_metadata['identification']['burst_id'], 't064_135518_iw1')
-            self.assertEqual(product_metadata['grids']['projection'], 32611)
-            self.assertAlmostEqual(product_metadata['grids']['y_spacing'], -10.0)
-            self.assertAlmostEqual(product_metadata['corrections']['zero_doppler_time_spacing'], 0.027999999991152436)
+            self.assertEqual(product_metadata['data']['projection'], 32611)
+            self.assertAlmostEqual(product_metadata['data']['y_spacing'], -10.0)
             self.assertEqual(product_metadata['processing_information']['algorithms']['COMPASS_version'], '0.1.3')
             self.assertEqual(product_metadata['orbit']['orbit_direction'], 'Ascending')
 

--- a/src/opera/test/util/test_metadata_utils.py
+++ b/src/opera/test/util/test_metadata_utils.py
@@ -80,7 +80,6 @@ class MetadataUtilsTestCase(unittest.TestCase):
         try:
             product_output = get_rtc_s1_product_metadata(file_name)
 
-            self.assertAlmostEqual(product_output['frequencyA']['centerFrequency'], 5405000454.33435)
             self.assertEqual(product_output['orbit']['orbitType'], "POE")
             self.assertEqual(product_output['processingInformation']['inputs']['demSource'], 'dem.tif')
             for po, eo in zip(product_output['processingInformation']['inputs']['annotationFiles'],

--- a/src/opera/util/input_validation.py
+++ b/src/opera/util/input_validation.py
@@ -114,7 +114,7 @@ def validate_slc_s1_inputs(runconfig, logger, name):
             # TODO: this might be utilized as an ancillary with later deliveries,
             #       but no example available currently
             continue
-        elif key in ('burst_id', 'dem_description'):
+        elif key in ('burst_id', 'dem_description', 'dem_file_description'):
             # these fields are included in the SAS input paths, but are not
             # actually file paths, so skip them
             continue

--- a/src/opera/util/metadata_utils.py
+++ b/src/opera/util/metadata_utils.py
@@ -18,7 +18,7 @@ from mgrs.core import MGRSError
 
 import numpy as np
 
-S1_SLC_HDF5_PREFIX = "/science/SENTINEL1"
+S1_SLC_HDF5_PREFIX = ""
 """Prefix used to index metadata within SLC-based HDF5 products"""
 
 # pylint: disable=F841
@@ -308,10 +308,10 @@ def get_rtc_s1_product_metadata(file_name):
         ISO template.
     """
     product_output = {
-        'frequencyA': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/RTC/grids/frequencyA"),
+        'data': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/data"),
         'processingInformation': get_hdf5_group_as_dict(file_name,
-                                                        f"{S1_SLC_HDF5_PREFIX}/RTC/metadata/processingInformation"),
-        'orbit': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/RTC/metadata/orbit"),
+                                                        f"{S1_SLC_HDF5_PREFIX}/metadata/processingInformation"),
+        'orbit': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/metadata/orbit"),
         'identification': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/identification")
     }
 
@@ -332,29 +332,21 @@ def create_test_rtc_metadata_product(file_path):
     """
     # pylint: disable=F841
     with h5py.File(file_path, 'w') as outfile:
-        frequencyA_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/RTC/grids/frequencyA")
-        centerFrequency_dset = frequencyA_grp.create_dataset("centerFrequency", data=5405000454.33435, dtype='float64')
-        centerFrequency_dset.attrs['description'] = np.string_("Center frequency of the processed image in Hz")
-        xCoordinateSpacing_dset = frequencyA_grp.create_dataset("xCoordinateSpacing", data=30.0, dtype='float64')
-        xCoordinates_dset = frequencyA_grp.create_dataset("xCoordinates", data=np.zeros((10,)), dtype='float64')
-        yCoordinateSpacing_dset = frequencyA_grp.create_dataset("yCoordinateSpacing", data=30.0, dtype='float64')
-        yCoordinates_dset = frequencyA_grp.create_dataset("yCoordinates", data=np.zeros((10,)), dtype='float64')
-        projection_dset = frequencyA_grp.create_dataset("projection", data=b'1234')
-        listOfPolarizations_dset = frequencyA_grp.create_dataset("listOfPolarizations", data=np.array([b'VV', b'VH']))
-        rangeBandwidth_dset = frequencyA_grp.create_dataset('rangeBandwidth', data=56500000.0, dtype='float64')
-        slantRangeSpacing_dset = frequencyA_grp.create_dataset('slantRangeSpacing', data=2.32956, dtype='float64')
-        zeroDopplerTimeSpacing_dset = frequencyA_grp.create_dataset('zeroDopplerTimeSpacing',
-                                                                    data=0.002055, dtype='float64')
-        radiometricTerrainCorrectionFlag_dset = frequencyA_grp.create_dataset('radiometricTerrainCorrectionFlag',
-                                                                              data=True, dtype='bool')
+        data_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/data")
+        xCoordinateSpacing_dset = data_grp.create_dataset("xCoordinateSpacing", data=30.0, dtype='float64')
+        xCoordinates_dset = data_grp.create_dataset("xCoordinates", data=np.zeros((10,)), dtype='float64')
+        yCoordinateSpacing_dset = data_grp.create_dataset("yCoordinateSpacing", data=30.0, dtype='float64')
+        yCoordinates_dset = data_grp.create_dataset("yCoordinates", data=np.zeros((10,)), dtype='float64')
+        projection_dset = data_grp.create_dataset("projection", data=b'1234')
+        listOfPolarizations_dset = data_grp.create_dataset("listOfPolarizations", data=np.array([b'VV', b'VH']))
 
-        orbit_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/RTC/metadata/orbit")
+        orbit_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/metadata/orbit")
         orbitType_dset = orbit_grp.create_dataset("orbitType", data=b'POE')
         interpMethod_dest = orbit_grp.create_dataset("interpMethod", data=b'Hermite')
         referenceEpoch_dset = orbit_grp.create_dataset("referenceEpoch", data=b'2018-05-02T10:45:07.581333000')
 
         processingInformation_inputs_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}"
-                                                                f"/RTC/metadata/processingInformation/inputs")
+                                                                f"/metadata/processingInformation/inputs")
         demSource_dset = processingInformation_inputs_grp.create_dataset("demSource", data=b'dem.tif')
         annotationFiles = np.array([b'calibration-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml',
                                     b'noise-s1b-iw1-slc-vv-20180504t104508-20180504t104533-010770-013aee-004.xml'])
@@ -366,36 +358,63 @@ def create_test_rtc_metadata_product(file_path):
         orbitFiles_dset = processingInformation_inputs_grp.create_dataset("orbitFiles", data=orbitFiles)
 
         processingInformation_algorithms_grp = outfile.create_group(
-            f"{S1_SLC_HDF5_PREFIX}/RTC/metadata/processingInformation/algorithms")
+            f"{S1_SLC_HDF5_PREFIX}/metadata/processingInformation/algorithms")
         demInterpolation_dset = processingInformation_algorithms_grp.create_dataset("demInterpolation",
                                                                                     data=b'biquintic')
         geocoding_dset = processingInformation_algorithms_grp.create_dataset("geocoding", data=b'area_projection')
+        geocodingAlgoRef_dset = processingInformation_algorithms_grp.create_dataset("geocodingAlgorithmReference",
+                                                                                    data=b'Geocoding Algorithm Reference')
+        isceVersion_dset = processingInformation_algorithms_grp.create_dataset("isce3Version", data=b'0.13.0')
+        noiseCorrectionAlgoRef_dset = processingInformation_algorithms_grp.create_dataset("noiseCorrectionAlgorithmReference",
+                                                                                          data=b'Noise Correction Algorithm Reference')
         radiometricTerrainCorrection_dset = processingInformation_algorithms_grp.create_dataset(
             "radiometricTerrainCorrection", data=b'area_projection')
-        isceVersion_dset = processingInformation_algorithms_grp.create_dataset("ISCEVersion", data=b'0.8.0-dev')
-        s1ReaderVersion_dset = processingInformation_algorithms_grp.create_dataset("S1ReaderVersion", data=b'1.2.3')
+        radiometricTerrainCorrectionAlgoRef_dset = processingInformation_algorithms_grp.create_dataset(
+            "radiometricTerrainCorrectionAlgorithmReference", data=b'Radiometric Terrain Correction Algorithm Reference')
+        s1ReaderVersion_dset = processingInformation_algorithms_grp.create_dataset("s1ReaderVersion", data=b'1.2.3')
+        softwareVersion_dset = processingInformation_algorithms_grp.create_dataset("softwareVersion", data=b'0.4')
+
+        processingInformation_parameters_grp = outfile.create_group(
+            f"{S1_SLC_HDF5_PREFIX}/metadata/processingInformation/parameters")
+        bistaticDelayCorrectionApplied_dset = processingInformation_parameters_grp.create_dataset(
+            "bistaticDelayCorrectionApplied", data=True, dtype='bool')
+        dryTroposphericGeolocationCorrectionApplied_dset = processingInformation_parameters_grp.create_dataset(
+            "dryTroposphericGeolocationCorrectionApplied", data=True, dtype='bool')
+        noiseCorrectionApplied_dset = processingInformation_parameters_grp.create_dataset(
+            "noiseCorrectionApplied", data=True, dtype='bool')
+        postProcessingFilteringApplied_dset = processingInformation_parameters_grp.create_dataset(
+            "postProcessingFilteringApplied", data=True, dtype='bool')
+        radiometricTerrainCorrectionApplied_dset = processingInformation_parameters_grp.create_dataset(
+            'radiometricTerrainCorrectionApplied', data=True, dtype='bool')
+        wetTroposphericGeolocationCorrectionApplied_dset = processingInformation_parameters_grp.create_dataset(
+            "wetTroposphericGeolocationCorrectionApplied", data=True, dtype='bool')
 
         identification_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/identification")
         absoluteOrbitNumber_dset = identification_grp.create_dataset("absoluteOrbitNumber", data=10770, dtype='int64')
         acquisitionMode_dset = identification_grp.create_dataset("acquisitionMode",
                                                                  data=np.string_('Interferometric Wide (IW)'))
         beamID_dset = identification_grp.create_dataset("beamID", data=np.string_('iw1'))
+        boundingBox_dset = identification_grp.create_dataset("boundingBox", data=b'[ 200700. 9391650.  293730. 9440880.]')
         boundingPolygon_dset = identification_grp.create_dataset(
             "boundingPolygon", data=b'POLYGON ((399015 3859970, 398975 3860000, ..., 399015 3859970))')
         burstID_dset = identification_grp.create_dataset("burstID", data=b't069_147170_iw1')
         diagnosticModeFlag_dset = identification_grp.create_dataset("diagnosticModeFlag", data=False, dtype='bool')
+        institution_dset = identification_grp.create_dataset("institution", data=b'NASA JPL')
+        instrumentName_dset = identification_grp.create_dataset("instrumentName", data=b'Sentinel-1B CSAR')
         isGeocodedFlag = identification_grp.create_dataset("isGeocoded", data=True, dtype='bool')
-        isUrgentObservation_dset = identification_grp.create_dataset("isUrgentObservation",
-                                                                     data=np.array([False, True]), dtype='bool')
         lookDirection_dset = identification_grp.create_dataset("lookDirection", data=b'Right')
-        listOfFrequencies_dset = identification_grp.create_dataset("listOfFrequencies", data=np.array([b'A']))
         orbitPassDirection_dset = identification_grp.create_dataset("orbitPassDirection", data=b'Descending')
         platform_dset = identification_grp.create_dataset("platform", data=b'Sentinel-1B')
         processingDateTime_dset = identification_grp.create_dataset("processingDateTime",
                                                                     data=np.string_('2023-03-23T20:32:18.962836Z'))
         processingType_dset = identification_grp.create_dataset("processingType", data=b'UNDEFINED')
+        productID_dset = identification_grp.create_dataset("productID", data=b'OPERA_L2_RTC-S1_T069-147169-IW3_v0.4')
+        productLevel_dset = identification_grp.create_dataset("productLevel", data=b'L2')
+        productSpecificationVersion_dset = identification_grp.create_dataset("productSpecificationVersion", data=b'0.1')
         productType_dset = identification_grp.create_dataset("productType", data=b'SLC')
         productVersion_dset = identification_grp.create_dataset("productVersion", data=b'1.0')
+        project_dset = identification_grp.create_dataset("project", data=b'OPERA')
+        radarBand_dset = identification_grp.create_dataset("radarBand", data=b'C')
         trackNumber_dset = identification_grp.create_dataset("trackNumber", data=147170, dtype='int64')
         zeroDopplerEndTime_dset = identification_grp.create_dataset("zeroDopplerEndTime",
                                                                     data=b'2018-05-04T10:45:11.501279')

--- a/src/opera/util/metadata_utils.py
+++ b/src/opera/util/metadata_utils.py
@@ -440,16 +440,15 @@ def get_cslc_s1_product_metadata(file_name):
     """
     cslc_metadata = {
         'identification': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/identification"),
-        'grids': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/CSLC/grids"),
-        'corrections': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/CSLC/corrections"),
+        'data': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/data"),
         'calibration_information':
             get_hdf5_group_as_dict(file_name,
-                                   f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/calibration_information"),
+                                   f"{S1_SLC_HDF5_PREFIX}/metadata/calibration_information"),
         'noise_information': get_hdf5_group_as_dict(file_name,
-                                                    f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/noise_information"),
+                                                    f"{S1_SLC_HDF5_PREFIX}/metadata/noise_information"),
         'processing_information': get_hdf5_group_as_dict(file_name,
-                                                         f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/processing_information"),
-        'orbit': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/orbit")
+                                                         f"{S1_SLC_HDF5_PREFIX}/metadata/processing_information"),
+        'orbit': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/metadata/orbit")
     }
 
     return cslc_metadata
@@ -474,52 +473,59 @@ def create_test_cslc_metadata_product(file_path):
         bounding_polygon_dset = identification_grp.create_dataset(
             "bounding_polygon", data=np.string_("POLYGON ((-118.77 33.67, -118.72 33.68, ..., -118.77 33.67))"))
         burst_id_dset = identification_grp.create_dataset("burst_id", data=np.string_("t064_135518_iw1"))
+        instrument_name_dset = identification_grp.create_dataset("instrument_name", data=np.string_('C-SAR'))
         is_geocoded_flag_dset = identification_grp.create_dataset("is_geocoded", data=True, dtype='bool')
-        is_urgent_observation_dset = identification_grp.create_dataset("is_urgent_observation",
-                                                                       data=False, dtype='bool')
         look_direction_dset = identification_grp.create_dataset("look_direction", data=np.string_("Right"))
         mission_id_dset = identification_grp.create_dataset("mission_id", data=np.string_("S1A"))
         orbit_pass_direction_dset = identification_grp.create_dataset("orbit_pass_direction",
                                                                       data=np.string_("Ascending"))
+        processing_center_dset = identification_grp.create_dataset("processing_center",
+                                                                   data=np.string_("Jet Propulsion Laboratory"))
+        processing_date_time_dset = identification_grp.create_dataset("processing_date_time",
+                                                                      data=np.string_("2023-06-05 21:43:21.317243"))
+        product_level_dset = identification_grp.create_dataset("product_level", data=np.string_("L2"))
+        product_specification_version_dset = identification_grp.create_dataset("product_specification_version",
+                                                                               data=np.string_("3.2.1"))
         product_type_dset = identification_grp.create_dataset("product_type", data=np.string_("CSLC-S1"))
         product_version_dset = identification_grp.create_dataset("product_version", data=np.string_("1.0"))
+        radar_band_dset = identification_grp.create_dataset("radar_band", data=np.string_("C"))
         track_number_dset = identification_grp.create_dataset("track_number", data=64, dtype="int64")
         zero_doppler_end_time_dset = identification_grp.create_dataset("zero_doppler_end_time",
                                                                        data=np.string_("2022-05-01 01:50:38.106185"))
         zero_doppler_start_time_dset = identification_grp.create_dataset("zero_doppler_start_time",
                                                                          data=np.string_("2022-05-01 01:50:35.031073"))
 
-        grids_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/CSLC/grids")
-        projection_dset = grids_grp.create_dataset("projection", data=32611, dtype='int32')
-        x_coordinates_dset = grids_grp.create_dataset("x_coordinates", data=np.zeros((10,)), dtype='float64')
-        x_spacing_dset = grids_grp.create_dataset("x_spacing", data=5.0, dtype="float64")
-        y_coordinates_dset = grids_grp.create_dataset("y_coordinates", data=np.zeros((10,)), dtype='float64')
-        y_spacing_dset = grids_grp.create_dataset("y_spacing", data=-10.0, dtype='float64')
-
-        corrections_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/CSLC/corrections")
-        zero_doppler_time_spacing_dset = corrections_grp.create_dataset("zero_doppler_time_spacing",
-                                                                        data=0.027999999991152436, dtype='float64')
+        data_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/data")
+        projection_dset = data_grp.create_dataset("projection", data=32611, dtype='int32')
+        x_coordinates_dset = data_grp.create_dataset("x_coordinates", data=np.zeros((10,)), dtype='float64')
+        x_spacing_dset = data_grp.create_dataset("x_spacing", data=5.0, dtype="float64")
+        y_coordinates_dset = data_grp.create_dataset("y_coordinates", data=np.zeros((10,)), dtype='float64')
+        y_spacing_dset = data_grp.create_dataset("y_spacing", data=-10.0, dtype='float64')
 
         calibration_information_grp = outfile.create_group(
-            f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/calibration_information")
+            f"{S1_SLC_HDF5_PREFIX}/metadata/calibration_information")
         cal_basename_dset = calibration_information_grp.create_dataset(
             "basename",
             data=np.string_('calibration-s1a-iw1-slc-vv-20220501t015035-20220501t015102-043011-0522a4-004.xml'))
 
-        noise_information_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/noise_information")
+        noise_information_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/metadata/noise_information")
         noise_basename_dset = noise_information_grp.create_dataset(
             "basename",
             data=np.string_('noise-s1a-iw1-slc-vv-20220501t015035-20220501t015102-043011-0522a4-004.xml'))
 
-        processing_information_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/processing_information")
-        algorithms_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/processing_information/algorithms")
+        processing_information_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/metadata/processing_information")
+
+        algorithms_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/metadata/processing_information/algorithms")
         COMPASS_version_dset = algorithms_grp.create_dataset("COMPASS_version", data=np.string_("0.1.3"))
         ISCE3_version_dset = algorithms_grp.create_dataset("ISCE3_version", data=np.string_("0.9.0"))
         dem_interpolation_dset = algorithms_grp.create_dataset("dem_interpolation", data=np.string_("biquintic"))
-        geocoding_interpolator_dset = algorithms_grp.create_dataset("geocoding_interpolator",
-                                                                    data=np.string_("sinc interpolation"))
+        complex_data_geocoding_interpolator_dset = algorithms_grp.create_dataset("complex_data_geocoding_interpolator",
+                                                                                  data=np.string_("sinc interpolation"))
+        float_data_geocoding_interpolator_dset = algorithms_grp.create_dataset("float_data_geocoding_interpolator",
+                                                                               data=np.string_("biquintic interpolation"))
         s1Reader_version_dset = algorithms_grp.create_dataset("s1Reader_version", data=np.string_("0.1.5"))
-        inputs_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/processing_information/inputs")
+
+        inputs_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/metadata/processing_information/inputs")
         calibration_file_dset = inputs_grp.create_dataset("calibration_file", data=np.string_(
             'calibration-s1a-iw1-slc-vv-20220501t015035-20220501t015102-043011-0522a4-004.xml'))
         dem_source_dset = inputs_grp.create_dataset("dem_source", data=np.string_('dem_4326.tiff'))
@@ -529,10 +535,43 @@ def create_test_cslc_metadata_product(file_path):
             'noise-s1a-iw1-slc-vv-20220501t015035-20220501t015102-043011-0522a4-004.xml'))
         orbit_files_dset = inputs_grp.create_dataset("orbit_files", data=np.array(
             [b'S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF']))
-        s1_burst_metadata_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}"
-                                                     f"/CSLC/metadata/processing_information/s1_burst_metadata")
+
+        burst_location_parameters_grp = outfile.create_group(
+            f"{S1_SLC_HDF5_PREFIX}/metadata/processing_information/inputs/burst_location_parameters")
+        burst_index_dset = burst_location_parameters_grp.create_dataset("burst_index", data=0, dtype='int64')
+        first_valid_line_dset = burst_location_parameters_grp.create_dataset("first_valid_line", data=0, dtype='int64')
+        first_valid_sample_dset = burst_location_parameters_grp.create_dataset("first_valid_sample", data=63, dtype='int64')
+        last_valid_line_dset = burst_location_parameters_grp.create_dataset("last_valid_line", data=1477, dtype='int64')
+        last_valid_sample_dset = burst_location_parameters_grp.create_dataset("last_valid_sample", data=20531, dtype='int64')
+        tiff_path_dset = burst_location_parameters_grp.create_dataset("tiff_path", data=np.string_(
+            "s1a-iw1-slc-vv-20220501t015035-20220501t015102-043011-0522a4-004.tiff"))
+
+        processing_parameters_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/metadata/processing_information/parameters")
+        azimuth_fm_rate_applied_dset = processing_parameters_grp.create_dataset("azimuth_fm_rate_applied", data=True, dtype='bool')
+        azimuth_solid_earth_tides_applied_dset = processing_parameters_grp.create_dataset("azimuth_solid_earth_tides_applied",
+                                                                                          data=True, dtype='bool')
+        bistatic_delay_applied_dset = processing_parameters_grp.create_dataset("bistatic_delay_applied", data=True, dtype='bool')
+        dry_troposphere_weather_model_applied_dset = processing_parameters_grp.create_dataset("dry_troposphere_weather_model_applied",
+                                                                                              data=True, dtype='bool')
+        ellipsoidal_flattening_applied_dset = processing_parameters_grp.create_dataset("ellipsoidal_flattening_applied",
+                                                                                       data=True, dtype='bool')
+        geometry_doppler_applied_dset = processing_parameters_grp.create_dataset("geometry_doppler_applied", data=True,
+                                                                                 dtype='bool')
+        ionosphere_tec_applied_dset = processing_parameters_grp.create_dataset("ionosphere_tec_applied", data=True,
+                                                                               dtype='bool')
+        los_solid_earth_tides_applied_dset = processing_parameters_grp.create_dataset("los_solid_earth_tides_applied",
+                                                                                      data=True, dtype='bool')
+        static_troposphere_applied_dset = processing_parameters_grp.create_dataset("static_troposphere_applied",
+                                                                                   data=True, dtype='bool')
+        topographic_flattening_applied_dset = processing_parameters_grp.create_dataset("topographic_flattening_applied",
+                                                                                       data=True, dtype='bool')
+        wet_troposphere_weather_model_applied_dset = processing_parameters_grp.create_dataset("wet_troposphere_weather_model_applied",
+                                                                                              data=True, dtype='bool')
+
+        input_burst_metadata_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}"
+                                                        f"/metadata/processing_information/input_burst_metadata")
         azimuth_fm_rate_grp = outfile.create_group(
-            f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/processing_information/s1_burst_metadata/azimuth_fm_rate")
+            f"{S1_SLC_HDF5_PREFIX}/metadata/processing_information/input_burst_metadata/azimuth_fm_rate")
         azimuth_fm_rate_coeffs_dset = azimuth_fm_rate_grp.create_dataset("coeffs",
                                                                          data=np.array([-2.32880269e+03, 4.49603956e+05,
                                                                                         -7.86316555e+07]),
@@ -540,52 +579,52 @@ def create_test_cslc_metadata_product(file_path):
         azimuth_fm_rate_mean_dset = azimuth_fm_rate_grp.create_dataset("mean", data=800082.3526126802, dtype='float64')
         azimuth_fm_rate_order_dset = azimuth_fm_rate_grp.create_dataset("order", data=2, dtype='int64')
         azimuth_fm_rate_std_dset = azimuth_fm_rate_grp.create_dataset("std", data=149896229.0, dtype='float64')
-        azimuth_steering_rate_dset = s1_burst_metadata_grp.create_dataset("azimuth_steering_rate",
-                                                                          data=0.027757171601738514, dtype='float64')
-        azimuth_time_interval_dset = s1_burst_metadata_grp.create_dataset("azimuth_time_interval",
-                                                                          data=0.002055556299999998, dtype='float64')
-        center_dset = s1_burst_metadata_grp.create_dataset("center", data=np.array([-118.30363047, 33.8399832]),
-                                                           dtype='float64')
+        azimuth_steering_rate_dset = input_burst_metadata_grp.create_dataset("azimuth_steering_rate",
+                                                                             data=0.027757171601738514, dtype='float64')
+        azimuth_time_interval_dset = input_burst_metadata_grp.create_dataset("azimuth_time_interval",
+                                                                             data=0.002055556299999998, dtype='float64')
+        center_dset = input_burst_metadata_grp.create_dataset("center", data=np.array([-118.30363047, 33.8399832]),
+                                                              dtype='float64')
         doppler_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}"
-                                           f"/CSLC/metadata/processing_information/s1_burst_metadata/doppler")
+                                           f"/metadata/processing_information/input_burst_metadata/doppler")
         doppler_coeffs_dset = doppler_grp.create_dataset("coeffs",
                                                          data=np.array([-3.356279e+01, 8.696714e+04, -8.216876e+07]),
                                                          dtype='float64')
         doppler_mean_dset = doppler_grp.create_dataset("mean", data=800229.7806151338, dtype='float64')
         doppler_order_dset = doppler_grp.create_dataset("order", data=2, dtype='int64')
         doppler_std_dset = doppler_grp.create_dataset("std", data=149896229.0, dtype='float64')
-        ipf_version_dset = s1_burst_metadata_grp.create_dataset("ipf_version", data=np.string_("3.51"))
-        iw2_mid_range_dset = s1_burst_metadata_grp.create_dataset("iw2_mid_range", data=876175.1695277416,
+        ipf_version_dset = input_burst_metadata_grp.create_dataset("ipf_version", data=np.string_("3.51"))
+        iw2_mid_range_dset = input_burst_metadata_grp.create_dataset("iw2_mid_range", data=876175.1695277416,
                                                                   dtype='float64')
-        platform_id_dset = s1_burst_metadata_grp.create_dataset("platform_id", data=np.string_("S1A"))
-        polarization_dset = s1_burst_metadata_grp.create_dataset("polarization", data=np.string_("VV"))
-        prf_raw_data_dset = s1_burst_metadata_grp.create_dataset("prf_raw_data", data=1717.128973878037,
+        platform_id_dset = input_burst_metadata_grp.create_dataset("platform_id", data=np.string_("S1A"))
+        polarization_dset = input_burst_metadata_grp.create_dataset("polarization", data=np.string_("VV"))
+        prf_raw_data_dset = input_burst_metadata_grp.create_dataset("prf_raw_data", data=1717.128973878037,
                                                                  dtype='float64')
-        radar_center_frequency_dset = s1_burst_metadata_grp.create_dataset("radar_center_frequency",
+        radar_center_frequency_dset = input_burst_metadata_grp.create_dataset("radar_center_frequency",
                                                                            data=5405000454.33435, dtype='float64')
-        range_bandwidth_dset = s1_burst_metadata_grp.create_dataset("range_bandwidth", data=56500000.0, dtype='float64')
-        range_chirp_rate_dset = s1_burst_metadata_grp.create_dataset("range_chirp_rate", data=1078230321255.894,
+        range_bandwidth_dset = input_burst_metadata_grp.create_dataset("range_bandwidth", data=56500000.0, dtype='float64')
+        range_chirp_rate_dset = input_burst_metadata_grp.create_dataset("range_chirp_rate", data=1078230321255.894,
                                                                      dtype='float64')
-        range_pixel_spacing_dset = s1_burst_metadata_grp.create_dataset("range_pixel_spacing", data=2.329562114715323,
+        range_pixel_spacing_dset = input_burst_metadata_grp.create_dataset("range_pixel_spacing", data=2.329562114715323,
                                                                         dtype='float64')
-        range_sampling_rate_dset = s1_burst_metadata_grp.create_dataset("range_sampling_rate", data=64345238.12571428,
+        range_sampling_rate_dset = input_burst_metadata_grp.create_dataset("range_sampling_rate", data=64345238.12571428,
                                                                         dtype='float64')
-        range_window_coefficient_dset = s1_burst_metadata_grp.create_dataset('range_window_coefficient', data=0.75,
+        range_window_coefficient_dset = input_burst_metadata_grp.create_dataset('range_window_coefficient', data=0.75,
                                                                              dtype='float64')
-        range_window_type_dset = s1_burst_metadata_grp.create_dataset("range_window_type", data=np.string_('Hamming'))
-        rank_dset = s1_burst_metadata_grp.create_dataset("rank", data=9, dtype='int64')
-        sensing_start_dset = s1_burst_metadata_grp.create_dataset("sensing_start",
+        range_window_type_dset = input_burst_metadata_grp.create_dataset("range_window_type", data=np.string_('Hamming'))
+        rank_dset = input_burst_metadata_grp.create_dataset("rank", data=9, dtype='int64')
+        sensing_start_dset = input_burst_metadata_grp.create_dataset("sensing_start",
                                                                   data=np.string_('2022-05-01 01:50:35.031073'))
-        sensing_stop_dset = s1_burst_metadata_grp.create_dataset("sensing_stop",
+        sensing_stop_dset = input_burst_metadata_grp.create_dataset("sensing_stop",
                                                                  data=np.string_('2022-05-01 01:50:38.106185'))
-        shape_dset = s1_burst_metadata_grp.create_dataset("shape", data=np.array([1497, 21576]), dtype='int64')
-        slant_range_time_dset = s1_burst_metadata_grp.create_dataset("slant_range_time",
+        shape_dset = input_burst_metadata_grp.create_dataset("shape", data=np.array([1497, 21576]), dtype='int64')
+        slant_range_time_dset = input_burst_metadata_grp.create_dataset("slant_range_time",
                                                                      data=0.00533757492066515, dtype='float64')
-        starting_range_dset = s1_burst_metadata_grp.create_dataset("starting_range",
+        starting_range_dset = input_burst_metadata_grp.create_dataset("starting_range",
                                                                    data=800082.3526126802, dtype='float64')
-        wavelength_dset = s1_burst_metadata_grp.create_dataset("wavelength", data=0.05546576, dtype='float64')
+        wavelength_dset = input_burst_metadata_grp.create_dataset("wavelength", data=0.05546576, dtype='float64')
 
-        orbit_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/CSLC/metadata/orbit")
+        orbit_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/metadata/orbit")
         orbit_direction_dset = orbit_grp.create_dataset("orbit_direction", data=np.string_("Ascending"))
         orbit_type_dset = orbit_grp.create_dataset("orbit_type", data=np.string_("POE"))
         position_x_dset = orbit_grp.create_dataset("position_x", data=np.zeros((12,)), dtype='float64')


### PR DESCRIPTION
## Description
- This branch updates the code for the CSLC-S1 and RTC-S1 PGE's to accommodate the CalVal release of the corresponding SAS. Updates include application of the latest "official" file naming conventions for the static layer output product(s), as well as addressing gaps in the ISO XML metadata.
   * To support the new file name convention for static layer products, a new `DataValidityStartTime` field has been added to the base PGE RunConfig schema. This field contains a datetime that is used in lieu of acquisition time in the static layer output file names.
- This branch also makes several enhancements to the integration test Jenkins pipeline:
   * The combined PGE/SAS .log file is now copied as a Jenkins artifact for each integration test.
   * The integration test pipeline now creates a temporary conda environment to ensure dependencies like gdal, h5py, pandas, etc. are available for use with the test.
   * Fixed bug in the RTC-S1 int test pipeline where the local scratch directory was not created properly
   * The RTC-S1 integration test now only runs on 10 bursts to cut the runtime down to under an hour

## Affected Issues
- Resolves #297
- Fixes #294

## Testing
- Existing unit tests have been updated where necessary to account for the new file name conventions and ISO xml template format
