### PR TITLE
DSWx-HLS Integration Test Comparison Step Refactor

### DIFF
--- a/.ci/scripts/cslc_s1/build_cslc_s1.sh
+++ b/.ci/scripts/cslc_s1/build_cslc_s1.sh
@@ -45,8 +45,6 @@ STAGING_DIR=$(mktemp -d -p ${WORKSPACE} docker_image_staging_XXXXXXXXXX)
 trap build_script_cleanup EXIT
 
 # Copy files to the staging area and build the PGE docker image
-mkdir -p ${STAGING_DIR}/opera/pge
-
 copy_pge_files $WORKSPACE $STAGING_DIR $PGE_NAME
 
 # Create a VERSION file in the staging area to track version and build time

--- a/.ci/scripts/cslc_s1/opera_pge_cslc_s1_delivery_6.1_final_runconfig.yaml
+++ b/.ci/scripts/cslc_s1/opera_pge_cslc_s1_delivery_6.1_final_runconfig.yaml
@@ -1,0 +1,113 @@
+RunConfig:
+    Name: OPERA-CSLC-S1-PGE-INT-TEST-CONFIG
+
+    Groups:
+        PGE:
+            PGENameGroup:
+                PGEName: CSLC_S1_PGE
+
+            InputFilesGroup:
+                InputFilePaths:
+                    - /home/compass_user/input_dir/S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC.zip
+                    - /home/compass_user/input_dir/S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF
+
+            DynamicAncillaryFilesGroup:
+                AncillaryFileMap:
+                    dem_file: /home/compass_user/input_dir/dem_4326.tiff
+
+                    tec_file: /home/compass_user/input_dir/jplg1210.22i
+
+                    burst_database_file: /home/compass_user/input_dir/burst_db_0.2.0_230831-bbox-only.sqlite
+
+            ProductPathGroup:
+                OutputProductPath: /home/compass_user/output_dir
+
+                ScratchPath: /home/compass_user/scratch
+
+            PrimaryExecutable:
+                ProductIdentifier: CSLC_S1
+
+                ProductVersion: "1.0"
+
+                ProgramPath: conda
+
+                ProgramOptions:
+                    - run
+                    - -n
+                    - COMPASS
+                    - s1_cslc.py
+
+                ErrorCodeBase: 200000
+
+                SchemaPath: /home/compass_user/opera/pge/cslc_s1/schema/cslc_s1_sas_schema.yaml
+
+                IsoTemplatePath: /home/compass_user/opera/pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
+
+                DataValidityStartDate: 20140403
+
+            QAExecutable:
+                Enabled: False
+
+                ProgramPath:
+
+                ProgramOptions:
+
+            DebugLevelGroup:
+                DebugSwitch: False
+
+                ExecuteViaShell: False
+
+        SAS:
+            runconfig:
+                name: cslc_s1_workflow_default
+
+                groups:
+                    pge_name_group:
+                        pge_name: CSLC_S1_PGE
+
+                    input_file_group:
+                        safe_file_path:
+                            - /home/compass_user/input_dir/S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC.zip
+                        orbit_file_path:
+                            - /home/compass_user/input_dir/S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF
+                        burst_id:
+                            - t064_135518_iw1
+                            - t064_135519_iw1
+                            - t064_135520_iw1
+                            - t064_135521_iw1
+                            - t064_135522_iw1
+                            - t064_135523_iw1
+                            - t064_135524_iw1
+                            - t064_135525_iw1
+                            - t064_135526_iw1
+                            - t064_135527_iw1
+
+                    dynamic_ancillary_file_group:
+                        dem_file: /home/compass_user/input_dir/dem_4326.tiff
+                        tec_file: /home/compass_user/input_dir/jplg1210.22i
+
+                    static_ancillary_file_group:
+                        burst_database_file: /home/compass_user/input_dir/burst_db_0.2.0_230831-bbox-only.sqlite
+
+                    product_path_group:
+                        product_path: /home/compass_user/output_dir
+
+                        scratch_path: /home/compass_user/scratch
+
+                        sas_output_file: /home/compass_user/output_dir
+
+                        product_version: "1.0"
+
+                    primary_executable:
+                        product_type: CSLC_S1
+
+                    processing:
+                        polarization: co-pol
+                        geocoding:
+                            flatten: True
+                            x_posting: 5
+                            y_posting: 10
+                        geo2rdr:
+                            lines_per_block: 1000
+                            threshold: 1.0e-8
+                            numiter: 25

--- a/.ci/scripts/cslc_s1/opera_pge_cslc_s1_static_delivery_6.1_final_runconfig.yaml
+++ b/.ci/scripts/cslc_s1/opera_pge_cslc_s1_static_delivery_6.1_final_runconfig.yaml
@@ -1,0 +1,113 @@
+RunConfig:
+    Name: OPERA-CSLC-S1-STATIC-PGE-INT-TEST-CONFIG
+
+    Groups:
+        PGE:
+            PGENameGroup:
+                PGEName: CSLC_S1_PGE
+
+            InputFilesGroup:
+                InputFilePaths:
+                    - /home/compass_user/input_dir/S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC.zip
+                    - /home/compass_user/input_dir/S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF
+
+            DynamicAncillaryFilesGroup:
+                AncillaryFileMap:
+                    dem_file: /home/compass_user/input_dir/dem_4326.tiff
+
+                    tec_file: /home/compass_user/input_dir/jplg1210.22i
+
+                    burst_database_file: /home/compass_user/input_dir/burst_db_0.2.0_230831-bbox-only.sqlite
+
+            ProductPathGroup:
+                OutputProductPath: /home/compass_user/output_dir
+
+                ScratchPath: /home/compass_user/scratch
+
+            PrimaryExecutable:
+                ProductIdentifier: CSLC_S1
+
+                ProductVersion: "1.0"
+
+                ProgramPath: conda
+
+                ProgramOptions:
+                    - run
+                    - -n
+                    - COMPASS
+                    - s1_cslc.py
+
+                ErrorCodeBase: 200000
+
+                SchemaPath: /home/compass_user/opera/pge/cslc_s1/schema/cslc_s1_sas_schema.yaml
+
+                IsoTemplatePath: /home/compass_user/opera/pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
+
+                DataValidityStartDate: 20140403
+
+            QAExecutable:
+                Enabled: False
+
+                ProgramPath:
+
+                ProgramOptions:
+
+            DebugLevelGroup:
+                DebugSwitch: False
+
+                ExecuteViaShell: False
+
+        SAS:
+            runconfig:
+                name: cslc_s1_workflow_default
+
+                groups:
+                    pge_name_group:
+                        pge_name: CSLC_S1_PGE
+
+                    input_file_group:
+                        safe_file_path:
+                            - /home/compass_user/input_dir/S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC.zip
+                        orbit_file_path:
+                            - /home/compass_user/input_dir/S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF
+                        burst_id:
+                            - t064_135518_iw1
+                            - t064_135519_iw1
+                            - t064_135520_iw1
+                            - t064_135521_iw1
+                            - t064_135522_iw1
+                            - t064_135523_iw1
+                            - t064_135524_iw1
+                            - t064_135525_iw1
+                            - t064_135526_iw1
+                            - t064_135527_iw1
+
+                    dynamic_ancillary_file_group:
+                        dem_file: /home/compass_user/input_dir/dem_4326.tiff
+                        tec_file: /home/compass_user/input_dir/jplg1210.22i
+
+                    static_ancillary_file_group:
+                        burst_database_file: /home/compass_user/input_dir/burst_db_0.2.0_230831-bbox-only.sqlite
+
+                    product_path_group:
+                        product_path: /home/compass_user/output_dir
+
+                        scratch_path: /home/compass_user/scratch
+
+                        sas_output_file: /home/compass_user/output_dir
+
+                        product_version: "1.0"
+
+                    primary_executable:
+                        product_type: CSLC_S1_STATIC
+
+                    processing:
+                        polarization: co-pol
+                        geocoding:
+                            flatten: True
+                            x_posting: 5
+                            y_posting: 10
+                        geo2rdr:
+                            lines_per_block: 1000
+                            threshold: 1.0e-8
+                            numiter: 25

