### PR TITLE
Remove pipeline dependency on `/usr/local/anaconda3`

### DIFF
--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -8,6 +8,10 @@ pipeline {
                      returnStdout: true,
                      script: 'echo ${GIT_BRANCH##*/}-build-int-test-$$'
                      ).trim()}"""
+        RUN_ID = """${sh(
+                 returnStdout: true,
+                 script: 'echo $$'
+                 ).trim()}"""
     }
     parameters {
         // TODO: update default value as newer PGE's are added
@@ -60,10 +64,10 @@ pipeline {
             steps{
                 sh label: 'Download and install',
                    script: """#!/bin/bash
-                     mkdir -p /var/lib/jenkins/miniconda3
-                     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/miniconda3/miniconda.sh
-                     bash /var/lib/jenkins/miniconda3/miniconda.sh -b -u -p ~/miniconda3
-                     rm /var/lib/jenkins/miniconda3/miniconda.sh
+                     mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
+                     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
+                     rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
                    """
             }
         }
@@ -72,10 +76,10 @@ pipeline {
                 script {
                     echo "Creating conda env"
                     sh label: 'Installing int test conda environment',
-                       script: '''#!/bin/bash
-                         /var/lib/jenkins/miniconda3/bin/conda create -n int_test_env python=3.10 pip
-                         /var/lib/jenkins/miniconda3/bin/conda init bash
-                    '''
+                       script: """#!/bin/bash
+                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda create -n int_test_env python=3.10 pip
+                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init bash
+                    """
 
                     sh label: 'Installing dependencies to int test conda environment',
                        script: '''#!/bin/bash
@@ -141,9 +145,9 @@ pipeline {
             echo "Cleaning up Docker images from local host"
             sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
             echo "Removing int test conda environment"
-            sh "/var/lib/jenkins/miniconda3/bin/conda env remove --name int_test_env"
-            sh "/var/lib/jenkins/miniconda3/bin/conda init --reverse"
-            sh "rm -rf /var/lib/jenkins/miniconda3"
+            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name int_test_env"
+            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
+            sh "rm -rf /var/lib/jenkins/conda_installs/${RUN_ID}/"
             deleteDir()
         }
         success {

--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -56,14 +56,25 @@ pipeline {
                 }
             }
         }
+        stage('Install miniconda') {
+            steps{
+                sh label: 'Download and install',
+                   script: """#!/bin/bash
+                     mkdir -p /var/lib/jenkins/miniconda3
+                     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/miniconda3/miniconda.sh
+                     bash /var/lib/jenkins/miniconda3/miniconda.sh -b -u -p ~/miniconda3
+                     rm /var/lib/jenkins/miniconda3/miniconda.sh
+                   """
+            }
+        }
         stage('Install local conda env') {
             steps {
                 script {
                     echo "Creating conda env"
                     sh label: 'Installing int test conda environment',
                        script: '''#!/bin/bash
-                         /usr/local/anaconda3/bin/conda create -n int_test_env python=3.10 pip
-                         /usr/local/anaconda3/bin/conda init bash
+                         /var/lib/jenkins/miniconda3/bin/conda create -n int_test_env python=3.10 pip
+                         /var/lib/jenkins/miniconda3/bin/conda init bash
                     '''
 
                     sh label: 'Installing dependencies to int test conda environment',
@@ -130,8 +141,9 @@ pipeline {
             echo "Cleaning up Docker images from local host"
             sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
             echo "Removing int test conda environment"
-            sh "/usr/local/anaconda3/bin/conda env remove --name int_test_env"
-            sh "/usr/local/anaconda3/bin/conda init --reverse"
+            sh "/var/lib/jenkins/miniconda3/bin/conda env remove --name int_test_env"
+            sh "/var/lib/jenkins/miniconda3/bin/conda init --reverse"
+            sh "rm -rf /var/lib/jenkins/miniconda3"
             deleteDir()
         }
         success {

--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
                 sh label: 'Download and install',
                    script: """#!/bin/bash
                      mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
                      bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
                      rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
                    """

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -8,6 +8,10 @@ pipeline {
                      returnStdout: true,
                      script: 'echo ${GIT_BRANCH##*/}'
                      ).trim()}"""
