### PR TITLE
ISO XML Measured Parameter Section Further Enhancements

### DIFF
--- a/src/opera/pge/base/base_pge.py
+++ b/src/opera/pge/base/base_pge.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from fnmatch import fnmatch
 from functools import lru_cache
 from os.path import abspath, basename, exists, join, splitext
-from textwrap import dedent
+from pkg_resources import resource_filename
 
 import yamale
 from yamale import YamaleError
@@ -190,15 +190,12 @@ class PreProcessorMixin:
                 msg = f'Could not load description file {description_file}, file does not exist.'
                 self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_NOT_FOUND, msg)
 
-            # Schema maps parameter names to maps which contain descriptions. Using this approach to facilitate adding
-            # any new fields as needed, eg attribute type, data type override, etc
-            schema = yamale.make_schema(content=dedent("""
-            map(include('parameter'), key=str())
-            ---
-            parameter:
-                description: str()
-            """))
+            schema_file = resource_filename(
+                'opera',
+                'pge/base/schema/iso_metadata_measured_parameters_config_schema.yaml'
+            )
 
+            schema = yamale.make_schema(schema_file)
             data = yamale.make_data(description_file)
 
             try:

--- a/src/opera/pge/base/schema/iso_metadata_measured_parameters_config_schema.yaml
+++ b/src/opera/pge/base/schema/iso_metadata_measured_parameters_config_schema.yaml
@@ -1,7 +1,22 @@
 map(include('parameter'), key=str())
 ---
 parameter:
+
+  # REQUIRED: Plain-text description of the Measured Parameter as provided in the product spec document
   description: str()
+
+  # REQUIRED: NASA/EOSDIS additional attribute type.
+  # Valid values defined here: https://git.earthdata.nasa.gov/projects/EMFD/repos/iso-schemas/browse/resources/Codelist/eosCodelists.xml?at=606229ea84f207f42b7b477c507eb422f8996115#23
   attribute_type: enum('geographicIdentifier', 'qualityInformation', 'instrumentInformation', 'sensorInformation', 'contentInformation', 'platformInformation', 'citation.identifier', 'descriptiveKeyword', 'processingInformation', 'processingParameter', 'commandLineArgument')
-  attribute_name: str(required=False)
+
+  # OPTIONAL: The data type of the attribute. The PGE will attempt to guess this based on the returned Python datatype
+  # provided by the TIFF metadata util, but this may not always be correct (ie: version strings being interpreted as
+  # a float); use this field to correct errors where needed.
+  # Valid values defined here: https://git.earthdata.nasa.gov/projects/EMFD/repos/iso-schemas/browse/resources/Codelist/eosCodelists.xml?at=606229ea84f207f42b7b477c507eb422f8996115#105
   attribute_data_type: enum('string', 'float', 'int', 'boolean', 'date', 'time', 'dateTime', 'dateString', 'timeString', 'dateTimeString', required=False)
+
+  # OPTIONAL: The display name of the attribute. The PGE will attempt to derive this from the internal metadata variable
+  # name by converting to title case and stripping out underscores. This should provide the proper display name, but may
+  # handle some acronyms improperly (ie, DSWx, MGRS, RTC) and some desired display names retain some underscores. Use
+  # this field to correct these errors where needed.
+  display_name: str(required=False)

--- a/src/opera/pge/base/schema/iso_metadata_measured_parameters_config_schema.yaml
+++ b/src/opera/pge/base/schema/iso_metadata_measured_parameters_config_schema.yaml
@@ -1,0 +1,7 @@
+map(include('parameter'), key=str())
+---
+parameter:
+  description: str()
+  attribute_type: enum('geographicIdentifier', 'qualityInformation', 'instrumentInformation', 'sensorInformation', 'contentInformation', 'platformInformation', 'citation.identifier', 'descriptiveKeyword', 'processingInformation', 'processingParameter', 'commandLineArgument')
+  attribute_name: str(required=False)
+  attribute_data_type: enum('string', 'float', 'int', 'boolean', 'date', 'time', 'dateTime', 'dateString', 'timeString', 'dateTimeString', required=False)

