### PR TITLE
Enhanced traceback capture for SAS failures

### DIFF
--- a/src/opera/test/data/test_sas_error_config.yaml
+++ b/src/opera/test/data/test_sas_error_config.yaml
@@ -26,42 +26,38 @@ RunConfig:
         ProgramOptions:
           - -c
           - echo START;
-          - echo sample traceback line 2;
-          - echo Traceback \(most recent call last):;
-          - echo File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main;
-          - echo "__main__", fname, loader, pkg_name);
-          - echo File "/usr/lib/python2.7/runpy.py", line 72, in _run_code;
-          - echo exec code in run_globals;
-          - echo File "/root/env/common/test/test/__main__.py", line 5, in <module>;
-          - echo main();
-          - echo File "/root/env/common/test/test/cli/parser.py", line 55, in main;
-          - echo run_script(args);
-          - echo File "/root/env/common/test/test/cli/runner.py", line 124, in run_script;
-          - echo exec_script(args.script, scope=globals(), root=True);
-          - echo File "/root/workspace/group/test_regression_utils.py", line 123, in exec_script;
-          - echo cli_exec_script(*args,**kwargs);
-          - echo File "/root/env/common/test/test/cli/runner.py", line 186, in exec_script;
-          - echo exec(compile(code, scriptpath, 'exec')) in scope;
-          - echo File "shiju_12.py", line 30, in <module>;
-          - echo File "/root/moaworkspace/group/testscript/utils/shiju_public.py", line 37, in shiju_move;
-          - echo EndOfStream;
-          - echo EndOfStream;
-          - echo Traceback (most recent call last):;
-          - echo File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main;
-          - echo "__main__", fname, loader, pkg_name);
-          - echo File "/usr/lib/python2.7/runpy.py", line 72, in _run_code;
-          - echo exec code in run_globals;
-          - echo File "/root/env/common/test/test/__main__.py", line 5, in <module>;
-          - echo main();
-          - echo File "/root/env/common/test/test/cli/parser.py", line 55, in main;
-          - echo run_script(args);
-          - echo File "/root/env/common/test/test/cli/runner.py", line 124, in run_script;
-          - echo exec_script(args.script, scope=globals(), root=True);
-          - echo File "/root/env/common/test/test/cli/runner.py", line 186, in exec_script;
-          - echo exec(compile(code, scriptpath, 'exec')) in scope;
-          - echo File "/root/env/common/mator/mator/mator.py", line 520, in start;
-          - echo raise IOError("RPC server not started!");
-          - failed with exit code 123;
+          - echo "Traceback (most recent call last):";
+          - echo "  File \"/usr/lib/python2.7/runpy.py\", line 174, in _run_module_as_main";
+          - echo "    \"__main__\", fname, loader, pkg_name)";
+          - echo "  File \"/usr/lib/python2.7/runpy.py\", line 72, in _run_code";
+          - echo "    exec code in run_globals";
+          - echo "  File \"/root/env/common/test/test/__main__.py\", line 5, in <module>";
+          - echo "    main()";
+          - echo "  File \"/root/env/common/test/test/cli/parser.py\", line 55, in main";
+          - echo "    run_script(args)";
+          - echo "  File \"/root/env/common/test/test/cli/runner.py\", line 124, in run_script";
+          - echo "    exec_script(args.script, scope=globals(), root=True)";
+          - echo "  File \"/root/workspace/group/test_regression_utils.py\", line 123, in exec_script";
+          - echo "    cli_exec_script(*args,**kwargs)";
+          - echo "  File \"/root/env/common/test/test/cli/runner.py\", line 186, in exec_script";
+          - echo "    exec(compile(code, scriptpath, 'exec')) in scope";
+          - echo "  File \"/usr/lib/python2.7/runpy.py\", line 174, in _run_module_as_main";
+          - echo "    \"__main__\", fname, loader, pkg_name)";
+          - echo "  File \"/usr/lib/python2.7/runpy.py\", line 72, in _run_code";
+          - echo "    exec code in run_globals";
+          - echo "  File \"/root/env/common/test/test/__main__.py\", line 5, in <module>";
+          - echo "    main()";
+          - echo "  File \"/root/env/common/test/test/cli/parser.py\", line 55, in main";
+          - echo "    run_script(args)";
+          - echo "  File \"/root/env/common/test/test/cli/runner.py\", line 124, in run_script";
+          - echo "    exec_script(args.script, scope=globals(), root=True)";
+          - echo "  File \"/root/env/common/test/test/cli/runner.py\", line 186, in exec_script";
+          - echo "    exec(compile(code, scriptpath, 'exec')) in scope";
+          - echo "  File \"/root/env/common/mator/mator/mator.py\", line 520, in start";
+          - echo "    raise IOError(\"RPC server not started!\")";
+          - >-
+            echo "IOError: RPC server not started!";
+          - exit 123;
         ErrorCodeBase: 100000
         SchemaPath: test/data/sample_sas_schema.yaml
         IsoTemplatePath: sample_iso_template.xml.jinja2