--- a/.ci/scripts/cslc_s1/test_int_cslc_s1.sh
+++ b/.ci/scripts/cslc_s1/test_int_cslc_s1.sh
@@ -43,18 +43,6 @@ test_int_setup_test_data
 # Setup cleanup on exit
 trap test_int_trap_cleanup EXIT
 
-# Download the RunConfig for the static layers workflow
-static_runconfig="opera_pge_cslc_s1_static_delivery_6.1_final_runconfig.yaml"
-local_static_runconfig="${TMP_DIR}/runconfig/${static_runconfig}"
-echo "Downloading s3://operasds-dev-pge/${PGE_NAME}/${static_runconfig} to ${local_static_runconfig}"
-aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/${static_runconfig} ${local_static_runconfig} --no-progress
-
-# Pull in validation script from S3.
-# Current source is https://raw.githubusercontent.com/opera-adt/COMPASS/main/src/compass/utils/validate_product.py
-local_validate_script=${TMP_DIR}/validate_product.py
-echo "Downloading s3://operasds-dev-pge/${PGE_NAME}/validate_cslc_product_final_0.5.1.py to $local_validate_script"
-aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/validate_cslc_product_final_0.5.1.py "$local_validate_script" --no-progress
-
 # overall_status values and their meanings
 # 0 - pass
 # 1 - failure to execute some part of this script
@@ -63,6 +51,18 @@ overall_status=0
 
 input_dir="${TMP_DIR}/${INPUT_DATA%.*}/input_data"
 runconfig_dir="${TMP_DIR}/runconfig"
+
+# Copy the RunConfig for the static layers workflow
+static_runconfig="opera_pge_cslc_s1_static_delivery_6.1_final_runconfig.yaml"
+local_static_runconfig="${SCRIPT_DIR}/runconfig/${static_runconfig}"
+echo "Copying runconfig file $local_static_runconfig to $runconfig_dir/"
+cp ${local_static_runconfig} ${runconfig_dir}
+
+# Pull in validation script from S3.
+# Current source is https://raw.githubusercontent.com/opera-adt/COMPASS/main/src/compass/utils/validate_product.py
+local_validate_script=${TMP_DIR}/validate_product.py
+echo "Downloading s3://operasds-dev-pge/${PGE_NAME}/validate_cslc_product_final_0.5.1.py to $local_validate_script"
+aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/validate_cslc_product_final_0.5.1.py "$local_validate_script" --no-progress
 
 # the testdata reference metadata contains this path so we use it here
 output_dir="${TMP_DIR}/output_cslc_s1"

--- a/.ci/scripts/cslc_s1/test_int_cslc_s1.sh
+++ b/.ci/scripts/cslc_s1/test_int_cslc_s1.sh
@@ -24,7 +24,7 @@ SAMPLE_TIME=15
 # Defaults, test data and runconfig files should be updated as-needed to use
 # the latest available as defaults for use with the Jenkins pipeline call.
 # Test data should be uploaded to  s3://operasds-dev-pge/${PGE_NAME}/
