### PR TITLE
Fix docs publish breaking post steps in release pipeline

### DIFF
--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
         stage('Push OPERA PGE HTML documentation to GitHub Pages') {
             when { expression { return params.PUBLISH_DOCS } }
             steps {
-                dir('/data/tmp/pages'){
+                dir('/data/tmp/tmp.gh-pages'){
                     git branch: 'gh-pages',
                         changelog: false,
                         poll: false,
@@ -154,7 +154,7 @@ pipeline {
                     withCredentials([string(credentialsId: params.GITHUB_OAUTH_TOKEN, variable: 'TOKEN')]) {
                         sh label: 'Updating gh-pages branch with latest HTML docs',
                            script: '''#!/bin/bash
-                           cp -rf ./docs/_build/html/* .
+                           cp -rf ${WORKSPACE}/docs/_build/html/* .
                            git add .
                            git add -u
                            git commit -m "HTML docs update by Jenkins"
@@ -162,6 +162,8 @@ pipeline {
                            git push --set-upstream origin gh-pages
                            '''
                     }
+
+                    deleteDir
                 }
 
             }

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -162,8 +162,7 @@ pipeline {
                            git push --set-upstream origin gh-pages
                            '''
                     }
-
-                    deleteDir
+                    deleteDir()
                 }
 
             }

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -145,22 +145,25 @@ pipeline {
         stage('Push OPERA PGE HTML documentation to GitHub Pages') {
             when { expression { return params.PUBLISH_DOCS } }
             steps {
-                git branch: 'gh-pages',
-                    changelog: false,
-                    poll: false,
-                    url: 'https://github.com/nasa/opera-sds-pge'
+                dir('/data/tmp/pages'){
+                    git branch: 'gh-pages',
+                        changelog: false,
+                        poll: false,
+                        url: 'https://github.com/nasa/opera-sds-pge'
 
-                withCredentials([string(credentialsId: params.GITHUB_OAUTH_TOKEN, variable: 'TOKEN')]) {
-                    sh label: 'Updating gh-pages branch with latest HTML docs',
-                       script: '''#!/bin/bash
-                       cp -rf ./docs/_build/html/* .
-                       git add .
-                       git add -u
-                       git commit -m "HTML docs update by Jenkins"
-                       git remote set-url origin https://${TOKEN}@github.com/nasa/opera-sds-pge.git
-                       git push --set-upstream origin gh-pages
-                       '''
+                    withCredentials([string(credentialsId: params.GITHUB_OAUTH_TOKEN, variable: 'TOKEN')]) {
+                        sh label: 'Updating gh-pages branch with latest HTML docs',
+                           script: '''#!/bin/bash
+                           cp -rf ./docs/_build/html/* .
+                           git add .
+                           git add -u
+                           git commit -m "HTML docs update by Jenkins"
+                           git remote set-url origin https://${TOKEN}@github.com/nasa/opera-sds-pge.git
+                           git push --set-upstream origin gh-pages
+                           '''
+                    }
                 }
+
             }
         }
         // TODO: revisit once latexpdf is working on CI system


### PR DESCRIPTION
## Description
- Handle docs publish stage in temp directory to avoid git checkout messing with the workspace dir.

## Affected Issues
- #468 

## Testing
- Tested with sandbox pipeline.