--- a/src/opera/pge/dswx_s1/dswx_s1_pge.py
+++ b/src/opera/pge/dswx_s1/dswx_s1_pge.py
@@ -25,7 +25,7 @@ from opera.util.error_codes import ErrorCode
 from opera.util.geo_utils import get_geographic_boundaries_from_mgrs_tile
 from opera.util.input_validation import validate_algorithm_parameters_config
 from opera.util.input_validation import validate_dswx_inputs
-from opera.util.render_jinja2 import render_jinja2, python_type_to_xml_type
+from opera.util.render_jinja2 import render_jinja2, python_type_to_xml_type, guess_attribute_display_name
 from opera.util.run_utils import get_checksum
 from opera.util.tiff_utils import get_geotiff_metadata
 from opera.util.time import get_time_for_filename
@@ -459,16 +459,14 @@ class DSWxS1PostProcessorMixin(PostProcessorMixin):
                 value = json.dumps(value)
 
             guessed_data_type = python_type_to_xml_type(value)
-            guessed_attr_name = (name.title()
-                                 .replace('Mgrs', 'MGRS')
-                                 .replace('Dswx', 'DSWx')
-                                 .replace('_', '')
-                                 )
+            guessed_attr_name = guess_attribute_display_name(name)
 
-            attr_description = descriptions.setdefault(name, dict(description=missing_description_value))['description']
+            descriptions.setdefault(name, dict())
+
+            attr_description = descriptions[name].get('description', missing_description_value)
             data_type = descriptions[name].get('attribute_data_type', guessed_data_type)
             attr_type = descriptions[name].get('attribute_type', "!Not Found!")
-            attr_name = descriptions[name].get('attribute_name', guessed_attr_name)
+            attr_name = descriptions[name].get('display_name', guessed_attr_name)
 
             augmented_parameters[name] = (dict(name=attr_name, value=value, attr_type=attr_type,
                                                attr_description=attr_description, data_type=data_type))

--- a/src/opera/pge/dswx_s1/dswx_s1_pge.py
+++ b/src/opera/pge/dswx_s1/dswx_s1_pge.py
@@ -458,19 +458,17 @@ class DSWxS1PostProcessorMixin(PostProcessorMixin):
             if isinstance(value, list):
                 value = json.dumps(value)
 
-            data_type = python_type_to_xml_type(value)
-
-            # TODO: This is hardcoded for now, but we should eventually try to guess this or add it to the descriptions
-            #  YAML file
-            attr_type = 'processingInformation'
+            guessed_data_type = python_type_to_xml_type(value)
+            guessed_attr_name = (name.title()
+                                 .replace('Mgrs', 'MGRS')
+                                 .replace('Dswx', 'DSWx')
+                                 .replace('_', '')
+                                 )
 
             attr_description = descriptions.setdefault(name, dict(description=missing_description_value))['description']
-
-            attr_name = (name.title()
-                         .replace('Mgrs', 'MGRS')
-                         .replace('Dswx', 'DSWx')
-                         .replace('_', '')
-                         )
+            data_type = descriptions[name].get('attribute_data_type', guessed_data_type)
+            attr_type = descriptions[name].get('attribute_type', "!Not Found!")
+            attr_name = descriptions[name].get('attribute_name', guessed_attr_name)
 
             augmented_parameters[name] = (dict(name=attr_name, value=value, attr_type=attr_type,
                                                attr_description=attr_description, data_type=data_type))

--- a/src/opera/pge/dswx_s1/templates/dswx_s1_measured_parameters.yaml
+++ b/src/opera/pge/dswx_s1/templates/dswx_s1_measured_parameters.yaml
@@ -1,134 +1,217 @@
 AREA_OR_POINT:
   description: Indicates that pixel values are assumed to represent an area rather than points.
+  attribute_type: processingInformation
 CONTACT_INFORMATION:
   description: OPERA Project contact email address.