--- a/src/opera/test/data/test_sas_error_config.yaml
+++ b/src/opera/test/data/test_sas_error_config.yaml
@@ -25,17 +25,43 @@ RunConfig:
         ProgramPath: bash
         ProgramOptions:
           - -c
-          - echo;
-          - echo sample traceback line 1;
+          - echo START;
           - echo sample traceback line 2;
-          - echo sample traceback line 3;
-          - echo sample traceback line 4;
-          - echo sample traceback line 5;
-          - echo sample traceback line 6;
-          - echo sample traceback line 7;
-          - echo sample traceback line 8;
-          - echo sample traceback line 9;
-          - exit 123;
+          - echo Traceback \(most recent call last):;
+          - echo File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main;
+          - echo "__main__", fname, loader, pkg_name);
+          - echo File "/usr/lib/python2.7/runpy.py", line 72, in _run_code;
+          - echo exec code in run_globals;
+          - echo File "/root/env/common/test/test/__main__.py", line 5, in <module>;
+          - echo main();
+          - echo File "/root/env/common/test/test/cli/parser.py", line 55, in main;
+          - echo run_script(args);
+          - echo File "/root/env/common/test/test/cli/runner.py", line 124, in run_script;
+          - echo exec_script(args.script, scope=globals(), root=True);
+          - echo File "/root/workspace/group/test_regression_utils.py", line 123, in exec_script;
+          - echo cli_exec_script(*args,**kwargs);
+          - echo File "/root/env/common/test/test/cli/runner.py", line 186, in exec_script;
+          - echo exec(compile(code, scriptpath, 'exec')) in scope;
+          - echo File "shiju_12.py", line 30, in <module>;
+          - echo File "/root/moaworkspace/group/testscript/utils/shiju_public.py", line 37, in shiju_move;
+          - echo EndOfStream;
+          - echo EndOfStream;
+          - echo Traceback (most recent call last):;
+          - echo File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main;
+          - echo "__main__", fname, loader, pkg_name);
+          - echo File "/usr/lib/python2.7/runpy.py", line 72, in _run_code;
+          - echo exec code in run_globals;
+          - echo File "/root/env/common/test/test/__main__.py", line 5, in <module>;
+          - echo main();
+          - echo File "/root/env/common/test/test/cli/parser.py", line 55, in main;
+          - echo run_script(args);
+          - echo File "/root/env/common/test/test/cli/runner.py", line 124, in run_script;
+          - echo exec_script(args.script, scope=globals(), root=True);
+          - echo File "/root/env/common/test/test/cli/runner.py", line 186, in exec_script;
+          - echo exec(compile(code, scriptpath, 'exec')) in scope;
+          - echo File "/root/env/common/mator/mator/mator.py", line 520, in start;
+          - echo raise IOError("RPC server not started!");
+          - failed with exit code 123;
         ErrorCodeBase: 100000
         SchemaPath: test/data/sample_sas_schema.yaml
         IsoTemplatePath: sample_iso_template.xml.jinja2

