### PR TITLE
326 Re-enable png output product validation for DISP-S1

### DIFF
--- a/.ci/scripts/disp_validate_product_opera_pge.py
+++ b/.ci/scripts/disp_validate_product_opera_pge.py
@@ -62,6 +62,7 @@ def compare_groups(
     test_group: h5py.Group,
     pixels_failed_threshold: float = 0.01,
     diff_threshold: float = 1e-5,
+    exclude_groups: list = []
 ) -> None:
     """Compare all datasets in two HDF5 files.
 
@@ -90,12 +91,17 @@ def compare_groups(
         )
 
     for key in golden_group.keys():
+        if exclude_groups and key in exclude_groups:
+            logger.info(f"group {key} has been excluded from comparison on the command line")
+            continue
+
         if isinstance(golden_group[key], h5py.Group):
             compare_groups(
                 golden_group[key],
                 test_group[key],
                 pixels_failed_threshold,
                 diff_threshold,
+                exclude_groups
             )
         else:
             test_dataset = test_group[key]
@@ -521,11 +527,11 @@ def _check_compressed_slc_dirs(golden: Filename, test: Filename) -> None:
         )
 
 
-def compare(golden: Filename, test: Filename, data_dset: str = DSET_DEFAULT) -> None:
+def compare(golden: Filename, test: Filename, data_dset: str = DSET_DEFAULT, exclude_groups: list = []) -> None:
     """Compare two HDF5 files for consistency."""
     logger.info("Comparing HDF5 contents...")
     with h5py.File(golden, "r") as hf_g, h5py.File(test, "r") as hf_t:
-        compare_groups(hf_g, hf_t)
+        compare_groups(hf_g, hf_t, exclude_groups=exclude_groups)
 
     logger.info("Checking geospatial metadata...")
     _check_raster_geometadata(
@@ -557,6 +563,11 @@ def get_parser(
     parser.add_argument("golden", help="The golden HDF5 file.")
     parser.add_argument("test", help="The test HDF5 file to be compared.")
     parser.add_argument("--data-dset", default=DSET_DEFAULT)
+    parser.add_argument('--exclude_groups',
+                        nargs='+',
+                        help=("List of group names to ignore for purposes "
+                              "of determining comparison success or failure."))
+
     parser.set_defaults(run_func=compare)
     return parser
 
@@ -564,4 +575,4 @@ def get_parser(
 if __name__ == "__main__":
     parser = get_parser()
     args = parser.parse_args()
-    compare(args.golden, args.test, args.data_dset)
+    compare(args.golden, args.test, args.data_dset, args.exclude_groups)

--- a/.ci/scripts/disp_validate_product_opera_pge.py
+++ b/.ci/scripts/disp_validate_product_opera_pge.py
@@ -64,7 +64,7 @@ def compare_groups(
     diff_threshold: float = 1e-5,
     exclude_groups: list = []
 ) -> None:
-    """Compare all datasets in two HDF5 files.
+    """Compare all datasets in two HDF5 files that are not in the exclude_groups.
 
     Parameters
     ----------
@@ -76,11 +76,13 @@ def compare_groups(
         The threshold of the percentage of pixels that can fail the comparison.
     diff_threshold : float, optional
         The abs. difference threshold between pixels to consider failing.
+    exclude_groups: list, optional
+        List of group names, e.g. pge_runconfig, to exclude from comparison.
 
     Raises
     ------
     ComparisonError
-        If the two files do not match in all datasets.
+        If the two files do not match in all compared datasets.
     """
     # Check if group names match
     if set(golden_group.keys()) != set(test_group.keys()):

--- a/.ci/scripts/test_int_disp_s1.sh
+++ b/.ci/scripts/test_int_disp_s1.sh
@@ -20,7 +20,7 @@ Integration Testing DISP-S1 PGE docker image...
 
 PGE_NAME="disp_s1"
 PGE_IMAGE="opera_pge/${PGE_NAME}"