+  attribute_type: contentInformation
 DSWX_PRODUCT_VERSION:
   description: The DSWx-S1 product version.
+  attribute_type: processingInformation
+  attribute_data_type: string
 INSTITUTION:
   description: Name of the generating Institution.
+  attribute_type: processingInformation
 LAYOVER_SHADOW_COVERAGE:
   description: The percentage of layover and shadow in the DSWx-S1 product based on OPERA RTC-S1 product.
+  attribute_type: processingInformation
 MGRS_COLLECTION_ACTUAL_NUMBER_OF_BURSTS:
   description: The number of actual RTC-S1 bursts that are collected within the MGRS tile collection ID.
+  attribute_type: processingInformation
 MGRS_COLLECTION_EXPECTED_NUMBER_OF_BURSTS:
   description: The number of expected RTC-S1 bursts that are supposed to be collected within the MGRS tile collection ID.
+  attribute_type: processingInformation
 MGRS_COLLECTION_MISSING_NUMBER_OF_BURSTS:
   description: The number of missing RTC-S1 bursts.
+  attribute_type: processingInformation
 MGRS_POL_MODE:
   description: "The description for the polarizations of the collected bursts. 'MIX_DUAL_POL': ['HH', 'HV', 'VV', 'VH'], 'MIX_DUAL_H_SINGLE_V_POL': ['HH', 'HV', 'VV'], 'MIX_DUAL_V_SINGLE_H_POL': ['VV', 'VH', 'HH'], 'MIX_SINGLE_POL': ['HH', 'VV'], 'DV_POL': ['VV', 'VH'], 'SV_POL': ['VV'], 'DH_POL': ['HH', 'HV'], 'SH_POL': ['HH']."
+  attribute_type: processingInformation
 INPUT_DEM_SOURCE:
   description: Description of the input DEM.
+  attribute_type: processingParameter
 INPUT_REFERENCE_WATER_SOURCE:
   description: Description of the input reference water file.
+  attribute_type: processingParameter
 INPUT_WORLDCOVER_SOURCE:
   description: Description of the input ESA WorldCover 10-m file.
+  attribute_type: processingParameter
 INPUT_HAND_SOURCE:
   description: Description of the input ASF GLO-30 HAND 30-m file.
+  attribute_type: processingParameter
 INPUT_GLAD_CLASSIFICATION_SOURCE:
   description: Description of the input GLAD Annual maps of land cover and land use 30-m file.
+  attribute_type: processingParameter
 INPUT_SHORELINE_SOURCE:
   description: Description of the input shoreline vector file.
+  attribute_type: processingParameter
 POLARIZATION:
   description: Polarizations (e.g. VV, VH).
+  attribute_type: processingInformation
 PROCESSING_DATETIME:
   description: 'DSWx-S1 product processing date. Format: YYYY-MM-DDTHH:MM:SSZ.'
+  attribute_type: processingInformation
+  attribute_name: ProcessingDateTime
 PROCESSING_INFORMATION_FILTER:
   description: RTC intensity filtering method (bregman, lee, guided_filter, anisotropic_diffusion, etc.).
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_FILTER_ENABLED:
   description: Indicates if the filter is applied to the input RTC.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_FILTER_OPTION:
   description: Parameters used for the despeckle filter.