--- a/src/opera/test/pge/base/test_base_pge.py
+++ b/src/opera/test/pge/base/test_base_pge.py
@@ -161,7 +161,6 @@ class BasePgeTestCase(unittest.TestCase):
             pge.run()
 
         self.assertIn('failed with exit code 123',str(err.exception))
-        self.assertIn('sample traceback line 2',str(err.exception))
 
         # Log should be fully initialized before SAS execution, so make sure it was
         # moved where we expect.

--- a/src/opera/test/pge/base/test_base_pge.py
+++ b/src/opera/test/pge/base/test_base_pge.py
@@ -160,7 +160,14 @@ class BasePgeTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError) as err:
             pge.run()
 
-        self.assertIn('failed with exit code 123',str(err.exception))
+        expected_error_code = 123
+
+        # Ensure both the return code and the trackback stack parsed from the log
+        # are present in the exception message that would be reported to an SDS operator
+        self.assertIn(f'failed with exit code {expected_error_code}', str(err.exception))
+        self.assertIn('Traceback from log', str(err.exception))
+        self.assertIn('Traceback (most recent call last):', str(err.exception))
+        self.assertIn('IOError: RPC server not started!', str(err.exception))
 
         # Log should be fully initialized before SAS execution, so make sure it was
         # moved where we expect.
@@ -171,9 +178,9 @@ class BasePgeTestCase(unittest.TestCase):
         with open(expected_log_file, 'r', encoding='utf-8') as infile:
             log_contents = infile.read()
 
-        expected_error_code = 123
-
         self.assertIn(f"failed with exit code {expected_error_code}", log_contents)
+        self.assertIn('Traceback (most recent call last):', log_contents)
+        self.assertIn('IOError: RPC server not started!', log_contents)
 
     def test_sas_qa_execution(self):
         """

--- a/src/opera/util/run_utils.py
+++ b/src/opera/util/run_utils.py
@@ -10,10 +10,9 @@ subsystem.
 
 """
 
-import re
-import traceback
 import hashlib
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -52,6 +51,37 @@ def get_checksum(file_name):
 def get_extension(file_name):
     """Returns the file extension (including the dot) of the provided file name."""
     return os.path.splitext(file_name)[-1]
+
+
+def get_traceback_from_log(log_contents):
+    """
+    Utilizes a regular expression to parse and return a traceback stack from
+    provided log contents.
+
+    Notes
+    -----
+    The regular expression used with this function was derived from the following
+    Stack Exchange answer: https://stackoverflow.com/a/53658873
+
+    Parameters
+    ----------
+    log_contents : str
+        The log contents to parse for a traceback stack.
+
+    Returns
+    -------
+        traceback_match : re.Match
+            The result of the regex search for a traceback. If none could be found,
+            None will be returned.
+
+    """
+    exception_pattern = re.compile(
+        r"Traceback \(most recent call last\):(?:\n.*)+?\n(.*?(?:Exception|Error):)\s*(.+)"
+    )
+
+    trackback_match = exception_pattern.search(log_contents)
+
+    return trackback_match
 
 
 def create_sas_command_line(sas_program_path, sas_runconfig_path,

--- a/src/opera/util/run_utils.py
+++ b/src/opera/util/run_utils.py
@@ -10,6 +10,8 @@ subsystem.
 
 """
 
+import re
+import traceback
 import hashlib
 import os
 import shutil


### PR DESCRIPTION
## Description
- This branch enhances the error reporting from SAS failures by utilizing a regular expression to capture a full traceback stack from the log, rather than just the last 20 lines.

## Affected Issues
- Resolves #423

## Testing
- Unit test for a failing SAS condition has been updated to ensure the full traceback (which is longer than 20 lines in this test) is now provided in the error message that would be reported to an SDS end user.
