### PR TITLE
DSWx-S1 Release v3.0.1

### DIFF
--- a/.ci/scripts/dswx_s1/build_dswx_s1.sh
+++ b/.ci/scripts/dswx_s1/build_dswx_s1.sh
@@ -24,7 +24,7 @@ BUILD_DATE_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 # defaults, SAS image should be updated as necessary for new image releases from ADT
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath $(dirname $(realpath $0))/../../..)
 [ -z "${TAG}" ] && TAG="${USER}-dev"
-[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/dswx-s1:final_1.0"
+[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/dswx-s1:final_patch_1.1"
 
 echo "WORKSPACE: $WORKSPACE"
 echo "IMAGE: $IMAGE"

--- a/.ci/scripts/dswx_s1/dswx_s1_final_1.1_runconfig.yaml
+++ b/.ci/scripts/dswx_s1/dswx_s1_final_1.1_runconfig.yaml
@@ -133,6 +133,8 @@ RunConfig:
               /home/dswx_user/input_dir/RTC/T114-243003-IW3,
               /home/dswx_user/input_dir/RTC/T114-243009-IW1
             ]
+
+            input_mgrs_collection_id: MS_114_28
           dynamic_ancillary_file_group:
             dem_file: /home/dswx_user/input_dir/ancillary_data/dem.tif
             dem_file_description: 'Copernicus DEM GLO-30 2021 WGS84'

--- a/.ci/scripts/dswx_s1/test_int_dswx_s1.sh
+++ b/.ci/scripts/dswx_s1/test_int_dswx_s1.sh
@@ -28,9 +28,9 @@ SAMPLE_TIME=1
 # RUNCONFIG should be the name of the runconfig in s3://operasds-dev-pge/dswx_s1/
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../../..)
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
-[ -z "${INPUT_DATA}" ] && INPUT_DATA="dswx_s1_final_1.0_expected_input.zip"
-[ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="dswx_s1_final_1.0_expected_output.zip"
-[ -z "${RUNCONFIG}" ] && RUNCONFIG="dswx_s1_final_1.0_runconfig.yaml"
+[ -z "${INPUT_DATA}" ] && INPUT_DATA="dswx_s1_final_1.1_expected_input.zip"
+[ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="dswx_s1_final_1.1_expected_output.zip"
+[ -z "${RUNCONFIG}" ] && RUNCONFIG="dswx_s1_final_1.1_runconfig.yaml"
 [ -z "${TMP_ROOT}" ] && TMP_ROOT="$DEFAULT_TMP_ROOT"
 
 # Create the test output directory in the work space

--- a/examples/dswx_s1_sample_runconfig-v3.0.1.yaml
+++ b/examples/dswx_s1_sample_runconfig-v3.0.1.yaml
@@ -1,4 +1,4 @@
-# Sample RunConfig for use with the DSWx-S1 PGE v3.0.0
+# Sample RunConfig for use with the DSWx-S1 PGE v3.0.1
 # This RunConfig should require minimal changes in order to be used with the
 # OPERA PCM.
 
@@ -162,6 +162,9 @@ RunConfig:
               /home/dswx_user/input_dir/rtc_data/t047_100910_iw2,
               /home/dswx_user/input_dir/rtc_data/t047_100910_iw3
             ]
+
+            # Specify the MGRS tile collection ID
+            input_mgrs_collection_id: MS_114_28
           dynamic_ancillary_file_group:
             # Digital elevation model (Required)
             dem_file: /home/dswx_user/input_dir/ancillary_data/dem.tif

--- a/src/opera/pge/dswx_s1/dswx_s1_pge.py
+++ b/src/opera/pge/dswx_s1/dswx_s1_pge.py
@@ -657,10 +657,10 @@ class DSWxS1Executor(DSWxS1PreProcessorMixin, DSWxS1PostProcessorMixin, PgeExecu
     LEVEL = "L3"
     """Processing Level for DSWx-S1 Products"""
 
-    PGE_VERSION = "3.0.0"
+    PGE_VERSION = "3.0.1"
     """Version of the PGE (overrides default from base_pge)"""
 
-    SAS_VERSION = "1.0"  # Final release https://github.com/opera-adt/DSWX-SAR/releases/tag/v1.0
+    SAS_VERSION = "1.1"  # Final release https://github.com/opera-adt/DSWX-SAR/releases/tag/v1.1
     """Version of the SAS wrapped by this PGE, should be updated as needed"""
 
     def __init__(self, pge_name, runconfig_path, **kwargs):

--- a/src/opera/pge/dswx_s1/schema/dswx_s1_sas_schema.yaml
+++ b/src/opera/pge/dswx_s1/schema/dswx_s1_sas_schema.yaml
@@ -13,6 +13,9 @@ runconfig:
             # REQUIRED - list of RTC products (directory or files)
             input_file_path: list(str(), min=1)
 
+            # Specify the MGRS tile collection ID
+            input_mgrs_collection_id: str(required=False)
+
         dynamic_ancillary_file_group:
             # Digital elevation model
             dem_file: str(required=True)

--- a/src/opera/test/data/test_dswx_s1_config.yaml
+++ b/src/opera/test/data/test_dswx_s1_config.yaml
@@ -50,6 +50,7 @@ RunConfig:
           input_file_group:
             input_file_path:
             - dswx_s1_pge_test/input_dir
+            input_mgrs_collection_id: MS_123_45
           dynamic_ancillary_file_group:
             dem_file: dswx_s1_pge_test/input_dir/dem.tif
             dem_file_description: DEM


### PR DESCRIPTION
This release updates the utilized version of the DSWx-S1 SAS to the v1.1 Final delivery. This delivery resolves an issue where the wrong output MGRS tiles could be produced in certain regions of the globe (near poles or equator).
