### PR TITLE
Reworked generation of custom metadata in DSWx-S1 and DSWx-NI to utilize the granule filename instead of the core filename

### DIFF
--- a/src/opera/pge/dswx_ni/dswx_ni_pge.py
+++ b/src/opera/pge/dswx_ni/dswx_ni_pge.py
@@ -209,13 +209,19 @@ class DSWxNIPostProcessorMixin(DSWxS1PostProcessorMixin):
 
         return output_product_metadata
 
-    def _create_custom_metadata(self):
+    def _create_custom_metadata(self, tile_filename):
         """
         Creates the "custom data" dictionary used with the ISO metadata rendering.
 
         Custom data contains all metadata information needed for the ISO template
         that is not found within any of the other metadata sources (such as the
         RunConfig, output product(s), or catalog metadata).
+
+        Parameters
+        ----------
+        tile_filename : str
+            Tile filename to be used as the granule identifier within the
+            custom metadata.
 
         Returns
         -------
@@ -224,13 +230,11 @@ class DSWxNIPostProcessorMixin(DSWxS1PostProcessorMixin):
             metadata Jinja2 template.
 
         """
-        core_filename = f"{self.PROJECT}_{self.LEVEL}_{self.NAME}"
-
         custom_metadata = {
-            'ISO_OPERA_FilePackageName': core_filename,
-            'ISO_OPERA_ProducerGranuleId': core_filename,
+            'ISO_OPERA_FilePackageName': tile_filename,
+            'ISO_OPERA_ProducerGranuleId': tile_filename,
             'MetadataProviderAction': "creation",
-            'GranuleFilename': core_filename,
+            'GranuleFilename': tile_filename,
             'ISO_OPERA_ProjectKeywords': ['OPERA', 'JPL', 'DSWx', 'Dynamic', 'Surface', 'Water', 'Extent'],
             'ISO_OPERA_PlatformKeywords': ['NI'],
             'ISO_OPERA_InstrumentKeywords': ['NISAR']
@@ -272,8 +276,8 @@ class DSWxNIPostProcessorMixin(DSWxS1PostProcessorMixin):
 
         # Generate the ISO metadata for use with product submission to DAAC(s)
         # For DSWX-S1, each tile-set is assigned an ISO xml file
-        for tile_id, tile_metadata in self._tile_metadata_cache.items():
-            iso_metadata = self._create_iso_metadata(tile_metadata)
+        for tile_id in self._tile_metadata_cache.keys():
+            iso_metadata = self._create_iso_metadata(tile_id)
 
             iso_meta_filename = self._iso_metadata_filename(tile_id)
             iso_meta_filepath = join(self.runconfig.output_product_path, iso_meta_filename)

--- a/src/opera/pge/dswx_s1/dswx_s1_pge.py
+++ b/src/opera/pge/dswx_s1/dswx_s1_pge.py
@@ -476,13 +476,19 @@ class DSWxS1PostProcessorMixin(PostProcessorMixin):
 
         return output_product_metadata
 
-    def _create_custom_metadata(self):
+    def _create_custom_metadata(self, tile_filename):
         """
         Creates the "custom data" dictionary used with the ISO metadata rendering.
 
         Custom data contains all metadata information needed for the ISO template
         that is not found within any of the other metadata sources (such as the
         RunConfig, output product(s), or catalog metadata).
+
+        Parameters
+        ----------
+        tile_filename : str
+            Tile filename to be used as the granule identifier within the
+            custom metadata.
 
         Returns
         -------
@@ -491,13 +497,11 @@ class DSWxS1PostProcessorMixin(PostProcessorMixin):
             metadata Jinja2 template.
 
         """
-        core_filename = f"{self.PROJECT}_{self.LEVEL}_{self.NAME}"
-
         custom_metadata = {
-            'ISO_OPERA_FilePackageName': core_filename,
-            'ISO_OPERA_ProducerGranuleId': core_filename,
+            'ISO_OPERA_FilePackageName': tile_filename,
+            'ISO_OPERA_ProducerGranuleId': tile_filename,
             'MetadataProviderAction': "creation",
-            'GranuleFilename': core_filename,
+            'GranuleFilename': tile_filename,
             'ISO_OPERA_ProjectKeywords': ['OPERA', 'JPL', 'DSWx', 'Dynamic', 'Surface', 'Water', 'Extent'],
             'ISO_OPERA_PlatformKeywords': ['S1'],
             'ISO_OPERA_InstrumentKeywords': ['Sentinel 1 A/B']
@@ -505,7 +509,7 @@ class DSWxS1PostProcessorMixin(PostProcessorMixin):
 
         return custom_metadata
 
-    def _create_iso_metadata(self, tile_metadata):
+    def _create_iso_metadata(self, tile_id):
         """
         Creates a rendered version of the ISO metadata template for DSWX-S1
         output products using metadata from the following locations:
@@ -517,9 +521,9 @@ class DSWxS1PostProcessorMixin(PostProcessorMixin):
 
         Parameters
         ----------
-        tile_metadata : dict
-            The product metadata corresponding to a specific tile product to
-            be included as the "product_output" metadata in the rendered ISO xml.
+        tile_id : str
+            MGRS tile identifier used to look up the metadata used to instantiate
+            the ISO template.
 
         Returns
         -------
@@ -528,13 +532,19 @@ class DSWxS1PostProcessorMixin(PostProcessorMixin):
             the sourced metadata dictionaries.
 
         """
+        if tile_id not in self._tile_metadata_cache or tile_id not in self._tile_filename_cache:
+            raise RuntimeError(f"No file name or metadata cached for tile ID {tile_id}")
+
+        tile_metadata = self._tile_metadata_cache[tile_id]
+        tile_filename = self._tile_filename_cache[tile_id]
+
         runconfig_dict = self.runconfig.asdict()
 
         product_output_dict = tile_metadata
 
         catalog_metadata_dict = self._create_catalog_metadata().asdict()
 
-        custom_data_dict = self._create_custom_metadata()
+        custom_data_dict = self._create_custom_metadata(tile_filename)
 
         iso_metadata = {
             'run_config': runconfig_dict,
@@ -584,8 +594,8 @@ class DSWxS1PostProcessorMixin(PostProcessorMixin):
 
         # Generate the ISO metadata for use with product submission to DAAC(s)
         # For DSWX-S1, each tile-set is assigned an ISO xml file
-        for tile_id, tile_metadata in self._tile_metadata_cache.items():
-            iso_metadata = self._create_iso_metadata(tile_metadata)
+        for tile_id in self._tile_metadata_cache.keys():
+            iso_metadata = self._create_iso_metadata(tile_id)
 
             iso_meta_filename = self._iso_metadata_filename(tile_id)
             iso_meta_filepath = join(self.runconfig.output_product_path, iso_meta_filename)

--- a/src/opera/test/pge/dswx_ni/test_dswx_ni_pge.py
+++ b/src/opera/test/pge/dswx_ni/test_dswx_ni_pge.py
@@ -515,8 +515,14 @@ class DswxNIPgeTestCase(unittest.TestCase):
         # Initialize the core filename for the catalog metadata generation step
         pge._core_filename()
 
+        # Populate the metadata/filename dictionaries that would normally occur
+        # during output product validation
+        tile_id = 'T11SLS'
+        pge._tile_metadata_cache[tile_id] = dswx_ni_metadata
+        pge._tile_filename_cache[tile_id] = 'OPERA_L3_DSWx-NI_T11SLS_20110226T061749Z_20240329T181033Z_LSAR_30_v0.1'
+
         # Render ISO metadata using the sample metadata
-        iso_metadata = pge._create_iso_metadata(dswx_ni_metadata)
+        iso_metadata = pge._create_iso_metadata(tile_id)
 
         # Rendered template should not have any missing placeholders
         self.assertNotIn('!Not found!', iso_metadata)
@@ -535,6 +541,9 @@ class DswxNIPgeTestCase(unittest.TestCase):
 
         try:
             pge = DSWxNIExecutor(pge_name="DswxNiPgeTest", runconfig_path=test_runconfig_path)
+
+            pge._tile_metadata_cache[tile_id] = dswx_ni_metadata
+            pge._tile_filename_cache[tile_id] = 'OPERA_L3_DSWx-NI_T11SLS_20110226T061749Z_20240329T181033Z_LSAR_30_v0.1'
 
             with self.assertRaises(RuntimeError):
                 pge.run()

--- a/src/opera/test/pge/dswx_s1/test_dswx_s1_pge.py
+++ b/src/opera/test/pge/dswx_s1/test_dswx_s1_pge.py
@@ -412,12 +412,19 @@ class DswxS1PgeTestCase(unittest.TestCase):
             outfile.write('dummy dswx data')
 
         dswx_s1_metadata = pge._collect_dswx_s1_product_metadata(dummy_tif_file)
+        dswx_s1_metadata['SPACECRAFT_NAME'] = 'SENTINEL-1A'
 
         # Initialize the core filename for the catalog metadata generation step
         pge._core_filename()
 
+        # Populate the metadata/filename dictionaries that would normally occur
+        # during output product validation
+        tile_id = 'T18MVA'
+        pge._tile_metadata_cache[tile_id] = dswx_s1_metadata
+        pge._tile_filename_cache[tile_id] = 'OPERA_L3_DSWx-S1_T18MVA_20200702T231843Z_20230317T190549Z_v0.1'
+
         # Render ISO metadata using the sample metadata
-        iso_metadata = pge._create_iso_metadata(dswx_s1_metadata)
+        iso_metadata = pge._create_iso_metadata(tile_id)
 
         # Rendered template should not have any missing placeholders
         self.assertNotIn('!Not found!', iso_metadata)
@@ -436,6 +443,9 @@ class DswxS1PgeTestCase(unittest.TestCase):
 
         try:
             pge = DSWxS1Executor(pge_name="DswxS1PgeTest", runconfig_path=test_runconfig_path)
+
+            pge._tile_metadata_cache[tile_id] = dswx_s1_metadata
+            pge._tile_filename_cache[tile_id] = 'OPERA_L3_DSWx-S1_T18MVA_20200702T231843Z_20230317T190549Z_v0.1'
 
             with self.assertRaises(RuntimeError):
                 pge.run()


### PR DESCRIPTION
Scott's patch for DSWx-S1 ISO XML issue