-SAMPLE_TIME=15
+SAMPLE_TIME=2
 
 # defaults, test data and runconfig files should be updated as-needed to use
 # the latest available as defaults for use with the Jenkins pipeline call
@@ -116,7 +116,8 @@ else
                             -v "$SCRIPT_DIR":/scripts \
                             --entrypoint /opt/conda/bin/python ${PGE_IMAGE}:"${PGE_TAG}" \
                             /scripts/disp_validate_product_opera_pge.py \
-                            /out/${output_file} /exp/${expected_file})
+                            /out/${output_file} /exp/${expected_file} \
+                            --exclude_groups pge_runconfig)
     echo "$docker_out"
 
     if [[ "$docker_out" == *"ERROR"* ]]; then

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -111,13 +111,11 @@ class DispS1PostProcessorMixin(PostProcessorMixin):
         if not exists(png_file):
             error_msg = f"SAS output file {basename(png_file)} does not exist"
 
-            print(f"TODO: {error_msg}")
-            # self.logger.critical(self.name, ErrorCode.INVALID_OUTPUT, error_msg)
+            self.logger.critical(self.name, ErrorCode.INVALID_OUTPUT, error_msg)
         elif not getsize(png_file):
             error_msg = f"SAS output file {basename(png_file)} exists but is empty"
 
-            print(f"TODO: {error_msg}")
-            # self.logger.critical(self.name, ErrorCode.INVALID_OUTPUT, error_msg)
+            self.logger.critical(self.name, ErrorCode.INVALID_OUTPUT, error_msg)
 
         save_compressed_slc = self.runconfig.sas_config['product_path_group']['save_compressed_slc']
         if save_compressed_slc:

--- a/src/opera/test/pge/disp_s1/test_disp_s1_pge.py
+++ b/src/opera/test/pge/disp_s1/test_disp_s1_pge.py
@@ -465,7 +465,6 @@ class DispS1PgeTestCase(unittest.TestCase):
             shutil.rmtree(pge.runconfig.output_product_path)
 
             # PNG file is missing
-            '''
             runconfig_dict['RunConfig']['Groups']['PGE']['PrimaryExecutable']['ProgramOptions'] = \
                 ['-p disp_s1_pge_test/output_dir/compressed_slcs;',
                  'dd if=/dev/urandom of=disp_s1_pge_test/output_dir/20180101_20180330.unw.nc bs=1M count=1;',
@@ -482,10 +481,8 @@ class DispS1PgeTestCase(unittest.TestCase):
                 log_contents = infile.read()
             self.assertIn("SAS output file 20180101_20180330.unw.png does not exist", log_contents)
             shutil.rmtree(pge.runconfig.output_product_path)
-            '''
 
             # PNG is zero sized
-            '''
             runconfig_dict['RunConfig']['Groups']['PGE']['PrimaryExecutable']['ProgramOptions'] = \
                 ['-p disp_s1_pge_test/output_dir/compressed_slcs;',
                  'dd if=/dev/urandom of=disp_s1_pge_test/output_dir/20180101_20180330.unw.nc bs=1M count=1;',
@@ -503,7 +500,6 @@ class DispS1PgeTestCase(unittest.TestCase):
                 log_contents = infile.read()
             self.assertIn("SAS output file 20180101_20180330.unw.png exists but is empty", log_contents)
             shutil.rmtree(pge.runconfig.output_product_path)
-            '''
 
             # compressed_slc directory does not exist
             runconfig_dict['RunConfig']['Groups']['PGE']['PrimaryExecutable']['ProgramOptions'] = \


### PR DESCRIPTION
## Description
- Code that was written to validate the .png product needed to be enabled and tested with an updated DISP-S1 SAS delivery.
- A change was made to the DISP-S1 validation tool to ignore selective groups during comparison, and the pge_runconfig is now being excluded from comparison during the integration test.

## Affected Issues
- #326 
- #339 

## Testing
- Testing was done at the unit and integration level.