-[ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../..)
+[ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../../..)
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
 [ -z "${INPUT_DATA}" ] && INPUT_DATA="delivery_cslc_s1_final_0.5.1_expected_input_data.zip"
 [ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="delivery_cslc_s1_final_0.5.1_expected_output.zip"

--- a/.ci/scripts/disp_s1/build_disp_s1.sh
+++ b/.ci/scripts/disp_s1/build_disp_s1.sh
@@ -45,8 +45,6 @@ STAGING_DIR=$(mktemp -d -p ${WORKSPACE} docker_image_staging_XXXXXXXXXX)
 trap build_script_cleanup EXIT
 
 # Copy files to the staging area and build the PGE docker image
-mkdir -p ${STAGING_DIR}/opera/pge
-
 copy_pge_files $WORKSPACE $STAGING_DIR $PGE_NAME
 
 # Create a VERSION file in the staging area to track version and build time

--- a/.ci/scripts/disp_s1/opera_pge_disp_s1_r3_beta_runconfig.yaml
+++ b/.ci/scripts/disp_s1/opera_pge_disp_s1_r3_beta_runconfig.yaml
@@ -1,0 +1,184 @@
+RunConfig:
+  Name: OPERA-DISP-S1-PGE-INT-TEST-CONFIG
+
+  Groups:
+    PGE:
+      PGENameGroup:
+        PGEName: DISP_S1_PGE
+
+      InputFilesGroup:
+        InputFilePaths:
+          - /home/mamba/input_dir/input_slcs/compressed_t042_088905_iw1_20221107_20230506.h5
+          - /home/mamba/input_dir/input_slcs/compressed_t042_088906_iw1_20221107_20230506.h5
+          - /home/mamba/input_dir/input_slcs/t042_088905_iw1_20221119.h5
+          - /home/mamba/input_dir/input_slcs/t042_088906_iw1_20221119.h5
+          - /home/mamba/input_dir/input_slcs/t042_088905_iw1_20221201.h5
+          - /home/mamba/input_dir/input_slcs/t042_088906_iw1_20221201.h5
+          - /home/mamba/input_dir/input_slcs/t042_088905_iw1_20221213.h5
+          - /home/mamba/input_dir/input_slcs/t042_088906_iw1_20221213.h5
+
+      DynamicAncillaryFilesGroup:
+        AncillaryFileMap:
+          dem_file: /home/mamba/input_dir/dynamic_ancillary_files/dem.tif
+          mask_file: /home/mamba/input_dir/dynamic_ancillary_files/watermask.flg
+          amplitude_dispersion_files:
+            - /home/mamba/input_dir/dynamic_ancillary_files/ps_files/t042_088905_iw1_amp_dispersion.tif
+            - /home/mamba/input_dir/dynamic_ancillary_files/ps_files/t042_088906_iw1_amp_dispersion.tif
+          amplitude_mean_files:
+            - /home/mamba/input_dir/dynamic_ancillary_files/ps_files/t042_088905_iw1_amp_mean.tif
+            - /home/mamba/input_dir/dynamic_ancillary_files/ps_files/t042_088906_iw1_amp_mean.tif
+          static_layers_files:
+            - /home/mamba/input_dir/dynamic_ancillary_files/static_layers/static_layers_t042_088905_iw1.h5
+            - /home/mamba/input_dir/dynamic_ancillary_files/static_layers/static_layers_t042_088906_iw1.h5
+          ionosphere_files:
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0060.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0180.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0300.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0420.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0540.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0660.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0780.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0900.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1020.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1140.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1260.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1380.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1500.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1620.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1860.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1980.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg2100.23i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg3230.22i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg3350.22i.Z
+            - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg3470.22i.Z
+          troposphere_files: []
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20221119_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20221201_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20221213_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230106_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230118_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230130_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230211_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230223_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230307_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230319_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230331_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230412_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230424_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230506_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230518_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230530_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230611_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230705_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230717_14.grb
+#            - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230729_14.grb
+
+      ProductPathGroup:
+        OutputProductPath: /home/mamba/output_dir
+        ScratchPath: /home/mamba/scratch_dir
+
+      PrimaryExecutable:
+        ProductIdentifier: DISP_S1
+        ProductVersion: "0.2"
+        ProgramPath: disp-s1
+        ProgramOptions: []
+        ErrorCodeBase: 500000
+        SchemaPath: /home/mamba/opera/pge/disp_s1/schema/disp_s1_sas_schema.yaml
+        AlgorithmParametersSchemaPath: /home/mamba/opera/pge/disp_s1/schema/algorithm_parameters_disp_s1_schema.yaml
+        IsoTemplatePath: /home/mamba/opera/pge/disp_s1/templates/OPERA_ISO_metadata_L3_DISP_S1_template.xml.jinja2
+
+      QAExecutable:
+        Enabled: False
+        ProgramPath:
+        ProgramOptions: []
+
+      DebugLevelGroup:
+        DebugSwitch: False
+        ExecuteViaShell: False
+    SAS:
+      input_file_group:
+        cslc_file_list:
+          - /home/mamba/input_dir/input_slcs/compressed_t042_088905_iw1_20221107_20230506.h5
+          - /home/mamba/input_dir/input_slcs/compressed_t042_088906_iw1_20221107_20230506.h5
+          - /home/mamba/input_dir/input_slcs/t042_088905_iw1_20221119.h5
+          - /home/mamba/input_dir/input_slcs/t042_088906_iw1_20221119.h5
+          - /home/mamba/input_dir/input_slcs/t042_088905_iw1_20221201.h5
+          - /home/mamba/input_dir/input_slcs/t042_088906_iw1_20221201.h5
+          - /home/mamba/input_dir/input_slcs/t042_088905_iw1_20221213.h5
+          - /home/mamba/input_dir/input_slcs/t042_088906_iw1_20221213.h5
+
+        frame_id: 11114
+      dynamic_ancillary_file_group:
+        algorithm_parameters_file: /home/mamba/input_dir/algorithm_parameters_forward.yaml
+        amplitude_dispersion_files:
+          - /home/mamba/input_dir/dynamic_ancillary_files/ps_files/t042_088905_iw1_amp_dispersion.tif
+          - /home/mamba/input_dir/dynamic_ancillary_files/ps_files/t042_088906_iw1_amp_dispersion.tif
+        amplitude_mean_files:
+          - /home/mamba/input_dir/dynamic_ancillary_files/ps_files/t042_088905_iw1_amp_mean.tif
+          - /home/mamba/input_dir/dynamic_ancillary_files/ps_files/t042_088906_iw1_amp_mean.tif
+        static_layers_files:
+          - /home/mamba/input_dir/dynamic_ancillary_files/static_layers/static_layers_t042_088905_iw1.h5
+          - /home/mamba/input_dir/dynamic_ancillary_files/static_layers/static_layers_t042_088906_iw1.h5
+        mask_file: /home/mamba/input_dir/dynamic_ancillary_files/watermask.flg
+        dem_file: /home/mamba/input_dir/dynamic_ancillary_files/dem.tif
+        ionosphere_files:
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0060.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0180.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0300.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0420.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0540.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0660.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0780.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg0900.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1020.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1140.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1260.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1380.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1500.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1620.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1860.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg1980.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg2100.23i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg3230.22i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg3350.22i.Z
+          - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg3470.22i.Z
+        troposphere_files: []
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20221119_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20221201_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20221213_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230106_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230118_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230130_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230211_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230223_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230307_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230319_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230331_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230412_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230424_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230506_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230518_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230530_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230611_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230705_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230717_14.grb
+#          - /home/mamba/input_dir/dynamic_ancillary_files/troposphere_files/ERA5_N30_N40_W120_W110_20230729_14.grb
+      static_ancillary_file_group:
+        frame_to_burst_json: /home/mamba/input_dir/opera-s1-disp-frame-to-burst.json
+      primary_executable:
+        product_type: DISP_S1_FORWARD
+      product_path_group:
+        product_path: /home/mamba/output_dir
+        scratch_path: /home/mamba/scratch_dir
+        sas_output_path: /home/mamba/output_dir
+        product_version: "0.2"
+        save_compressed_slc: true
+      worker_settings:
+        gpu_enabled: true
+        n_workers: 4
+        threads_per_worker: 2
+        n_parallel_bursts: 1
+        block_shape:
+          - 512
+          - 512
+      log_file: /home/mamba/output_dir/sas_logfile.log

--- a/.ci/scripts/disp_s1/test_int_disp_s1.sh
+++ b/.ci/scripts/disp_s1/test_int_disp_s1.sh
@@ -26,7 +26,7 @@ SAMPLE_TIME=2
 # the latest available as defaults for use with the Jenkins pipeline call
 # INPUT/OUTPUT_DATA should be the name of the corresponding archives in s3://operasds-dev-pge/disp_s1/
 # RUNCONFIG should be the name of the runconfig in s3://operasds-dev-pge/disp_s1/
-[ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../..)
+[ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../../..)
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
 [ -z "${INPUT_DATA}" ] && INPUT_DATA="disp_s1_r3_beta_expected_input.zip"
 [ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="disp_s1_r3_beta_expected_output.zip"

--- a/.ci/scripts/dswx_hls/build_dswx_hls.sh
+++ b/.ci/scripts/dswx_hls/build_dswx_hls.sh
@@ -69,7 +69,7 @@ else
 fi
 
 # Build the PGE docker image
-docker build ${PLATFORM} --rm --force-rm -t ${IMAGE}:${TAG} \
+docker build ${PLATFORM} --progress plain --rm --force-rm -t ${IMAGE}:${TAG} \
     --build-arg SAS_IMAGE=${SAS_IMAGE} \
     --build-arg BUILD_DATE_TIME=${BUILD_DATE_TIME} \
     --build-arg BUILD_VERSION=${TAG} \

--- a/.ci/scripts/dswx_hls/build_dswx_hls.sh
+++ b/.ci/scripts/dswx_hls/build_dswx_hls.sh
@@ -45,8 +45,6 @@ STAGING_DIR=$(mktemp -d -p ${WORKSPACE} docker_image_staging_XXXXXXXXXX)
 trap build_script_cleanup EXIT
 
 # Copy files to the staging area and build the PGE docker image
-mkdir -p ${STAGING_DIR}/opera/pge
-
 copy_pge_files $WORKSPACE $STAGING_DIR $PGE_NAME
 
 # Create a VERSION file in the staging area to track version and build time

--- a/.ci/scripts/dswx_hls/compare_dswx_hls_products.sh
+++ b/.ci/scripts/dswx_hls/compare_dswx_hls_products.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# Script used to orchestrate the pairwise comparison of output and expected
+# DSWx-HLS products. Each individual pair of products is compared using the
+# dswx_hls_compare.py script.
+
+set -e
+umask 002
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+. "$SCRIPT_DIR"/../util/test_int_util.sh
+
+# TODO: add validation that OUTPUT/EXPECTED exist within container
+OUTPUT_DIR="/home/conda/output_dir"
+EXPECTED_DIR="/home/conda/expected_output_dir"
+PGE_NAME="dswx_hls"
+
+initialize_html_results_file "$OUTPUT_DIR" "$PGE_NAME"
+
+# overall_status values and their meaning
+# 0 - pass
+# 1 - failure to execute some part of this script
+# 2 - product validation failure
+overall_status=0
+
+# Compare output files against expected files
+for output_file in "$OUTPUT_DIR"/*
+do
+    compare_out="N/A"
+    compare_result="N/A"
+    expected_file="N/A"
+
+    echo "Evaluating output file $output_file"
+
+    if [[ "${output_file##*/}" == *.tif* ]]
+    then
+        # Determine the type of the current output product
+        for potential_product in B01_WTR B02_BWTR B03_CONF B04_DIAG B05_WTR-1 B06_WTR-2 B07_LAND B08_SHAD B09_CLOUD B10_DEM BROWSE
+        do
+            if [[ "$output_file" == *"$potential_product"* ]]; then
+                product=$potential_product
+                break
+            fi
+        done
+
+        echo "Product type is $product"
+
+        # Find the matching product type in the list of expected products
+        for potential_file in "$EXPECTED_DIR"/*.tif*
+        do
+            if [[ "$potential_file" == *"$product"* ]]; then
+                expected_file=$potential_file
+                echo "Expected output file is $expected_file"
+                break
+            fi
+        done
+
+        if [ ! -f "$expected_file" ]; then
+            echo "No expected file found for product type $product in expected directory $EXPECTED_DIR"
+            overall_status=1
+        else
+            # Compare the output and expected files with the Python script
+            # furnished from ADT
+            compare_out=$("$SCRIPT_DIR"/dswx_hls_compare.py \
+                          "${output_file}" "${expected_file}" -x "PRODUCT_VERSION")
+
+            echo "$compare_out"
+
+            if [[ "$compare_out" == *"[FAIL]"* ]]; then
+                echo "File comparison failed. Output and expected files differ for ${output_file}"
+                compare_result="FAIL"
+                overall_status=2
+            elif [[ "$compare_out" == *"ERROR"* ]]; then
+                echo "An error occurred during file comparison."
+                compare_result="ERROR"
+                overall_status=1
+            else
+                echo "File comparison passed for ${output_file}"
+                compare_result="PASS"
+            fi
+        fi
+    else
+        echo "Not comparing file ${output_file}"
+        compare_result="SKIPPED"
+    fi
+
+    compare_out="${compare_out//$'\n'/<br>}"
+    update_html_results_file "${compare_result}" "${output_file}" "${expected_file}" "${compare_out}"
+done
+
+finalize_html_results_file
+
+# Write the status code to an RC file so the integration test script can pick
+# it up.
+echo $overall_status > $OUTPUT_DIR/"compare_dswx_hls_products.rc"
+
+# Always want to return 0 even if some comparisons failed to avoid error handling
+# logic in the PGE
+exit 0

--- a/.ci/scripts/dswx_hls/dswx_hls_compare.py
+++ b/.ci/scripts/dswx_hls/dswx_hls_compare.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import numpy as np
 import os
@@ -6,7 +8,10 @@ from osgeo import gdal
 COMPARE_DSWX_HLS_PRODUCTS_ERROR_TOLERANCE_ATOL = 1e-6
 COMPARE_DSWX_HLS_PRODUCTS_ERROR_TOLERANCE_RTOL = 1e-5
 
-DEFAULT_METADATA_EXCLUDE_LIST = ['PROCESSING_DATETIME', 'DEM_SOURCE', 'LANDCOVER_SOURCE', 'WORLDCOVER_SOURCE']
+DEFAULT_METADATA_EXCLUDE_LIST = ['PROCESSING_DATETIME',
+                                 'DEM_SOURCE',
+                                 'LANDCOVER_SOURCE',
+                                 'WORLDCOVER_SOURCE']
 PREFIX = ' ' * 7
 
 
@@ -33,7 +38,7 @@ def _get_prefix_str(current_flag, flag_all_ok):
     return flag_all_ok, prefix_str
 
 
-def compare_dswx_hls_products(file_1, file_2, metadata_exclude_list=[]):
+def compare_dswx_hls_products(file_1, file_2, metadata_exclude_list):
     """
     Compare DSWx-HLS products in various ways
 
@@ -133,7 +138,7 @@ def compare_dswx_hls_products(file_1, file_2, metadata_exclude_list=[]):
 
     # compare metadata
     metadata_compare_message, flag_same_metadata = \
-        _compare_dswx_hls_metadata(metadata_1, metadata_2, metadata_exclude_list=metadata_exclude_list)
+        _compare_dswx_hls_metadata(metadata_1, metadata_2, metadata_exclude_list)
 
     flag_all_ok, flag_same_metadata_str = _get_prefix_str(flag_same_metadata, flag_all_ok)
     print(f'{flag_same_metadata_str}Comparing metadata')
@@ -144,7 +149,7 @@ def compare_dswx_hls_products(file_1, file_2, metadata_exclude_list=[]):
     return flag_all_ok
 
 
-def _compare_dswx_hls_metadata(metadata_1, metadata_2, metadata_exclude_list=[]):
+def _compare_dswx_hls_metadata(metadata_1, metadata_2, metadata_exclude_list):
     """
     Compare DSWx-HLS products' metadata
 
@@ -163,6 +168,7 @@ def _compare_dswx_hls_metadata(metadata_1, metadata_2, metadata_exclude_list=[])
         A string containing any metadata comparison failure messages
     flag_same_metadata: bool
         Flag indicating that metadata comparison succeeded
+
     """
     flag_same_metadata = True
     metadata_compare_message = ""
@@ -204,11 +210,10 @@ def _compare_dswx_hls_metadata(metadata_1, metadata_2, metadata_exclude_list=[])
 
 
 if __name__ == "__main__":
-
     desc = "Compare two DSWx-HLS product files."
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument('files', nargs=2, help="Product filenames to be compared.")
-    parser.add_argument('--metadata_exclude_list',
+    parser.add_argument('--metadata-exclude-list', '-x',
                         nargs='+',
                         help=("Metadata field names to ignore for purposes "
                               "of determining comparison success or failure."))
@@ -217,10 +222,11 @@ if __name__ == "__main__":
     file_2 = args.files[1]
 
     metadata_exclude_list = DEFAULT_METADATA_EXCLUDE_LIST
-    if args.metadata_exclude_list:
-        metadata_exclude_list += args.metadata_exclude_list
 
-    result = compare_dswx_hls_products(file_1, file_2, metadata_exclude_list=metadata_exclude_list)
+    if args.metadata_exclude_list:
+        metadata_exclude_list.extend(args.metadata_exclude_list)
+
+    result = compare_dswx_hls_products(file_1, file_2, metadata_exclude_list)
 
     if result is True:
         print("Comparison succeeded")

--- a/.ci/scripts/dswx_hls/opera_pge_dswx_hls_delivery_4.1_final_runconfig.yaml
+++ b/.ci/scripts/dswx_hls/opera_pge_dswx_hls_delivery_4.1_final_runconfig.yaml
@@ -1,0 +1,98 @@
+RunConfig:
+    Name: OPERA-DSWX-HLS-PGE-INT-TEST-CONFIG
+
+    Groups:
+
+        PGE:
+            PGENameGroup:
+                PGEName: DSWX_HLS_PGE
+
+            InputFilesGroup:
+                InputFilePaths:
+                    - /home/conda/input_dir
+
+            DynamicAncillaryFilesGroup:
+                AncillaryFileMap:
+                    dem_file: /home/conda/input_dir/dem.tif
+                    landcover_file: /home/conda/input_dir/landcover.tif
+                    worldcover_file: /home/conda/input_dir/worldcover.tif
+
+            ProductPathGroup:
+                OutputProductPath: /home/conda/output_dir
+                ScratchPath: /home/conda/scratch_dir
+
+            PrimaryExecutable:
+                ProductIdentifier: DSWX_HLS
+                ProductVersion: 1.0
+                ProgramPath: python3
+                ProgramOptions:
+                    - /home/conda/proteus-1.0.1/bin/dswx_hls.py
+                    - --full-log-format
+                ErrorCodeBase: 100000
+                SchemaPath: pge/dswx_hls/schema/dswx_hls_sas_schema.yaml
+                IsoTemplatePath: pge/dswx_hls/templates/OPERA_ISO_metadata_L3_DSWx_HLS_template.xml.jinja2
+
+            QAExecutable:
+                Enabled: True
+                ProgramPath: /home/conda/opera/.ci/scripts/dswx_hls/compare_dswx_hls_products.sh
+                ProgramOptions: []
+
+            DebugLevelGroup:
+                DebugSwitch: False
+                ExecuteViaShell: False
+
+        SAS:
+            runconfig:
+                name: dswx_hls_workflow_default
+
+                groups:
+                    pge_name_group:
+                        pge_name: DSWX_HLS_PGE
+
+                    input_file_group:
+                        input_file_path:
+                            - /home/conda/input_dir
+
+                    dynamic_ancillary_file_group:
+                        dem_file: /home/conda/input_dir/dem.tif
+                        dem_file_description: Digital Elevation Model (DEM) for the NASA OPERA project (v1.0) based on the Copernicus DEM 30-m and Copernicus 90-m referenced to the WGS84 ellipsoid
+                        landcover_file: /home/conda/input_dir/landcover.tif
+                        landcover_file_description: Land Cover 100m - collection 3 - epoch 2019 discrete classification map
+                        worldcover_file: /home/conda/input_dir/worldcover.tif
+                        worldcover_file_description: ESA WorldCover 10m 2020 v1.0
+
+                    primary_executable:
+                        product_type: DSWX_HLS
+
+                    product_path_group:
+                        product_path: /home/conda/output_dir
+                        scratch_path: /home/conda/scratch_dir
+                        output_dir: /home/conda/output_dir
+                        product_id: dswx_hls
+                        product_version: 1.0
+
+                    processing:
+                        check_ancillary_inputs_coverage: True
+                        apply_ocean_masking: False
+
+                        save_wtr: True    # Layer 1 - WTR
+                        save_bwtr: True   # Layer 2 - BWTR
+                        save_conf: True   # Layer 3 - CONF
+                        save_diag: True   # Layer 4 - DIAG
+                        save_wtr_1: True   # Layer 5 - WTR-1
+                        save_wtr_2: True   # Layer 6 - WTR-2
+                        save_land: True   # Layer 7 - LAND
+                        save_shad: True   # Layer 8 - SHAD
+                        save_cloud: True  # Layer 9 - CLOUD
+                        save_dem: True   # Layer 10 - DEM
+                        save_rgb: False
+                        save_infrared_rgb: False
+
+                    browse_image_group:
+                        save_browse: True
+                        browse_image_height: 1024
+                        browse_image_width: 1024
+                        exclude_psw_aggressive_in_browse: False
+                        not_water_in_browse: 'white'
+                        cloud_in_browse: 'gray'
+                        snow_in_browse: 'cyan'

--- a/.ci/scripts/dswx_hls/test_int_dswx_hls.sh
+++ b/.ci/scripts/dswx_hls/test_int_dswx_hls.sh
@@ -25,7 +25,7 @@ SAMPLE_TIME=1
 # defaults, test data and runconfig files should be updated as-needed to use
 # the latest available as defaults for use with the Jenkins pipeline call
 # INPUT/OUTPUT_DATA should be the name of the corresponding archives in s3://operasds-dev-pge/dswx_hls/
-# RUNCONFIG should be the name of the runconfig in s3://operasds-dev-pge/dswx_hls/
+# RUNCONFIG should be the name of the latest runconfig in .ci/scripts/dswx_hls/
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../..)
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
 [ -z "${INPUT_DATA}" ] && INPUT_DATA="dswx_hls_final_4.1_expected_input.zip"

--- a/.ci/scripts/dswx_hls/test_int_dswx_hls.sh
+++ b/.ci/scripts/dswx_hls/test_int_dswx_hls.sh
@@ -26,7 +26,7 @@ SAMPLE_TIME=1
 # the latest available as defaults for use with the Jenkins pipeline call
 # INPUT/OUTPUT_DATA should be the name of the corresponding archives in s3://operasds-dev-pge/dswx_hls/
 # RUNCONFIG should be the name of the latest runconfig in .ci/scripts/dswx_hls/
-[ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../..)
+[ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../../..)
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
 [ -z "${INPUT_DATA}" ] && INPUT_DATA="dswx_hls_final_4.1_expected_input.zip"
 [ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="dswx_hls_final_4.1_expected_output.zip"

--- a/.ci/scripts/dswx_s1/build_dswx_s1.sh
+++ b/.ci/scripts/dswx_s1/build_dswx_s1.sh
@@ -45,8 +45,6 @@ STAGING_DIR=$(mktemp -d -p ${WORKSPACE} docker_image_staging_XXXXXXXXXX)
 trap build_script_cleanup EXIT
 
 # Copy files to the staging area and build the PGE docker image
-mkdir -p ${STAGING_DIR}/opera/pge
-
 copy_pge_files $WORKSPACE $STAGING_DIR $PGE_NAME
 
 # Create a VERSION file in the staging area to track version and build time

--- a/.ci/scripts/dswx_s1/dswx_s1_gamma_0.3_runconfig.yaml
+++ b/.ci/scripts/dswx_s1/dswx_s1_gamma_0.3_runconfig.yaml
@@ -1,0 +1,174 @@
+RunConfig:
+  Name: OPERA-DSWX-S1-PGE-SAMPLE-CONFIG
+
+  Groups:
+    PGE:
+      PGENameGroup:
+        PGEName: DSWX_S1_PGE
+
+      InputFilesGroup:
+        InputFilePaths: [
+            /home/dswx_user/input_dir/RTC/T114-243003-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243010-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243002-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243011-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243008-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243005-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243003-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243010-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243006-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243011-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243007-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243016-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243015-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243004-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243009-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243010-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243009-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243012-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243011-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243002-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243008-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243007-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243013-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243004-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243006-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243012-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243001-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243013-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243013-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243005-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243006-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243008-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243012-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243004-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243014-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243007-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243014-IW2,
+            /home/dswx_user/input_dir/RTC/T114-243005-IW1,
+            /home/dswx_user/input_dir/RTC/T114-243003-IW3,
+            /home/dswx_user/input_dir/RTC/T114-243009-IW1
+        ]
+
+      DynamicAncillaryFilesGroup:
+        AncillaryFileMap:
+          dem_file: /home/dswx_user/input_dir/ancillary_data/dem.tif
+          hand_file: /home/dswx_user/input_dir/ancillary_data/hand.tif
+          reference_water_file: /home/dswx_user/input_dir/ancillary_data/reference_water.tif
+          worldcover_file: /home/dswx_user/input_dir/ancillary_data/worldcover.tif
+
+      ProductPathGroup:
+        OutputProductPath: /home/dswx_user/output_dir
+        ScratchPath: /home/dswx_user/scratch_dir
+
+      PrimaryExecutable:
+        ProductIdentifier: DSWX_S1
+        ProductVersion: "0.1"
+        ProgramPath: python3
+        ProgramOptions:
+          - /home/dswx_user/OPERA/DSWX-SAR/src/dswx_sar/dswx_s1.py
+        ErrorCodeBase: 400000
+        SchemaPath: /home/dswx_user/opera/pge/dswx_s1/schema/dswx_s1_sas_schema.yaml
+        AlgorithmParametersSchemaPath: /home/dswx_user/opera/pge/dswx_s1/schema/algorithm_parameters_s1_schema.yaml
+        IsoTemplatePath: /home/dswx_user/opera/pge/dswx_s1/templates/OPERA_ISO_metadata_L3_DSWx_S1_template.xml.jinja2
+
+      QAExecutable:
+        Enabled: False
+        ProgramPath:
+        ProgramOptions:
+
+      DebugLevelGroup:
+        DebugSwitch: False
+        ExecuteViaShell: False
+
+    SAS:
+      runconfig:
+        name: dswx_s1_workflow_default
+
+        groups:
+          pge_name_group:
+            pge_name: DSWX_S1_PGE
+
+          input_file_group:
+            input_file_path: [
+              /home/dswx_user/input_dir/RTC/T114-243003-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243010-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243002-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243011-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243008-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243005-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243003-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243010-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243006-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243011-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243007-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243016-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243015-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243004-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243009-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243010-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243009-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243012-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243011-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243002-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243008-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243007-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243013-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243004-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243006-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243012-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243001-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243013-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243013-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243005-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243006-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243008-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243012-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243004-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243014-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243007-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243014-IW2,
+              /home/dswx_user/input_dir/RTC/T114-243005-IW1,
+              /home/dswx_user/input_dir/RTC/T114-243003-IW3,
+              /home/dswx_user/input_dir/RTC/T114-243009-IW1
+            ]
+          dynamic_ancillary_file_group:
+            dem_file: /home/dswx_user/input_dir/ancillary_data/dem.tif
+            dem_file_description: 'Copernicus DEM GLO-30 2021 WGS84'
+            worldcover_file: /home/dswx_user/input_dir/ancillary_data/worldcover.tif
+            worldcover_file_description: 'ESA WorldCover 10m 2020 v1.0'
+            reference_water_file: /home/dswx_user/input_dir/ancillary_data/reference_water.tif
+            reference_water_file_description: 'JRC Global Surface Water - collection from 1984 to 2021'
+            hand_file: /home/dswx_user/input_dir/ancillary_data/hand.tif
+            hand_file_description: 'ASF HAND GLO30'
+            shoreline_shapefile:
+            shoreline_shapefile_description: 'NOAA GSHHS Level 1 resolution f - GSHHS_f_L1'
+            algorithm_parameters: /home/dswx_user/input_dir/ancillary_data/algorithm_parameters_s1.yaml
+
+          static_ancillary_file_group:
+            static_ancillary_inputs_flag: True
+            mgrs_database_file: /home/dswx_user/input_dir/ancillary_data/MGRS_tile.sqlite
+            mgrs_collection_database_file: /home/dswx_user/input_dir/ancillary_data/MGRS_tile_collection.sqlite
+
+          primary_executable:
+            product_type: dswx_s1
+
+          product_path_group:
+            product_path: /home/dswx_user/output_dir
+            scratch_path: /home/dswx_user/scratch_dir
+            sas_output_path: /home/dswx_user/output_dir
+            product_version: 0.1
+            output_imagery_format: 'COG'
+
+          browse_image_group:
+            save_browse: True
+            browse_image_height: 1024
+            browse_image_width: 1024
+            flag_collapse_wtr_classes: True
+            exclude_inundated_vegetation: False
+            set_not_water_to_nodata: False
+            set_hand_mask_to_nodata: False
+            set_layover_shadow_to_nodata: False
+            set_ocean_masked_to_nodata: False
+
+          log_file: /home/dswx_user/output_dir/dswx-s1.log

--- a/.ci/scripts/dswx_s1/test_int_dswx_s1.sh
+++ b/.ci/scripts/dswx_s1/test_int_dswx_s1.sh
@@ -26,7 +26,7 @@ SAMPLE_TIME=1
 # the latest available as defaults for use with the Jenkins pipeline call
 # INPUT/OUTPUT_DATA should be the name of the corresponding archives in s3://operasds-dev-pge/dswx_s1/
 # RUNCONFIG should be the name of the runconfig in s3://operasds-dev-pge/dswx_s1/
-[ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../..)
+[ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../../..)
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
 [ -z "${INPUT_DATA}" ] && INPUT_DATA="dswx_s1_gamma_0.3_expected_input.zip"
 [ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="dswx_s1_gamma_0.3_expected_output.zip"

--- a/.ci/scripts/metrics/plot_metric_data.py
+++ b/.ci/scripts/metrics/plot_metric_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import datetime
 import matplotlib.pyplot as plt
 import os

--- a/.ci/scripts/metrics/process_metric_data.py
+++ b/.ci/scripts/metrics/process_metric_data.py
@@ -10,7 +10,6 @@ Post process the csv file returned when metric data is collected
 """
 
 import csv
-import datetime
 import os
 import sys
 
@@ -160,7 +159,7 @@ def make_lists(csv_file):
 
     Parameters
     ----------
-    csv_file : file
+    csv_file : str
         file used to capture either docker stats or miscellaneous OS measurements
 
     Returns
@@ -184,10 +183,7 @@ def main():
     # Remove lines that may have been recorded before Docker stated.
     stats_columns = "SECONDS,{{.Name}},CPU,{{.CPUPerc}},MEM,{{.MemUsage}},MEM_PERC,{{.MemPerc}},NET,{{.NetIO}},BLOCK,{{.BlockIO}},PIDS,{{.PIDs}},disk_used,swap_used,total_threads"
     expected_column_count = len(stats_columns.split(','))
-    print(f"expected cols {expected_column_count}")
     remove_unwanted_lines(stats_file, temp_stats, expected_column_count)
-
-    current_time = datetime.datetime.today().strftime('%Y%m%d_%H%M%S')
 
     # read files into lists
     stats_list = make_lists(temp_stats)

--- a/.ci/scripts/rtc_s1/build_rtc_s1.sh
+++ b/.ci/scripts/rtc_s1/build_rtc_s1.sh
@@ -45,8 +45,6 @@ STAGING_DIR=$(mktemp -d -p ${WORKSPACE} docker_image_staging_XXXXXXXXXX)
 trap build_script_cleanup EXIT
 
 # Copy files to the staging area and build the PGE docker image
-mkdir -p ${STAGING_DIR}/opera/pge
-
 copy_pge_files $WORKSPACE $STAGING_DIR $PGE_NAME
 
 # Create a VERSION file in the staging area to track version and build time

--- a/.ci/scripts/rtc_s1/opera_pge_rtc_s1_delivery_5_final_runconfig.yaml
+++ b/.ci/scripts/rtc_s1/opera_pge_rtc_s1_delivery_5_final_runconfig.yaml
@@ -1,0 +1,152 @@
+RunConfig:
+
+    Name: OPERA-RTC-S1-PGE-SAMPLE-CONFIG
+
+    Groups:
+        PGE:
+            PGENameGroup:
+                PGEName: RTC_S1_PGE
+
+            InputFilesGroup:
+                InputFilePaths:
+                    - /home/rtc_user/input_dir/S1B_IW_SLC__1SDV_20180504T104507_20180504T104535_010770_013AEE_919F.zip
+                    - /home/rtc_user/input_dir/S1B_OPER_AUX_POEORB_OPOD_20180524T110543_V20180503T225942_20180505T005942.EOF
+
+            DynamicAncillaryFilesGroup:
+                AncillaryFileMap:
+                    dem_file: /home/rtc_user/input_dir/dem.tif
+
+                    burst_database_file: /home/rtc_user/input_dir/burst_db_0.2.0_230831-bbox-only.sqlite
+
+            ProductPathGroup:
+                OutputProductPath: /home/rtc_user/output_dir
+
+                ScratchPath: /home/rtc_user/scratch_dir
+
+            PrimaryExecutable:
+                ProductIdentifier: RTC_S1
+
+                ProductVersion: "1.0"
+
+                ProgramPath: conda
+
+                ProgramOptions:
+                    - run
+                    - --no-capture-output
+                    - -n
+                    - RTC
+                    - rtc_s1.py
+
+                ErrorCodeBase: 300000
+
+                SchemaPath: /home/rtc_user/opera/pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
+
+                IsoTemplatePath: /home/rtc_user/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
+
+                DataValidityStartDate: 20140403
+
+            QAExecutable:
+                Enabled: False
+
+                ProgramPath:
+
+                ProgramOptions: []
+
+            DebugLevelGroup:
+                DebugSwitch: False
+
+                ExecuteViaShell: False
+
+        SAS:
+            runconfig:
+                name: rtc_s1_workflow_default
+
+                groups:
+                    pge_name_group:
+                        pge_name: RTC_S1_PGE
+
+                    input_file_group:
+                        safe_file_path:
+                            - /home/rtc_user/input_dir/S1B_IW_SLC__1SDV_20180504T104507_20180504T104535_010770_013AEE_919F.zip
+
+                        orbit_file_path:
+                            - /home/rtc_user/input_dir/S1B_OPER_AUX_POEORB_OPOD_20180524T110543_V20180503T225942_20180505T005942.EOF
+
+                        burst_id:
+                            - t069_147169_iw3
+                            - t069_147170_iw3
+                            - t069_147171_iw3
+                            - t069_147172_iw3
+                            - t069_147173_iw3
+                            - t069_147174_iw3
+                            - t069_147175_iw3
+                            - t069_147176_iw3
+                            - t069_147177_iw3
+                            - t069_147178_iw3
+
+                        source_data_access: "https://search.asf.alaska.edu/#/?dataset=SENTINEL-1&productTypes=SLC"
+
+                    dynamic_ancillary_file_group:
+                        dem_file: /home/rtc_user/input_dir/dem.tif
+                        dem_file_description: "Digital Elevation Model (DEM) for the NASA OPERA project version 1.1 (v1.1) based on the Copernicus DEM 30-m and Copernicus 90-m referenced to the WGS84 ellipsoid"
+
+                    static_ancillary_file_group:
+                        burst_database_file: /home/rtc_user/input_dir/burst_db_0.2.0_230831-bbox-only.sqlite
+
+                    product_group:
+                        product_version: "1.0"
+
+                        product_path: /home/rtc_user/output_dir
+
+                        scratch_path: /home/rtc_user/scratch_dir
+
+                        output_dir: /home/rtc_user/output_dir
+
+                        product_id:
+
+                        rtc_s1_static_validity_start_date: 20140403
+
+                        product_data_access: "https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=RTC"
+
+                        save_bursts: True
+
+                        save_mosaics: False
+
+                        save_browse: True
+
+                        output_imagery_format: COG
+
+                        save_metadata: True
+
+                    primary_executable:
+                        product_type: RTC_S1
+
+                    processing:
+
+                        check_ancillary_inputs_coverage: True
+
+                        polarization: dual-pol
+
+                        rtc:
+                            output_type: gamma0
+
+                        num_workers: 0
+
+                        geocoding:
+                            memory_mode: auto
+
+                            bursts_geogrid:
+                                top_left:
+                                    x:
+                                    y:
+                                bottom_right:
+                                    x:
+                                    y:
+
+                            estimated_geometric_accuracy_bias_x: 0.0
+                            estimated_geometric_accuracy_bias_y: 0.0
+                            estimated_geometric_accuracy_stddev_x: 0.0
+                            estimated_geometric_accuracy_stddev_y: 0.0
+
+                        mosaicking:
+                            mosaic_mode: first

--- a/.ci/scripts/rtc_s1/opera_pge_rtc_s1_static_delivery_5_final_runconfig.yaml
+++ b/.ci/scripts/rtc_s1/opera_pge_rtc_s1_static_delivery_5_final_runconfig.yaml
@@ -1,0 +1,152 @@
+RunConfig:
+
+    Name: OPERA-RTC-S1-PGE-SAMPLE-CONFIG
+
+    Groups:
+        PGE:
+            PGENameGroup:
+                PGEName: RTC_S1_PGE
+
+            InputFilesGroup:
+                InputFilePaths:
+                    - /home/rtc_user/input_dir/S1B_IW_SLC__1SDV_20180504T104507_20180504T104535_010770_013AEE_919F.zip
+                    - /home/rtc_user/input_dir/S1B_OPER_AUX_POEORB_OPOD_20180524T110543_V20180503T225942_20180505T005942.EOF
+
+            DynamicAncillaryFilesGroup:
+                AncillaryFileMap:
+                    dem_file: /home/rtc_user/input_dir/dem.tif
+
+                    burst_database_file: /home/rtc_user/input_dir/burst_db_0.2.0_230831-bbox-only.sqlite
+
+            ProductPathGroup:
+                OutputProductPath: /home/rtc_user/output_dir
+
+                ScratchPath: /home/rtc_user/scratch_dir
+
+            PrimaryExecutable:
+                ProductIdentifier: RTC_S1
+
+                ProductVersion: "1.0"
+
+                ProgramPath: conda
+
+                ProgramOptions:
+                    - run
+                    - --no-capture-output
+                    - -n
+                    - RTC
+                    - rtc_s1.py
+
+                ErrorCodeBase: 300000
+
+                SchemaPath: /home/rtc_user/opera/pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
+
+                IsoTemplatePath: /home/rtc_user/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
+
+                DataValidityStartDate: 20140403
+
+            QAExecutable:
+                Enabled: False
+
+                ProgramPath:
+
+                ProgramOptions: []
+
+            DebugLevelGroup:
+                DebugSwitch: False
+
+                ExecuteViaShell: False
+
+        SAS:
+            runconfig:
+                name: rtc_s1_workflow_default
+
+                groups:
+                    pge_name_group:
+                        pge_name: RTC_S1_PGE
+
+                    input_file_group:
+                        safe_file_path:
+                            - /home/rtc_user/input_dir/S1B_IW_SLC__1SDV_20180504T104507_20180504T104535_010770_013AEE_919F.zip
+
+                        orbit_file_path:
+                            - /home/rtc_user/input_dir/S1B_OPER_AUX_POEORB_OPOD_20180524T110543_V20180503T225942_20180505T005942.EOF
+
+                        burst_id:
+                            - t069_147169_iw3
+                            - t069_147170_iw3
+                            - t069_147171_iw3
+                            - t069_147172_iw3
+                            - t069_147173_iw3
+                            - t069_147174_iw3
+                            - t069_147175_iw3
+                            - t069_147176_iw3
+                            - t069_147177_iw3
+                            - t069_147178_iw3
+
+                        source_data_access: "https://search.asf.alaska.edu/#/?dataset=SENTINEL-1&productTypes=SLC"
+
+                    dynamic_ancillary_file_group:
+                        dem_file: /home/rtc_user/input_dir/dem.tif
+                        dem_file_description: Digital Elevation Model (DEM) for the NASA OPERA project (v1.0) based on the Copernicus DEM 30-m and Copernicus 90-m referenced to the WGS84 ellipsoid
+
+                    static_ancillary_file_group:
+                        burst_database_file: /home/rtc_user/input_dir/burst_db_0.2.0_230831-bbox-only.sqlite
+
+                    product_group:
+                        product_version: "1.0"
+
+                        product_path: /home/rtc_user/output_dir
+
+                        scratch_path: /home/rtc_user/scratch_dir
+
+                        output_dir: /home/rtc_user/output_dir
+
+                        product_id:
+
+                        rtc_s1_static_validity_start_date: 20140403
+
+                        product_data_access: "https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=RTC"
+
+                        save_bursts: True
+
+                        save_mosaics: False
+
+                        save_browse: True
+
+                        output_imagery_format: COG
+
+                        save_metadata: True
+
+                    primary_executable:
+                        product_type: RTC_S1_STATIC
+
+                    processing:
+
+                        check_ancillary_inputs_coverage: True
+
+                        polarization: dual-pol
+
+                        rtc:
+                            output_type: gamma0
+
+                        num_workers: 3
+
+                        geocoding:
+                            memory_mode: auto
+
+                            bursts_geogrid:
+                                top_left:
+                                    x:
+                                    y:
+                                bottom_right:
+                                    x:
+                                    y:
+
+                            estimated_geometric_accuracy_bias_x: 0.0
+                            estimated_geometric_accuracy_bias_y: 0.0
+                            estimated_geometric_accuracy_stddev_x: 0.0
+                            estimated_geometric_accuracy_stddev_y: 0.0
+
+                        mosaicking:
+                            mosaic_mode: first

--- a/.ci/scripts/rtc_s1/test_int_rtc_s1.sh
+++ b/.ci/scripts/rtc_s1/test_int_rtc_s1.sh
@@ -44,18 +44,6 @@ test_int_setup_test_data
 # Setup cleanup on exit
 trap test_int_trap_cleanup EXIT
 
-# Download the RunConfig for the static layers workflow
-static_runconfig="opera_pge_rtc_s1_static_delivery_5_final_runconfig.yaml"
-local_static_runconfig="${TMP_DIR}/runconfig/${static_runconfig}"
-echo "Downloading s3://operasds-dev-pge/${PGE_NAME}/${static_runconfig} to ${local_static_runconfig}"
-aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/${static_runconfig} ${local_static_runconfig} --no-progress
-
-# Pull in product compare script from S3.
-# Current source is https://raw.githubusercontent.com/opera-adt/RTC/main/app/rtc_compare.py
-local_compare_script=${TMP_DIR}/rtc_compare.py
-echo "Downloading s3://operasds-dev-pge/${PGE_NAME}/rtc_compare_final_1.0.0.py to ${local_compare_script}"
-aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/rtc_compare_calval_0.4.1.py "$local_compare_script"
-
 # overall_status values and their meaning
 # 0 - pass
 # 1 - failure to execute some part of this script
@@ -64,6 +52,18 @@ overall_status=0
 
 input_dir="${TMP_DIR}/${INPUT_DATA%.*}/input_dir"
 runconfig_dir="${TMP_DIR}/runconfig"
+
+# Copy the RunConfig for the static layers workflow
+static_runconfig="opera_pge_rtc_s1_static_delivery_5_final_runconfig.yaml"
+local_static_runconfig="${SCRIPT_DIR}/${static_runconfig}"
+echo "Copying runconfig file $local_static_runconfig to $runconfig_dir/"
+cp ${local_static_runconfig} ${runconfig_dir}
+
+# Pull in product compare script from S3.
+# Current source is https://raw.githubusercontent.com/opera-adt/RTC/main/app/rtc_compare.py
+local_compare_script=${TMP_DIR}/rtc_compare.py
+echo "Downloading s3://operasds-dev-pge/${PGE_NAME}/rtc_compare_final_1.0.0.py to ${local_compare_script}"
+aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/rtc_compare_calval_0.4.1.py "$local_compare_script"
 
 # the testdata reference metadata contains this path so we use it here
 output_dir="${TMP_DIR}/rtc_s1_output_dir"

--- a/.ci/scripts/util/test_int_util.sh
+++ b/.ci/scripts/util/test_int_util.sh
@@ -125,7 +125,7 @@ test_int_setup_test_data()
     #
     local_input_data_archive=${TMP_DIR}/${INPUT_DATA}
     local_expected_data_archive=${TMP_DIR}/${EXPECTED_DATA}
-    local_runconfig=${TMP_DIR}/${RUNCONFIG}
+    local_runconfig=${SCRIPT_DIR}/${RUNCONFIG}
 
     # Pull in test data and runconfig from S3
     echo "Downloading input data from s3://operasds-dev-pge/${PGE_NAME}/${INPUT_DATA} to $local_input_data_archive"
@@ -133,9 +133,6 @@ test_int_setup_test_data()
 
     echo "Downloading expected outputs from s3://operasds-dev-pge/${PGE_NAME}/${EXPECTED_DATA} to $local_expected_data_archive"
     aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/${EXPECTED_DATA} $local_expected_data_archive --no-progress
-
-    echo "Downloading runconfig from s3://operasds-dev-pge/${PGE_NAME}/${RUNCONFIG} to $local_runconfig"
-    aws s3 cp s3://operasds-dev-pge/${PGE_NAME}/${RUNCONFIG} $local_runconfig --no-progress
 
     for local_testdata_archive in $local_input_data_archive $local_expected_data_archive
     do
@@ -166,8 +163,6 @@ test_int_setup_test_data()
 
         echo "Copying runconfig file $local_runconfig to $runconfig_dir/"
         cp $local_runconfig $runconfig_dir
-
-        rm -f $local_runconfig
     else
         echo "Unable to find runconfig file $local_runconfig"
         exit 1

--- a/.ci/scripts/util/test_int_util.sh
+++ b/.ci/scripts/util/test_int_util.sh
@@ -76,16 +76,39 @@ test_int_setup_results_directory()
     echo "Test results output directory: ${TEST_RESULTS_DIR}"
     mkdir --parents ${TEST_RESULTS_DIR}
     chmod -R 775 ${TEST_RESULTS_DIR}
-    RESULTS_FILE="${TEST_RESULTS_DIR}/test_int_${PGE_NAME}_results.html"
+}
+
+initialize_html_results_file()
+{
+    local output_dir=$1
+    local pge_name=$2
+
+    RESULTS_FILE="${output_dir}/test_int_${pge_name}_results.html"
 
     # Add the initial HTML to the results file
-    results_html_init="<html><b>${PGE_NAME} product comparison results</b><p> \
+    results_html_init="<html><b>${pge_name} product comparison results</b><p> \
         <style>* {font-family: sans-serif;} \
         table {border-collapse: collapse;} \
         th,td {padding: 4px 6px; border: thin solid white} \
         tr:nth-child(even) {background-color: whitesmoke;} \
         </style><table>"
-    echo "${results_html_init}" > ${RESULTS_FILE}
+
+    echo "${results_html_init}" > "$RESULTS_FILE"
+}
+
+update_html_results_file()
+{
+    local compare_result=$1
+    local output_file=$2
+    local expected_file=$3
+    local compare_out=$4
+
+    echo "<tr><td>${compare_result}</td><td><ul><li>Output: ${output_file}</li><li>Expected: ${expected_file}</li></ul></td><td>${compare_out}</td></tr>" >> "$RESULTS_FILE"
+}
+
+finalize_html_results_file()
+{
+    echo "</table></html>" >> "$RESULTS_FILE"
 }
 
 test_int_setup_data_tmp_directory()
@@ -153,10 +176,8 @@ test_int_setup_test_data()
 
 test_int_trap_cleanup_temp_dir()
 {
-    # Finalize results HTML file and set permissions on data that was created during the test.
-
-    echo "</table></html>" >> $RESULTS_FILE
-
+    # set permissions on data that was created during the test to ensure we can
+    # delete said data outside of the container's file system
     DOCKER_RUN="docker run --rm -u $UID:$(id -g)"
 
     # Check options before exiting

--- a/.ci/scripts/util/util.sh
+++ b/.ci/scripts/util/util.sh
@@ -79,6 +79,9 @@ copy_pge_files() {
   STAGING_DIR=$2
   PGE_NAME=$3
 
+  mkdir -p ${STAGING_DIR}/opera/pge
+  mkdir -p ${STAGING_DIR}/opera/.ci/scripts
+
   cp ${WORKSPACE}/src/opera/__init__.py \
    ${STAGING_DIR}/opera/
 
@@ -99,6 +102,15 @@ copy_pge_files() {
 
   cp -r ${WORKSPACE}/src/opera/util \
         ${STAGING_DIR}/opera/
+
+  cp -r ${WORKSPACE}/.ci/scripts/${PGE_NAME} \
+        ${STAGING_DIR}/opera/.ci/scripts/
+
+  cp -r ${WORKSPACE}/.ci/scripts/metrics \
+        ${STAGING_DIR}/opera/.ci/scripts/
+
+  cp -r ${WORKSPACE}/.ci/scripts/util \
+        ${STAGING_DIR}/opera/.ci/scripts/
 
   cp ${WORKSPACE}/COPYING \
      ${STAGING_DIR}/opera
@@ -140,7 +152,6 @@ metrics_collection_start()
       # Initialize output files and statistics format
       metrics_stats="${results_dir}/${pge}_metrics_stats.csv"
       stats_pid_file="${results_dir}/${pge}_metrics_stats_bg_pid.txt"
-
 
       # initialize start seconds and the rest of the csv file's column titles
       METRICS_START_SECONDS=$SECONDS


### PR DESCRIPTION
## Description
- This branch lays the initial groundwork of refactoring the PGE integration tests such that the product comparison step is now performed within the PGE container. Currently, only DSWx-HLS is affected by this branch.
- The product comparison logic has been refactored into its own shell script, `compare_dswx_hls_products.sh`
- The new comparison script is now configured as the "Quality Assurance" step of PGE execution within the RunConfig used with the integration test
- The RunConfigs used with all integration tests are now part of the repository, rather than downloaded from S3
- The `.ci/scripts/<pge>` directory is now copied into PGE containers at build time, so the comparison scripts are available to the PGE at runtime

## Affected Issues
- Resolves #401 

## Testing
- Branch was tested on opera-dev-pge by running the test_int_dswx_hls.sh locally