+  attribute_type: processingParameter
+  attribute_name: ProcessingInformationFilterOptions
 PROCESSING_INFORMATION_FUZZY_VALUE_AREA:
   description: The foot and shoulder values used to construct an S-shaped function for water body areas.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_FUZZY_VALUE_DARK_AREA:
   description: List of the intensity values to define dark land.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_FUZZY_VALUE_HAND:
   description: Foot and shoulder value to construct a Z-shape function for height above nearest drainage (HAND).
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_FUZZY_VALUE_HIGH_FREQUENT_AREA:
   description: The minimum and maximum values representing reference water levels to identify areas with frequent water extent changes.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_FUZZY_VALUE_REFERENCE_WATER:
   description: Foot and shoulder value to construct an S-shape function for reference water.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_FUZZY_VALUE_SLOPE:
   description: Foot and shoulder value to construct a Z-shape function for slope angle.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_INUNDATED_VEGETATION:
   description: Indicates whether inundated vegetation is a factor in the processing.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_INUNDATED_VEGETATION_AREA_DATA_TYPE:
   description: Indicates what sources are used to define the potential wetland areas (e.g. GLAD, WorldCover).
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_INUNDATED_VEGETATION_CROSS_POL_MIN:
   description: The cross-polarization backscattering value [dB] used to filter out areas for inundated vegetation mapping. The areas that have this threshold are automatically considered not inundated vegetation.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_INUNDATED_VEGETATION_DUAL_POL_RATIO_MAX:
   description: The maximum threshold for the ratio of co-polarization to cross-polarization in mapping inundated vegetation. It defines the upper limit for this ratio, beyond which vegetation is not considered inundated.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_INUNDATED_VEGETATION_DUAL_POL_RATIO_MIN:
   description: The minimum threshold for the ratio of co-polarization to cross-polarization required to identify inundated vegetation.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_INUNDATED_VEGETATION_DUAL_POL_RATIO_THRESHOLD:
   description: Threshold value for co-pol to cross-pol ratio used to map inundated vegetation areas.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_INUNDATED_VEGETATION_FILTER:
   description: Filtering method used for dual polarization ratio.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_INUNDATED_VEGETATION_TARGET_CLASS:
   description: Land cover classes used to define potential wetland areas.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_MASKING_ANCILLARY_CO_POL_THRESHOLD:
   description: Threshold level [dB] to be used for dark land identification for co-polarization.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_MASKING_ANCILLARY_CROSS_POL_THRESHOLD:
   description: Threshold level [dB] to be used for dark land identification for cross-polarization.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_MASKING_ANCILLARY_WATER_THRESHOLD:
   description: Threshold to be used for dry region identification for reference water data. The fuzzy values computed from cross-polarization are replaced with the one from co-polarization.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_REFINE_BIMODALITY_MINIMUM_PIXEL:
   description: Minimum number of pixels to pass to bimodality test.
+  attribute_type: processingInformation
 PROCESSING_INFORMATION_REFINE_BIMODALITY_THRESHOLD:
   description: List of the thresholds to determine if the distribution is close to bimodal distribution.
+  attribute_type: processingInformation
 PROCESSING_INFORMATION_REGION_GROWING_INITIAL_SEED:
   description: Seed value for region-growing method.
+  attribute_type: processingInformation
 PROCESSING_INFORMATION_REGION_GROWING_RELAXED_THRESHOLD:
   description: Tolerance value for region-growing method.
+  attribute_type: processingInformation
 PROCESSING_INFORMATION_THRESHOLDING:
   description: 'Initial thresholding algorithm, either "Kittler-Illingworth" or "OTSU".'
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_THRESHOLD_BIMODALITY:
   description: Bimodality threshold for identifying bimodality in data tiles. It is used to select tiles that exhibit bimodal distribution, essential for specific analyses where recognizing two distinct data groups is crucial.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_THRESHOLD_BOUNDS:
   description: Threshold bounds for polarizations (e.g. co-pol and cross-pol).
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_THRESHOLD_MULTI_THRESHOLD:
   description: Indicates a Boolean indicator specifying whether a trimodal distribution is assumed in the processing.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_THRESHOLD_TILE_AVERAGE:
   description: Indicates whether averaging of thresholds within a tile is enabled or not.
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_THRESHOLD_TILE_SELECTION:
   description: Tile selection method (e.g. Tweles, Chini, Bimodality or combined).
+  attribute_type: processingParameter
 PROCESSING_INFORMATION_THRESHOLD_TWELE:
   description: Threshold value for tile selection using the 'twele' method.
+  attribute_type: processingParameter
 PRODUCT_LEVEL:
   description: Product level.
+  attribute_type: processingInformation
 PRODUCT_SOURCE:
   description: Source data for the product.
+  attribute_type: processingInformation
 PRODUCT_TYPE:
   description: Product type.
