### PR TITLE
Check that ISO XML path is provided when needed and log critical failure message if not

### DIFF
--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -730,6 +730,13 @@ class CslcS1PostProcessorMixin(PostProcessorMixin):
         }
 
         iso_template_path = os.path.abspath(self.runconfig.iso_template_path)
+        iso_template_path = self.runconfig.iso_template_path
+
+        if iso_template_path is None:
+            msg = "ISO template path not provided in runconfig"
+            self.logger.critical(self.name, ErrorCode.ISO_METADATA_TEMPLATE_NOT_PROVIDED_WHEN_NEEDED, msg)
+
+        iso_template_path = os.path.abspath(iso_template_path)
 
         if not os.path.exists(iso_template_path):
             msg = f"Could not load ISO template {iso_template_path}, file does not exist"

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -696,7 +696,13 @@ class DispS1PostProcessorMixin(PostProcessorMixin):
             'custom_data': custom_data_dict
         }
 
-        iso_template_path = os.path.abspath(self.runconfig.iso_template_path)
+        iso_template_path = self.runconfig.iso_template_path
+
+        if iso_template_path is None:
+            msg = "ISO template path not provided in runconfig"
+            self.logger.critical(self.name, ErrorCode.ISO_METADATA_TEMPLATE_NOT_PROVIDED_WHEN_NEEDED, msg)
+
+        iso_template_path = os.path.abspath(iso_template_path)
 
         if not os.path.exists(iso_template_path):
             msg = f"Could not load ISO template {iso_template_path}, file does not exist"

--- a/src/opera/pge/dswx_hls/dswx_hls_pge.py
+++ b/src/opera/pge/dswx_hls/dswx_hls_pge.py
@@ -544,7 +544,13 @@ class DSWxHLSPostProcessorMixin(PostProcessorMixin):
             'custom_data': custom_data_dict
         }
 
-        iso_template_path = os.path.abspath(self.runconfig.iso_template_path)
+        iso_template_path = self.runconfig.iso_template_path
+
+        if iso_template_path is None:
+            msg = "ISO template path not provided in runconfig"
+            self.logger.critical(self.name, ErrorCode.ISO_METADATA_TEMPLATE_NOT_PROVIDED_WHEN_NEEDED, msg)
+
+        iso_template_path = os.path.abspath(iso_template_path)
 
         if not os.path.exists(iso_template_path):
             msg = f"Could not load ISO template {iso_template_path}, file does not exist"

--- a/src/opera/pge/dswx_s1/dswx_s1_pge.py
+++ b/src/opera/pge/dswx_s1/dswx_s1_pge.py
@@ -553,7 +553,13 @@ class DSWxS1PostProcessorMixin(PostProcessorMixin):
             'custom_data': custom_data_dict
         }
 
-        iso_template_path = abspath(self.runconfig.iso_template_path)
+        iso_template_path = self.runconfig.iso_template_path
+
+        if iso_template_path is None:
+            msg = "ISO template path not provided in runconfig"
+            self.logger.critical(self.name, ErrorCode.ISO_METADATA_TEMPLATE_NOT_PROVIDED_WHEN_NEEDED, msg)
+
+        iso_template_path = abspath(iso_template_path)
 
         if not exists(iso_template_path):
             msg = f"Could not load ISO template {iso_template_path}, file does not exist"

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -815,7 +815,13 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
             'custom_data': custom_data_dict
         }
 
-        iso_template_path = os.path.abspath(self.runconfig.iso_template_path)
+        iso_template_path = self.runconfig.iso_template_path
+
+        if iso_template_path is None:
+            msg = "ISO template path not provided in runconfig"
+            self.logger.critical(self.name, ErrorCode.ISO_METADATA_TEMPLATE_NOT_PROVIDED_WHEN_NEEDED, msg)
+
+        iso_template_path = os.path.abspath(iso_template_path)
 
         if not os.path.exists(iso_template_path):
             msg = f"Could not load ISO template {iso_template_path}, file does not exist"

--- a/src/opera/util/error_codes.py
+++ b/src/opera/util/error_codes.py
@@ -109,6 +109,7 @@ class ErrorCode(IntEnum):
     LOGGED_CRITICAL_LINE = auto()
     DYNAMIC_IMPORT_FAILED = auto()
     GRIB_TO_NETCDF_CONVERSION_FAILED = auto()
+    ISO_METADATA_TEMPLATE_NOT_PROVIDED_WHEN_NEEDED = auto()
 
     @classmethod
     def describe(cls):


### PR DESCRIPTION
## Description
- Previously in PRs #504 and #496, spin off this work to all PGEs in its own, documented feature branch

## Affected Issues
- #512 

## Testing
- No changes
