### PR TITLE
DSWx-S1 HDF5 package installation fix

### DIFF
--- a/.ci/docker/Dockerfile_dswx_s1
+++ b/.ci/docker/Dockerfile_dswx_s1
@@ -50,7 +50,8 @@ RUN set -ex \
     && cp ${PGE_DEST_DIR}/opera/scripts/*_entrypoint.sh ${CONDA_ROOT}/bin \
     && chmod +x ${CONDA_ROOT}/bin/*_entrypoint.sh \
     && . ${CONDA_ROOT}/bin/activate root \
-    && conda install --yes --channel conda-forge --file ${PGE_DEST_DIR}/opera/requirements.txt
+    && python -m pip install -r ${PGE_DEST_DIR}/opera/requirements.txt \
+    && conda install --yes --channel conda-forge hdf5
 
 # Set the Docker entrypoint and clear the default command
 ENTRYPOINT ["sh", "-c", "exec ${CONDA_ROOT}/bin/pge_docker_entrypoint.sh \"${@}\"", "--"]

--- a/.ci/scripts/build_dswx_s1.sh
+++ b/.ci/scripts/build_dswx_s1.sh
@@ -78,7 +78,7 @@ else
 fi
 
 # Build the PGE docker image
-docker build ${PLATFORM} --rm --force-rm -t ${IMAGE}:${TAG} \
+docker build ${PLATFORM} --progress plain --rm --force-rm -t ${IMAGE}:${TAG} \
     --build-arg SAS_IMAGE=${SAS_IMAGE} \
     --build-arg BUILD_DATE_TIME=${BUILD_DATE_TIME} \
     --build-arg BUILD_VERSION=${TAG} \


### PR DESCRIPTION
## Description
- This branch fixes a bug in the container build configuration for the DSWx-S1 PGE, where a version of the hdf5 library compatible with the installation of h5py was not getting installed due to recent changes to requirements.txt

## Affected Issues
- Fixes #343 

## Testing
- The test_dswx_s1.sh script now successfully runs all DSWx-S1 unit tests within the container as expected.