+  attribute_type: processingInformation
 PROJECT:
   description: Name of the project.
+  attribute_type: processingInformation
 RTC_ABSOLUTE_ORBIT_NUMBER:
   description: Absolute orbit number. Copied from OPERA RTC-S1 products.
+  attribute_type: platformInformation
+  attribute_name: RTCAbsoluteOrbitNumber
 RTC_BURST_ID:
   description: 'List of the burst ids used to generate the tile. Format: TrackNumber_BurstID_SwathNumber.'
+  attribute_type: platformInformation
+  attribute_name: RTCBurstID
 RTC_INPUT_L1_SLC_GRANULES:
   description: List of input L1 SLC granules used.
+  attribute_type: platformInformation
+  attribute_name: RTCInputL1SLCGranules
 RTC_INPUT_LIST:
   description: List of input RTC-S1 files.
+  attribute_type: platformInformation
+  attribute_name: RTCInputList
 RTC_ORBIT_PASS_DIRECTION:
   description: Orbit direction (e.g. Ascending or Descending). Copied from OPERA RTC-S1 products.
+  attribute_type: platformInformation
+  attribute_name: RTCOrbitPassDirection
 RTC_PRODUCT_VERSION:
   description: The version of the OPERA RTC-S1 algorithm used for RTC products. Copied directly from OPERA RTC-S1 metadata.
+  attribute_type: processingInformation
+  attribute_name: RTCProductVersion
+  attribute_data_type: string
 RTC_QA_RFI_INFO_AVAILABLE:
   description: A flag to indicate whether RFI information is available in the source data.
+  attribute_type: processingInformation
+  attribute_name: RTC_QA_RFI_InfoAvailable
 RTC_QA_RFI_NUMBER_OF_BURSTS:
   description: Number of RTC-S1 bursts affected by RFI.
+  attribute_type: processingInformation
+  attribute_name: RTC_QA_RFI_NumberOfBursts
 RTC_SENSING_END_TIME:
   description: 'Sensing end time. Latest acquisition time of OPERA burst RTC set. Format: YYYY-MM-DDTHH:MM:SSZ.'
+  attribute_type: platformInformation
+  attribute_name: RTCSensingEndTime
 RTC_SENSING_START_TIME:
   description: 'Sensing start time. Earliest acquisition time of OPERA burst RTC set. Format: YYYY-MM-DDTHH:MM:SSZ.'
+  attribute_type: platformInformation
+  attribute_name: RTCSensingStartTime
 RTC_TRACK_NUMBER:
   description: Track number. Copied from OPERA RTC-S1.
+  attribute_type: platformInformation
+  attribute_name: RTCTrackNumber
 SENSOR:
   description: Name of the sensor instrument (i.e. IW).
+  attribute_type: platformInformation
 SOFTWARE_VERSION:
   description: The software version used to generate the DSWx-S1 product.
+  attribute_type: processingInformation
+  attribute_data_type: string
 SPACECRAFT_NAME:
   description: Name of the sensor platform (i.e.  Sentinel-1A/B).
+  attribute_type: processingInformation
 SPATIAL_COVERAGE:
   description: The area percentage of the tile with data.
+  attribute_type: platformInformation

--- a/src/opera/pge/dswx_s1/templates/dswx_s1_measured_parameters.yaml
+++ b/src/opera/pge/dswx_s1/templates/dswx_s1_measured_parameters.yaml
@@ -8,6 +8,7 @@ DSWX_PRODUCT_VERSION:
   description: The DSWx-S1 product version.
   attribute_type: processingInformation
   attribute_data_type: string
+  display_name: DSWxProductVersion
 INSTITUTION:
   description: Name of the generating Institution.
   attribute_type: processingInformation
@@ -17,15 +18,19 @@ LAYOVER_SHADOW_COVERAGE:
 MGRS_COLLECTION_ACTUAL_NUMBER_OF_BURSTS:
   description: The number of actual RTC-S1 bursts that are collected within the MGRS tile collection ID.
   attribute_type: processingInformation