+        RUN_ID = """${sh(
+                 returnStdout: true,
+                 script: 'echo $$'
+                 ).trim()}"""
     }
     parameters {
         // TODO: update default value as newer PGE's are added
@@ -103,10 +107,10 @@ pipeline {
             steps{
                 sh label: 'Download and install',
                    script: """#!/bin/bash
-                     mkdir -p /var/lib/jenkins/miniconda3
-                     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/miniconda3/miniconda.sh
-                     bash /var/lib/jenkins/miniconda3/miniconda.sh -b -u -p ~/miniconda3
-                     rm /var/lib/jenkins/miniconda3/miniconda.sh
+                     mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
+                     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
+                     rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
                    """
             }
         }
@@ -116,10 +120,10 @@ pipeline {
                 script {
                     echo "Installing Sphinx Dependencies"
                     sh label: 'Installing conda environment for Sphinx',
-                       script: '''#!/bin/bash
-                         /var/lib/jenkins/miniconda3/bin/conda create -n sphinx_env python=3.8 pip
-                         /var/lib/jenkins/miniconda3/bin/conda init bash
-                    '''
+                       script: """#!/bin/bash
+                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda create -n sphinx_env python=3.8 pip
+                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init bash
+                    """
 
                     sh label: 'Installing Sphinx to conda environment',
                        script: '''#!/bin/bash
@@ -277,9 +281,9 @@ pipeline {
             echo "Cleaning up Docker images from local host"
             sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
             echo "Removing Sphinx build environment"
-            sh "/var/lib/jenkins/miniconda3/bin/conda env remove --name int_test_env"
-            sh "/var/lib/jenkins/miniconda3/bin/conda init --reverse"
-            sh "rm -rf /var/lib/jenkins/miniconda3"
+            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name sphinx_env"
+            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
+            sh "rm -rf /var/lib/jenkins/conda_installs/${RUN_ID}/"
             deleteDir()
         }
         success {

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -99,6 +99,17 @@ pipeline {
                 }
             }
         }
+        stage('Install miniconda') {
+            steps{
+                sh label: 'Download and install',
+                   script: """#!/bin/bash
+                     mkdir -p /var/lib/jenkins/miniconda3
+                     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/miniconda3/miniconda.sh
+                     bash /var/lib/jenkins/miniconda3/miniconda.sh -b -u -p ~/miniconda3
+                     rm /var/lib/jenkins/miniconda3/miniconda.sh
+                   """
+            }
+        }
         stage('Generate OPERA PGE Sphinx Documentation') {
             when { expression { return params.PUBLISH_DOCS } }
             steps {
@@ -106,8 +117,8 @@ pipeline {
                     echo "Installing Sphinx Dependencies"
                     sh label: 'Installing conda environment for Sphinx',
                        script: '''#!/bin/bash
-                         /usr/local/anaconda3/bin/conda create -n sphinx_env python=3.8 pip
-                         /usr/local/anaconda3/bin/conda init bash
+                         /var/lib/jenkins/miniconda3/bin/conda create -n sphinx_env python=3.8 pip
+                         /var/lib/jenkins/miniconda3/bin/conda init bash
                     '''
 
                     sh label: 'Installing Sphinx to conda environment',
@@ -266,8 +277,9 @@ pipeline {
             echo "Cleaning up Docker images from local host"
             sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
             echo "Removing Sphinx build environment"
-            sh "/usr/local/anaconda3/bin/conda env remove --name sphinx_env"
-            sh "/usr/local/anaconda3/bin/conda init --reverse"
+            sh "/var/lib/jenkins/miniconda3/bin/conda env remove --name int_test_env"
+            sh "/var/lib/jenkins/miniconda3/bin/conda init --reverse"
+            sh "rm -rf /var/lib/jenkins/miniconda3"
             deleteDir()
         }
         success {

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -108,7 +108,7 @@ pipeline {
                 sh label: 'Download and install',
                    script: """#!/bin/bash
                      mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
                      bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
                      rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
                    """

--- a/.ci/jenkins/delete-tmp-dirs/Jenkinsfile
+++ b/.ci/jenkins/delete-tmp-dirs/Jenkinsfile
@@ -15,6 +15,8 @@ pipeline {
                 sh 'rm -rf /data/tmp/tmp.*'
                 echo "Cleaning up old Docker data"
                 sh 'docker system prune -f'
+                echo "Removing any orphaned conda environments"
+                sh 'find /var/lib/jenkins/conda_installs/ -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \\;'
             }
         }
     }


### PR DESCRIPTION
## Description
- To avoid complexities with keeping conda up to date on CI, reconfigure pipelines that use conda to install a copy locally, then delete it when finished.
- Each pipeline run installs to a unique directory under `/var/lib/jenkins/conda_installs/` to avoid any issues in the event of concurrent pipeline runs.
- Added to cleanup pipeline to check for and delete any conda installs that are over a day old in case of pipeline failure preventing removal.

## Affected Issues
- #497 

## Testing
- Ran changed pipeline on sandbox
- Was unable to simulate concurrent pipeline runs as Jenkins wouldn't schedule it
