### PR TITLE
CSLC-S1 SAS Final PGE Integration

### DIFF
--- a/.ci/scripts/build_cslc_s1.sh
+++ b/.ci/scripts/build_cslc_s1.sh
@@ -24,7 +24,7 @@ BUILD_DATE_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 # defaults, SAS image should be updated as necessary for new image releases from ADT
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath $(dirname $(realpath $0))/../..)
 [ -z "${TAG}" ] && TAG="${USER}-dev"
-[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/cslc_s1:calval_0.4.0"
+[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/cslc_s1:final_0.5.1"
 
 echo "WORKSPACE: $WORKSPACE"
 echo "IMAGE: $IMAGE"

--- a/.ci/scripts/test_int_cslc_s1.sh
+++ b/.ci/scripts/test_int_cslc_s1.sh
@@ -26,9 +26,9 @@ SAMPLE_TIME=15
 # Test data should be uploaded to  s3://operasds-dev-pge/${PGE_NAME}/
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../..)
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
-[ -z "${INPUT_DATA}" ] && INPUT_DATA="delivery_cslc_s1_calval_0.4.0_expected_input_data.zip"
-[ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="delivery_cslc_s1_calval_0.4.0_expected_output.zip"
-[ -z "${RUNCONFIG}" ] && RUNCONFIG="opera_pge_cslc_s1_delivery_5.1_calval_runconfig.yaml"
+[ -z "${INPUT_DATA}" ] && INPUT_DATA="delivery_cslc_s1_final_0.5.1_expected_input_data.zip"
+[ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="delivery_cslc_s1_final_0.5.1_expected_output.zip"
+[ -z "${RUNCONFIG}" ] && RUNCONFIG="opera_pge_cslc_s1_delivery_6.1_final_runconfig.yaml"
 [ -z "${TMP_ROOT}" ] && TMP_ROOT="$DEFAULT_TMP_ROOT"
 
 # Create the test output directory in the workspace
@@ -44,7 +44,7 @@ test_int_setup_test_data
 trap test_int_trap_cleanup EXIT
 
 # Download the RunConfig for the static layers workflow
-static_runconfig="opera_pge_cslc_s1_static_delivery_5.1_calval_runconfig.yaml"
+static_runconfig="opera_pge_cslc_s1_static_delivery_6.1_final_runconfig.yaml"
 local_static_runconfig="${TMP_DIR}/runconfig/${static_runconfig}"
 echo "Downloading s3://operasds-dev-pge/${PGE_NAME}/${static_runconfig} to ${local_static_runconfig}"
 aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/${static_runconfig} ${local_static_runconfig} --no-progress
@@ -52,8 +52,8 @@ aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/${static_runconfig} ${local_static_r
 # Pull in validation script from S3.
 # Current source is https://raw.githubusercontent.com/opera-adt/COMPASS/main/src/compass/utils/validate_product.py
 local_validate_script=${TMP_DIR}/validate_product.py
-echo "Downloading s3://operasds-dev-pge/${PGE_NAME}/validate_cslc_product_calval_0.4.0.py to $local_validate_script"
-aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/validate_cslc_product_calval_0.4.0.py "$local_validate_script" --no-progress
+echo "Downloading s3://operasds-dev-pge/${PGE_NAME}/validate_cslc_product_final_0.5.1.py to $local_validate_script"
+aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/validate_cslc_product_final_0.5.1.py "$local_validate_script" --no-progress
 
 # overall_status values and their meanings
 # 0 - pass

--- a/examples/cslc_s1_sample_runconfig-v2.0.0.yaml
+++ b/examples/cslc_s1_sample_runconfig-v2.0.0.yaml
@@ -1,4 +1,4 @@
-# Sample RunConfig for use with the CSLC-S1 PGE v2.0.0-rc.2.1
+# Sample RunConfig for use with the CSLC-S1 PGE v2.0.0
 # This RunConfig should require minimal changes in order to be used with the
 # OPERA PCM.
 
@@ -38,7 +38,7 @@ RunConfig:
                     tec_file: /home/compass_user/input_dir/jplg1210.22i
 
                     # Burst database, must be an .sqlite3 file
-                    burst_database_file: /home/compass_user/input_dir/burst_db_20230713-bbox-only.sqlite
+                    burst_database_file: /home/compass_user/input_dir/burst_db_0.2.0_230831-bbox-only.sqlite
 
             ProductPathGroup:
                 # Path to where output products should be stored
@@ -61,7 +61,7 @@ RunConfig:
                 ProductIdentifier: CSLC_S1
 
                 # Product version specific to output products
-                ProductVersion: 1.0
+                ProductVersion: "1.0"
 
                 # Path to the executable to run, path must be reachable from
                 # within the Docker container (i.e. findable with a "which" command)
@@ -98,7 +98,7 @@ RunConfig:
                 # CSLC static layer product(s) should be considered valid.
                 # This field must be provided for CSLC-S1 jobs when static layer
                 # generation is enabled (see below), and must be of the form YYYYMMDD
-                DataValidityStartDate: 20140101
+                DataValidityStartDate: 20140403
 
             QAExecutable:
                 # Set to True to enable execution of an additional "Quality Assurance"
@@ -146,11 +146,13 @@ RunConfig:
                     # This section should match the DynamicAncillaryFilesGroup of the PGE RunConfig
                     dynamic_ancillary_file_group:
                         dem_file: /home/compass_user/input_dir/dem_4326.tiff
+                        dem_description: "Digital Elevation Model (DEM) for the NASA OPERA project version 1.1 (v1.1) based on the Copernicus DEM 30-m and Copernicus 90-m referenced to the WGS84 ellipsoid"
+
                         tec_file: /home/compass_user/input_dir/jplg1210.22i
 
                     static_ancillary_file_group:
                         # burst database sqlite file
-                        burst_database_file: /home/compass_user/input_dir/burst_db_20230713-bbox-only.sqlite
+                        burst_database_file: /home/compass_user/input_dir/burst_db_0.2.0_230831-bbox-only.sqlite
 
                     product_path_group:
                         # This should match the path used for OutputProductPath
@@ -166,7 +168,7 @@ RunConfig:
                         product_version: "1.0"
 
                         # Product specification document version
-                        product_specification_version: "0.1.5"
+                        product_specification_version: "0.1.7"
 
                     primary_executable:
                         # Must be one of CSLC_S1 or CSLC_S1_STATIC, this determines the type of

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Jinja2
 jsonschema
 mgrs
 PyYAML
-pylint==2.12.2
+pylint
 pytest
 pytest-cov
 yamale

--- a/src/opera/pge/base/schema/base_pge_schema.yaml
+++ b/src/opera/pge/base/schema/base_pge_schema.yaml
@@ -22,7 +22,7 @@ RunConfig:
 
       PrimaryExecutable:
         ProductIdentifier: str(required=False)
-        ProductVersion: num(required=False)
+        ProductVersion: any(str(), num(), required=False)
         CompositeReleaseID: str(required=False)
         ProgramPath: str(required=True)
         ProgramOptions: list(str(), min=0, required=False)

--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -837,7 +837,7 @@ class CslcS1Executor(CslcS1PreProcessorMixin, CslcS1PostProcessorMixin, PgeExecu
     LEVEL = "L2"
     """Processing Level for CSLC-S1 Products"""
 
-    PGE_VERSION = "2.0.0-rc.2.1"
+    PGE_VERSION = "2.0.0"
     """Version of the PGE (overrides default from base_pge)"""
 
     SAS_VERSION = "0.5.1"  # Final release https://github.com/opera-adt/COMPASS/releases/tag/v0.5.1

--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -840,7 +840,7 @@ class CslcS1Executor(CslcS1PreProcessorMixin, CslcS1PostProcessorMixin, PgeExecu
     PGE_VERSION = "2.0.0-rc.2.1"
     """Version of the PGE (overrides default from base_pge)"""
 
-    SAS_VERSION = "0.4.0"  # CalVal# release https://github.com/opera-adt/COMPASS/releases/tag/v0.4.0
+    SAS_VERSION = "0.5.1"  # Final release https://github.com/opera-adt/COMPASS/releases/tag/v0.5.1
     """Version of the SAS wrapped by this PGE, should be updated as needed"""
 
     def __init__(self, pge_name, runconfig_path, **kwargs):

--- a/src/opera/pge/cslc_s1/schema/cslc_s1_sas_schema.yaml
+++ b/src/opera/pge/cslc_s1/schema/cslc_s1_sas_schema.yaml
@@ -21,6 +21,8 @@ runconfig:
     dynamic_ancillary_file_group:
       # Digital Elevation Model.
       dem_file: str(required=False)
+      # Description for DEM used for the processing
+      dem_description: str(required=False)
       # TEC file in IONEX format for ionosphere correction
       tec_file: str(required=False)
       # Troposphere weather model

--- a/src/opera/pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
+++ b/src/opera/pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
@@ -486,7 +486,7 @@
                 <gmd:MD_TopicCategoryCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/gmxCodelists.xml#MD_TopicCategoryCode" codeListValue="geoscientificInformation">geoscientificInformation</gmd:MD_TopicCategoryCode>
             </gmd:topicCategory>
             <gmd:environmentDescription>
-                <gco:CharacterString>Data product generated in Cloud-Optimized GeoTIFF format with ISO 19115 conformant metadata.</gco:CharacterString>
+                <gco:CharacterString>Data product generated in HDF5 format with ISO 19115 conformant metadata.</gco:CharacterString>
             </gmd:environmentDescription>
             <!-- This section documents the granules spatial and temporal extent as well as the grid mapping names and the projection names - NOT the TilingIdentificationSystem. -->
             <gmd:extent>
@@ -1014,6 +1014,7 @@
                                         <gco:CharacterString>{{ product_output.processing_information.algorithms.dem_interpolation }}{# ISO_OPERA_demInterpolation #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
+                                {%- if run_config.Groups.SAS.runconfig.groups.primary_executable.product_type == 'CSLC_S1' %}
                                 <eos:AdditionalAttribute>
                                     <eos:reference>
                                         <eos:EOS_AdditionalAttributeDescription>
@@ -1024,7 +1025,7 @@
                                                 <gco:CharacterString>ComplexDataGeocodingInterpolator</gco:CharacterString>
                                             </eos:name>
                                             <eos:description>
-                                                <gco:CharacterString>Complex Data Geocoding interpolation algorithm algorithm</gco:CharacterString>
+                                                <gco:CharacterString>Complex Data Geocoding interpolation algorithm</gco:CharacterString>
                                             </eos:description>
                                             <eos:dataType>
                                                 <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
@@ -1035,6 +1036,50 @@
                                         <gco:CharacterString>{{ product_output.processing_information.algorithms.complex_data_geocoding_interpolator }}{# ISO_OPERA_complexDataGeocodingInterpolator #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
+                                {%- else %}
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>TopographyAlgorithm</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Topography generation algorithm</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.algorithms.topography_algorithm }}{# ISO_OPERA_topographyAlgorithm #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>UintDataGeocodingInterpolator</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>Unsigned int geocoding interpolation method</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.processing_information.algorithms.uint_data_geocoding_interpolator }}{# ISO_OPERA_uintDataGeocodingInterpolator #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                {%- endif %}
                                 <eos:AdditionalAttribute>
                                     <eos:reference>
                                         <eos:EOS_AdditionalAttributeDescription>
@@ -1203,6 +1248,7 @@
                                         <gco:CharacterString>{{ product_output.processing_information.inputs.burst_location_parameters.tiff_path }}{# ISO_OPERA_burstLocationLastValidSample #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
+                                {%- if run_config.Groups.SAS.runconfig.groups.primary_executable.product_type == 'CSLC_S1' %}
                                 <eos:AdditionalAttribute>
                                     <eos:reference>
                                         <eos:EOS_AdditionalAttributeDescription>
@@ -1455,6 +1501,7 @@
                                         <gco:CharacterString>{{ product_output.processing_information.parameters.wet_troposphere_weather_model_applied }}{# ISO_OPERA_wetTroposphereWeatherModelApplied #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
+                                {%- endif %}
                                 <eos:AdditionalAttribute>
                                     <eos:reference>
                                         <eos:EOS_AdditionalAttributeDescription>
@@ -1473,7 +1520,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.inputs.calibration_files|string }}{# ISO_OPERA_calibrationFiles #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.inputs.calibration_files|list|tojson }}{# ISO_OPERA_calibrationFiles #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1515,7 +1562,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.inputs.l1_slc_files|string }}{# ISO_OPERA_l1SlcFiles #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.inputs.l1_slc_files|list|tojson }}{# ISO_OPERA_l1SlcFiles #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1536,7 +1583,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.inputs.noise_files|string }}{# ISO_OPERA_noiseFiles #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.inputs.noise_files|list|tojson }}{# ISO_OPERA_noiseFiles #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1557,7 +1604,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.inputs.orbit_files|string }}{# ISO_OPERA_orbitFiles #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.inputs.orbit_files|list|tojson }}{# ISO_OPERA_orbitFiles #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1716,7 +1763,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.shape|string }}{# ISO_OPERA_shape #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.shape|list|tojson }}{# ISO_OPERA_shape #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -1944,7 +1991,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.azimuth_fm_rate.coeffs|string }}{# ISO_OPERA_azimuthFmRateCoeffs #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.azimuth_fm_rate.coeffs|list|tojson }}{# ISO_OPERA_azimuthFmRateCoeffs #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -2028,7 +2075,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.doppler.coeffs|string }}{# ISO_OPERA_dopplerCoeffs #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.processing_information.input_burst_metadata.doppler.coeffs|list|tojson }}{# ISO_OPERA_dopplerCoeffs #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -2289,7 +2336,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.orbit.time|string }}{# ISO_OPERA_orbitTime #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.orbit.time|list|tojson }}{# ISO_OPERA_orbitTime #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -2313,7 +2360,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.orbit.position_x|string }}{# ISO_OPERA_orbitPosX #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.orbit.position_x|list|tojson }}{# ISO_OPERA_orbitPosX #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -2337,7 +2384,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.orbit.position_y|string }}{# ISO_OPERA_orbitPosY #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.orbit.position_y|list|tojson }}{# ISO_OPERA_orbitPosY #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -2361,7 +2408,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.orbit.position_z|string }}{# ISO_OPERA_orbitPosZ #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.orbit.position_z|list|tojson }}{# ISO_OPERA_orbitPosZ #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -2385,7 +2432,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.orbit.velocity_x|string }}{# ISO_OPERA_orbitVelX #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.orbit.velocity_x|list|tojson }}{# ISO_OPERA_orbitVelX #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -2409,7 +2456,7 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.orbit.velocity_y|string }}{# ISO_OPERA_orbitVelY #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.orbit.velocity_y|list|tojson }}{# ISO_OPERA_orbitVelY #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                                 <eos:AdditionalAttribute>
@@ -2433,7 +2480,78 @@
                                         </eos:EOS_AdditionalAttributeDescription>
                                     </eos:reference>
                                     <eos:value>
-                                        <gco:CharacterString>{{ product_output.orbit.velocity_z|string }}{# ISO_OPERA_orbitVelZ #}</gco:CharacterString>
+                                        <gco:CharacterString>{{ product_output.orbit.velocity_z|list|tojson }}{# ISO_OPERA_orbitVelZ #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>QualityAssuranceOrbitInformation</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                <gco:CharacterString>The type of orbit ephemeris (i.e., restituted or precise) used for processing</gco:CharacterString>
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.quality_assurance.orbit_information|tojson }}{# ISO_OPERA_QaOrbitInformation #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>QualityAssurancePixelClassification</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                {%- if run_config.Groups.SAS.runconfig.groups.primary_executable.product_type == 'CSLC_S1' %}
+                                                <gco:CharacterString>Contains information on the percentage of valid pixels with the complex backscatter layer and the percentage of valid pixels covering land</gco:CharacterString>
+                                                {%- else %}
+                                                <gco:CharacterString>Contains information on the percentage of pixels labeled as affected by layover, shadow, or both</gco:CharacterString>
+                                                {%- endif %}
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.quality_assurance.pixel_classification|tojson }}{# ISO_OPERA_QaPixelClassification #}</gco:CharacterString>
+                                    </eos:value>
+                                </eos:AdditionalAttribute>
+                                <eos:AdditionalAttribute>
+                                    <eos:reference>
+                                        <eos:EOS_AdditionalAttributeDescription>
+                                            <eos:type>
+                                                <eos:EOS_AdditionalAttributeTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeTypeCode" codeListValue="processingInformation">processingInformation</eos:EOS_AdditionalAttributeTypeCode>
+                                            </eos:type>
+                                            <eos:name>
+                                                <gco:CharacterString>QualityAssuranceStatistics</gco:CharacterString>
+                                            </eos:name>
+                                            <eos:description>
+                                                {%- if run_config.Groups.SAS.runconfig.groups.primary_executable.product_type == 'CSLC_S1' %}
+                                                <gco:CharacterString>Includes a series of metrics which statistically characterize the main data layers contained in the /data group and the timing corrections LUTs contained in processing_information/timing_corrections</gco:CharacterString>
+                                                {%- else %}
+                                                <gco:CharacterString>A set of metrics which statistically characterize the floating-point geometry layers contained within the CSLC-S1-Static Layer product</gco:CharacterString>
+                                                {%- endif %}
+                                            </eos:description>
+                                            <eos:dataType>
+                                                <eos:EOS_AdditionalAttributeDataTypeCode codeList="https://cdn.earthdata.nasa.gov/iso/resources/Codelist/eosCodelists.xml#EOS_AdditionalAttributeDataTypeCode" codeListValue="string">string</eos:EOS_AdditionalAttributeDataTypeCode>
+                                            </eos:dataType>
+                                        </eos:EOS_AdditionalAttributeDescription>
+                                    </eos:reference>
+                                    <eos:value>
+                                        <gco:CharacterString>{{ product_output.quality_assurance.statistics|tojson }}{# ISO_OPERA_QaRfiInformation #}</gco:CharacterString>
                                     </eos:value>
                                 </eos:AdditionalAttribute>
                             </eos:AdditionalAttributes>
@@ -2451,7 +2569,7 @@
                     <gmd:distributionFormat>
                         <gmd:MD_Format>
                             <gmd:name>
-                                <gco:CharacterString>GeoTIFF</gco:CharacterString>
+                                <gco:CharacterString>HDF5</gco:CharacterString>
                             </gmd:name>
                         </gmd:MD_Format>
                     </gmd:distributionFormat>

--- a/src/opera/test/data/test_cslc_s1_config.yaml
+++ b/src/opera/test/data/test_cslc_s1_config.yaml
@@ -24,7 +24,7 @@ RunConfig:
 
             PrimaryExecutable:
                 ProductIdentifier: CSLC_S1
-                ProductVersion: 1.0
+                ProductVersion: "1.0"
                 ProgramPath: mkdir
                 ProgramOptions:
                     - '-p cslc_pge_test/output_dir/t064_135518_iw1/20220501/;'

--- a/src/opera/test/data/test_cslc_s1_static_config.yaml
+++ b/src/opera/test/data/test_cslc_s1_static_config.yaml
@@ -1,0 +1,77 @@
+RunConfig:
+    Name: OPERA-CSLC-S1-PGE-TEST-CONFIG
+
+    Groups:
+
+        PGE:
+            PGENameGroup:
+                PGEName: CSLC_S1_PGE
+
+            InputFilesGroup:
+                InputFilePaths:
+                    - cslc_pge_test/input_dir/S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC.zip
+                    - cslc_pge_test/input_dir/S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF
+
+            DynamicAncillaryFilesGroup:
+                AncillaryFileMap:
+                    dem_file: cslc_pge_test/input_dir/dem_4326.tiff
+                    tec_file: cslc_pge_test/input_dir/jplg1210.22i
+                    burst_database_file: cslc_pge_test/input_dir/opera_burst_database_deploy_2022_1212.sqlite3
+
+            ProductPathGroup:
+                OutputProductPath: cslc_pge_test/output_dir
+                ScratchPath: cslc_pge_test/output_dir/scratch_dir
+
+            PrimaryExecutable:
+                ProductIdentifier: CSLC_S1
+                ProductVersion: "1.0"
+                ProgramPath: mkdir
+                ProgramOptions:
+                    - '-p cslc_pge_test/output_dir/t064_135518_iw1/20220501/;'
+                    - 'python3 -c "from opera.util.metadata_utils import create_test_cslc_metadata_product; create_test_cslc_metadata_product(\"cslc_pge_test/output_dir/t064_135518_iw1/20220501/static_layers_t064_135518_iw1_20220501.h5\")";'
+                    - '/bin/echo CSLC-S1 invoked with RunConfig'
+                ErrorCodeBase: 200000
+                SchemaPath: pge/cslc_s1/schema/cslc_s1_sas_schema.yaml
+                IsoTemplatePath: pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
+                DataValidityStartDate: 20000101
+
+            QAExecutable:
+                Enabled: False
+                ProgramPath:
+                ProgramOptions: []
+
+            DebugLevelGroup:
+                DebugSwitch: False
+                ExecuteViaShell: True  # Must be set to True for test to work
+
+        SAS:
+            runconfig:
+                name: cslc_s1_workflow_default
+
+                groups:
+                    pge_name_group:
+                        pge_name: CSLC_S1_PGE
+
+                    input_file_group:
+                        safe_file_path:
+                            - cslc_pge_test/input_dir/S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC.zip
+                        orbit_file_path:
+                            - cslc_pge_test/input_dir/S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF
+                        burst_id:
+                            - t064_135518_iw1
+
+                    dynamic_ancillary_file_group:
+                        dem_file: cslc_pge_test/input_dir/dem_4326.tiff
+                        tec_file: cslc_pge_test/input_dir/jplg1210.22i
+
+                    static_ancillary_file_group:
+                        burst_database_file: cslc_pge_test/input_dir/db.sqlite3
+
+                    product_path_group:
+                        product_path: output_dir
+                        scratch_path: output_dir/scratch_dir
+                        sas_output_file: output_s1_cslc
+                        product_version: "1.0"
+
+                    primary_executable:
+                        product_type: CSLC_S1_STATIC

--- a/src/opera/test/data/test_dswx_s1_config.yaml
+++ b/src/opera/test/data/test_dswx_s1_config.yaml
@@ -19,7 +19,7 @@ RunConfig:
         ScratchPath: dswx_s1_pge_test/scratch_dir
       PrimaryExecutable:
         ProductIdentifier: DSWX_S1
-        ProductVersion: 1.0
+        ProductVersion: "1.0"
         ProgramPath: /bin/echo
         ProgramOptions:
         - hello world > dswx_s1_pge_test/output_dir/OPERA_L3_DSWx-S1_T18MVA_20200702T231843Z_20230317T190549Z_v0.1_B01_WTR.tif;

--- a/src/opera/test/data/test_rtc_s1_config.yaml
+++ b/src/opera/test/data/test_rtc_s1_config.yaml
@@ -21,7 +21,7 @@ RunConfig:
 
             PrimaryExecutable:
                 ProductIdentifier: RTC_S1
-                ProductVersion: 1.0
+                ProductVersion: "1.0"
                 ProgramPath: mkdir
                 ProgramOptions:
                     - '-p rtc_s1_test/output_dir/t069_147170_iw1/;'

--- a/src/opera/test/util/test_logger.py
+++ b/src/opera/test/util/test_logger.py
@@ -134,7 +134,9 @@ class LoggerTestCase(unittest.TestCase):
         self.assertEqual(line_fields[1].strip(), severity)
         self.assertEqual(line_fields[2].strip(), workflow)
         self.assertEqual(line_fields[3].strip(), module)
-        self.assertEqual(line_fields[4].strip(), 'ErrorCode.OVERALL_SUCCESS')
+        # Python 3.11 (used by some SAS containers) changes the semantics of
+        # string representation for an IntEnum, so cover both cases here
+        self.assertIn(line_fields[4].strip(), ('0', 'ErrorCode.OVERALL_SUCCESS'))
         self.assertEqual(line_fields[5].strip(), error_location)
         self.assertEqual(line_fields[6].strip(), f'"{description}"')
 

--- a/src/opera/util/metadata_utils.py
+++ b/src/opera/util/metadata_utils.py
@@ -493,7 +493,8 @@ def get_cslc_s1_product_metadata(file_name):
         'data': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/data", cslc_ignore_list),
         'processing_information': get_hdf5_group_as_dict(file_name,
                                                          f"{S1_SLC_HDF5_PREFIX}/metadata/processing_information"),
-        'orbit': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/metadata/orbit")
+        'orbit': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/metadata/orbit"),
+        'quality_assurance': get_hdf5_group_as_dict(file_name, f"{S1_SLC_HDF5_PREFIX}/quality_assurance")
     }
 
     return cslc_metadata
@@ -557,6 +558,9 @@ def create_test_cslc_metadata_product(file_path):
                                                                                   data=np.string_("sinc interpolation"))
         float_data_geocoding_interpolator_dset = algorithms_grp.create_dataset("float_data_geocoding_interpolator",
                                                                                data=np.string_("biquintic interpolation"))
+        topography_algorithm_dset = algorithms_grp.create_dataset("topography_algorithm", data=np.string_("isce3.geometry.topo"))
+        uint_data_geocoding_interpolator = algorithms_grp.create_dataset("uint_data_geocoding_interpolator",
+                                                                         data=np.string_("nearest neighbor interpolation"))
         s1_reader_version_dset = algorithms_grp.create_dataset("s1_reader_version", data=np.string_("0.2.0"))
 
         inputs_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/metadata/processing_information/inputs")
@@ -673,6 +677,19 @@ def create_test_cslc_metadata_product(file_path):
         velocity_y_dset = orbit_grp.create_dataset("velocity_y", data=np.zeros(12, ), dtype='float64')
         velocity_z_dset = orbit_grp.create_dataset("velocity_z", data=np.zeros(12, ), dtype='float64')
 
+        quality_assurance_grp = outfile.create_group(f"{S1_SLC_HDF5_PREFIX}/quality_assurance")
+        orbit_information_grp = quality_assurance_grp.create_group('orbit_information')
+        qa_orbit_type_dset = orbit_information_grp.create_dataset('orbit_type', data=np.string_('precise_orbit_file'))
+        pixel_classification_grp = quality_assurance_grp.create_group('pixel_classification')
+        percent_land_pixels_dset = pixel_classification_grp.create_dataset('percent_land_pixels', data=59.38486551338992, dtype='float64')
+        percent_valid_pixels_dset = pixel_classification_grp.create_dataset('percent_valid_pixels', data=100.0, dtype='float64')
+        statistics_grp = quality_assurance_grp.create_group('statistics')
+        static_layers_grp = statistics_grp.create_group('static_layers')
+        local_incidence_angle_grp = static_layers_grp.create_group('local_incidence_angle')
+        max_dset = local_incidence_angle_grp.create_dataset('max', data=76.16073608398438, dtype='float64')
+        mean_dset = local_incidence_angle_grp.create_dataset('mean', data=36.48636245727539, dtype='float64')
+        min_dset = local_incidence_angle_grp.create_dataset('min', data=0.1674480438232422, dtype='float64')
+        std_dest = local_incidence_angle_grp.create_dataset('std', data=3.5223963260650635, dtype='float64')
 
 def get_disp_s1_product_metadata(file_name):
     """


### PR DESCRIPTION
## Description
- This branch integrates the Final SAS delivery for CSLC-S1 with the PGE library. Expected assets for the integration test have been updated, as well as the example RunConfig. This branch also updates the base PGE schema to allow product version to be a string or a number, so we can support specifying multi-part version numbers (i.e. 1.0.0 and not just 1.0).

## Affected Issues
- Resolves #352 

## Testing
- Unit tests have been updated to account for the change to the base PGE schema.
- The CSLC SAS image now utilizes Python 3.11, which changes the default behavior for how `IntEnum` values (such as our `ErrorCode` enum) are represented as strings. An affected test in `test_logger.py` has been updated to support both Python 3.11 and previous.