+  display_name: MGRSCollectionActualNumberOfBursts
 MGRS_COLLECTION_EXPECTED_NUMBER_OF_BURSTS:
   description: The number of expected RTC-S1 bursts that are supposed to be collected within the MGRS tile collection ID.
   attribute_type: processingInformation
+  display_name: MGRSCollectionExpectedNumberOfBursts
 MGRS_COLLECTION_MISSING_NUMBER_OF_BURSTS:
   description: The number of missing RTC-S1 bursts.
   attribute_type: processingInformation
+  display_name: MGRSCollectionMissingNumberOfBursts
 MGRS_POL_MODE:
   description: "The description for the polarizations of the collected bursts. 'MIX_DUAL_POL': ['HH', 'HV', 'VV', 'VH'], 'MIX_DUAL_H_SINGLE_V_POL': ['HH', 'HV', 'VV'], 'MIX_DUAL_V_SINGLE_H_POL': ['VV', 'VH', 'HH'], 'MIX_SINGLE_POL': ['HH', 'VV'], 'DV_POL': ['VV', 'VH'], 'SV_POL': ['VV'], 'DH_POL': ['HH', 'HV'], 'SH_POL': ['HH']."
   attribute_type: processingInformation
+  display_name: MGRSPolMode
 INPUT_DEM_SOURCE:
   description: Description of the input DEM.
   attribute_type: processingParameter
@@ -50,7 +55,7 @@ POLARIZATION:
 PROCESSING_DATETIME:
   description: 'DSWx-S1 product processing date. Format: YYYY-MM-DDTHH:MM:SSZ.'
   attribute_type: processingInformation
-  attribute_name: ProcessingDateTime
+  display_name: ProcessingDateTime
 PROCESSING_INFORMATION_FILTER:
   description: RTC intensity filtering method (bregman, lee, guided_filter, anisotropic_diffusion, etc.).
   attribute_type: processingParameter
@@ -60,7 +65,7 @@ PROCESSING_INFORMATION_FILTER_ENABLED:
 PROCESSING_INFORMATION_FILTER_OPTION:
   description: Parameters used for the despeckle filter.
   attribute_type: processingParameter
-  attribute_name: ProcessingInformationFilterOptions
+  display_name: ProcessingInformationFilterOption
 PROCESSING_INFORMATION_FUZZY_VALUE_AREA:
   description: The foot and shoulder values used to construct an S-shaped function for water body areas.
   attribute_type: processingParameter
@@ -160,48 +165,48 @@ PROJECT:
 RTC_ABSOLUTE_ORBIT_NUMBER:
   description: Absolute orbit number. Copied from OPERA RTC-S1 products.
   attribute_type: platformInformation
-  attribute_name: RTCAbsoluteOrbitNumber
+  display_name: RTCAbsoluteOrbitNumber
 RTC_BURST_ID:
   description: 'List of the burst ids used to generate the tile. Format: TrackNumber_BurstID_SwathNumber.'
   attribute_type: platformInformation
-  attribute_name: RTCBurstID
+  display_name: RTCBurstID
 RTC_INPUT_L1_SLC_GRANULES:
   description: List of input L1 SLC granules used.
   attribute_type: platformInformation
-  attribute_name: RTCInputL1SLCGranules
+  display_name: RTCInputL1SLCGranules
 RTC_INPUT_LIST:
   description: List of input RTC-S1 files.
   attribute_type: platformInformation
-  attribute_name: RTCInputList
+  display_name: RTCInputList
 RTC_ORBIT_PASS_DIRECTION:
   description: Orbit direction (e.g. Ascending or Descending). Copied from OPERA RTC-S1 products.
   attribute_type: platformInformation
-  attribute_name: RTCOrbitPassDirection
+  display_name: RTCOrbitPassDirection
 RTC_PRODUCT_VERSION:
   description: The version of the OPERA RTC-S1 algorithm used for RTC products. Copied directly from OPERA RTC-S1 metadata.
   attribute_type: processingInformation
-  attribute_name: RTCProductVersion
+  display_name: RTCProductVersion
   attribute_data_type: string
 RTC_QA_RFI_INFO_AVAILABLE:
   description: A flag to indicate whether RFI information is available in the source data.
   attribute_type: processingInformation
-  attribute_name: RTC_QA_RFI_InfoAvailable
+  display_name: RTC_QA_RFI_InfoAvailable
 RTC_QA_RFI_NUMBER_OF_BURSTS:
   description: Number of RTC-S1 bursts affected by RFI.
   attribute_type: processingInformation
-  attribute_name: RTC_QA_RFI_NumberOfBursts
+  display_name: RTC_QA_RFI_NumberOfBursts
 RTC_SENSING_END_TIME:
   description: 'Sensing end time. Latest acquisition time of OPERA burst RTC set. Format: YYYY-MM-DDTHH:MM:SSZ.'
   attribute_type: platformInformation
-  attribute_name: RTCSensingEndTime
+  display_name: RTCSensingEndTime
 RTC_SENSING_START_TIME:
   description: 'Sensing start time. Earliest acquisition time of OPERA burst RTC set. Format: YYYY-MM-DDTHH:MM:SSZ.'
   attribute_type: platformInformation
-  attribute_name: RTCSensingStartTime
+  display_name: RTCSensingStartTime
 RTC_TRACK_NUMBER:
   description: Track number. Copied from OPERA RTC-S1.
   attribute_type: platformInformation
-  attribute_name: RTCTrackNumber
+  display_name: RTCTrackNumber
 SENSOR:
   description: Name of the sensor instrument (i.e. IW).
   attribute_type: platformInformation

--- a/src/opera/util/render_jinja2.py
+++ b/src/opera/util/render_jinja2.py
@@ -155,3 +155,7 @@ def python_type_to_xml_type(obj) -> str:
 
     return XML_TYPES[obj]
 
+
+def guess_attribute_display_name(var_name: str) -> str:
+    return var_name.title().replace('_', '')
+


### PR DESCRIPTION
## Description
- Moved inline Measured Parameters Config (MPC) schema into a dedicated file `src/opera/pge/base/schema/iso_metadata_measured_parameters_config_schema.yaml`
- Added fields to MPC schema:
  - `attribute_type`: The parameter's EOS AdditionalAttributeDataTypeCode ([info](https://git.earthdata.nasa.gov/projects/EMFD/repos/iso-schemas/browse/resources/Codelist/eosCodelists.xml?at=606229ea84f207f42b7b477c507eb422f8996115#23)) [REQUIRED]
    - Must be one of: `geographicIdentifier`, `qualityInformation`, `instrumentInformation`, `sensorInformation`, `contentInformation`, `platformInformation`, `citation.identifier`, `descriptiveKeyword`, `processingInformation`, `processingParameter`, or `commandLineArgument`
  - `display_name`: Override for parameter's display name that is normally derived from the metadata variable name. [OPTIONAL]
  - `attribute_data_type`: Override for parameter's data type that is normally guessed from metadata variable's Python `type`. ([info](https://git.earthdata.nasa.gov/projects/EMFD/repos/iso-schemas/browse/resources/Codelist/eosCodelists.xml?at=606229ea84f207f42b7b477c507eb422f8996115#105)) [OPTIONAL]
    - Must be one of: `string`, `float`, `int`, `boolean`, `date`, `time`, `dateTime`, `dateString`, `timeString`, or `dateTimeString`
- Updated DSWx-S1 PGE to use the new MPC fields to populate the ISO XML template, falling back to guesses for absent, non-required fields.

## Affected Issues
- #514 

## Testing
- Manually ran unit tests, injecting a copy statement to pull out the temporary ISO XML files for [diffing](https://github.com/user-attachments/files/17156313/514-diff.html.zip).
```python
# in test_dswx_s1_pge.py @ line 290
shutil.copy(expected_iso_metadata_file, '/tmp/.')
```
- Ran int test on dev-pge, checking the produced XML files
