### PR TITLE
DISP-S1 SAS v0.4.6 Integration

### DIFF
--- a/.ci/scripts/disp_s1/build_disp_s1.sh
+++ b/.ci/scripts/disp_s1/build_disp_s1.sh
@@ -24,7 +24,7 @@ BUILD_DATE_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 # defaults, SAS image should be updated as necessary for new image releases from ADT
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath $(dirname $(realpath $0))/../../..)
 [ -z "${TAG}" ] && TAG="${USER}-dev"
-[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/disp-s1:0.4.4"
+[ -z "${SAS_IMAGE}" ] && SAS_IMAGE="artifactory-fn.jpl.nasa.gov:16001/gov/nasa/jpl/opera/adt/opera/disp-s1:0.4.6"
 
 echo "WORKSPACE: $WORKSPACE"
 echo "IMAGE: $IMAGE"

--- a/.ci/scripts/disp_s1/opera_pge_disp_s1_r5.5_calval_algorithm_parameters_forward.yaml
+++ b/.ci/scripts/disp_s1/opera_pge_disp_s1_r5.5_calval_algorithm_parameters_forward.yaml
@@ -182,6 +182,35 @@ unwrap_options:
       #   Type: string.
       #   Options: ['integer', 'L2'].
       bulk_method: L2
+timeseries_options:
+  # Whether to run the inversion step after unwrapping, if more than a single-reference
+  #   network is used.
+  #   Type: boolean.
+  run_inversion: false
+  # Norm to use during timeseries inversion.
+  #   Type: string.
+  #   Options: ['L1', 'L2'].
+  method: L1
+  # Reference point (row, col) used if performing a time series inversion. If not provided, a
+  #   point will be selected from a consistent connected component with low amplitude
+  #   dispersion.
+  #   Type: array | null.
+  reference_point:
+  # Run the velocity estimation from the phase time series.
+  #   Type: boolean.
+  run_velocity: false
+  # Pixels with correlation below this value will be masked out.
+  #   Type: number.
+  correlation_threshold: 0.0
+  # Size (rows, columns) of blocks of data to load at a time. 3D dimsion is number of
+  #   interferograms (during inversion) and number of SLC dates (during velocity fitting).
+  #   Type: array.
+  block_shape:
+    - 256
+    - 256
+  # Number of parallel blocks to process at once.
+  #   Type: integer.
+  num_parallel_blocks: 4
 output_options:
   # Output (x, y) resolution (in units of input data).
   #   Type: object | null.

--- a/.ci/scripts/disp_s1/opera_pge_disp_s1_r5.5_calval_algorithm_parameters_historical.yaml
+++ b/.ci/scripts/disp_s1/opera_pge_disp_s1_r5.5_calval_algorithm_parameters_historical.yaml
@@ -5,11 +5,11 @@ ps_options:
 phase_linking:
   # Size of the ministack for sequential estimator.
   #   Type: integer.
-  ministack_size: 1000
+  ministack_size: 100
   # Maximum number of compressed images to use in sequential estimator. If there are more
   #   ministacks than this, the earliest CCSLCs will be left out of the later stacks.
   #   Type: integer.
-  max_num_compressed: 10
+  max_num_compressed: 100
   half_window:
     # Half window size (in pixels) for x direction.
     #   Type: integer.
@@ -30,6 +30,11 @@ phase_linking:
   # Significance level (probability of false alarm) for SHP tests.
   #   Type: number.
   shp_alpha: 0.001
+  # If True, pixels labeled as PS will get set to NaN during phase linking to avoid summing
+  #   their phase. Default of False means that the SHP algorithm will decide if a pixel should
+  #   be included, regardless of its PS label.
+  #   Type: boolean.
+  mask_input_ps: false
   # StBAS parameter to include only nearest-N interferograms forphase linking. A
   #   `baseline_lag` of `n` will only include the closest`n` interferograms. `baseline_line`
   #   must be positive.
@@ -61,10 +66,10 @@ unwrap_options:
   # Phase unwrapping method.
   #   Type: string.
   #   Options: ['snaphu', 'icu', 'phass', 'spurt', 'whirlwind'].
-  unwrap_method: phass
+  unwrap_method: snaphu
   # Number of interferograms to unwrap in parallel.
   #   Type: integer.
-  n_parallel_jobs: 1
+  n_parallel_jobs: 4
   # Set wrapped phase/correlation to 0 where mask is 0 before unwrapping. .
   #   Type: boolean.
   zero_where_masked: false
@@ -74,11 +79,11 @@ unwrap_options:
     alpha: 0.5
     # (for interpolation) Maximum radius to find scatterers.
     #   Type: integer.
-    max_radius: 51
+    max_radius: 71
     # Threshold on the correlation raster to use for interpolation. Pixels with less than this
     #   value are replaced by a weighted combination of neighboring pixels.
     #   Type: number.
-    interpolation_cor_threshold: 0.5
+    interpolation_cor_threshold: 0.3
   snaphu_options:
     # Number of tiles to split the inputs into using SNAPHU's internal tiling.
     #   Type: array.
@@ -146,15 +151,15 @@ unwrap_options:
       # Number of workers for temporal unwrapping in parallel. Set value to <=0 to let workflow
       #   use default workers (ncpus - 1).
       #   Type: integer.
-      t_worker_count: 1
+      t_worker_count: 16
       # Number of workers for spatial unwrapping in parallel. Set value to <=0 to let workflow use
       #   (ncpus - 1).
       #   Type: integer.
-      s_worker_count: 1
+      s_worker_count: 8
       # Temporal unwrapping operations over spatial links are performed in batches and each batch
       #   is solved in parallel.
       #   Type: integer.
-      links_per_batch: 50000
+      links_per_batch: 150000
       # Temporal unwrapping costs.
       #   Type: string.
       #   Options: ['constant', 'distance', 'centroid'].
@@ -169,6 +174,9 @@ unwrap_options:
       # Scale factor used to compute edge costs for spatial unwrapping.
       #   Type: number.
       s_cost_scale: 100.0
+      # Number of tiles to process in parallel. Set to 0 for all tiles.
+      #   Type: integer.
+      num_parallel_tiles: 3
     merger_settings:
       # Minimum number of overlap pixels to be considered valid.
       #   Type: integer.
@@ -180,6 +188,39 @@ unwrap_options:
       #   Type: string.
       #   Options: ['integer', 'L2'].
       bulk_method: L2
+      # Number of interferograms to merge in one batch. Use zero to merge all interferograms in a
+      #   single batch.
+      #   Type: integer.
+      num_parallel_ifgs: 8
+timeseries_options:
+  # Whether to run the inversion step after unwrapping, if more than  a single-reference
+  #   network is used.
+  #   Type: boolean.
+  run_inversion: true
+  # Norm to use during timeseries inversion.
+  #   Type: string.
+  #   Options: ['L1', 'L2'].
+  method: L1
+  # Reference point (row, col) used if performing a time series inversion. If not provided, a
+  #   point will be selected from a consistent connected component with low amplitude
+  #   dispersion.
+  #   Type: array | null.
+  reference_point:
+  # Run the velocity estimation from the phase time series.
+  #   Type: boolean.
+  run_velocity: false
+  # Pixels with correlation below this value will be masked out.
+  #   Type: number.
+  correlation_threshold: 0.0
+  # Size (rows, columns) of blocks of data to load at a time. 3D dimsion is number of
+  #   interferograms (during inversion) and number of SLC dates (during velocity fitting).
+  #   Type: array.
+  block_shape:
+    - 256
+    - 256
+  # Number of parallel blocks to process at once.
+  #   Type: integer.
+  num_parallel_blocks: 4
 output_options:
   # Output (x, y) resolution (in units of input data).
   #   Type: object | null.
@@ -230,6 +271,16 @@ output_options:
     - 16
     - 32
     - 64
+  # Specify an extra reference datetime in UTC. Adding this lets you to create and unwrap two
+  #   single reference networks; the later resets at the given date (e.g. for a large
+  #   earthquake event). If passing strings, formats accepted are YYYY-MM-
+  #   DD[T]HH:MM[:SS[.ffffff]][Z or [±]HH[:]MM], or YYYY-MM-DD.
+  #   Type: string | null.
+  extra_reference_date:
 # Name of the subdataset to use in the input NetCDF files.
 #   Type: string.
 subdataset: /data/VV
+# Spatial wavelength cutoff (in meters) for the spatial filter. Used to create the short
+#   wavelength displacement layer.
+#   Type: number.
+spatial_wavelength_cutoff: 25000.0

--- a/.ci/scripts/disp_s1/opera_pge_disp_s1_r5.5_calval_runconfig_forward.yaml
+++ b/.ci/scripts/disp_s1/opera_pge_disp_s1_r5.5_calval_runconfig_forward.yaml
@@ -77,13 +77,14 @@ RunConfig:
             - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg3480.17i
             - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg3600.17i
           troposphere_files:
+
       ProductPathGroup:
         OutputProductPath: /home/mamba/output_dir
         ScratchPath: /home/mamba/scratch_dir
 
       PrimaryExecutable:
         ProductIdentifier: DISP_S1
-        ProductVersion: "0.4"
+        ProductVersion: "0.7"
         ProgramPath: disp-s1
         ProgramOptions:
           - run
@@ -120,7 +121,7 @@ RunConfig:
 
         frame_id: 7091
       dynamic_ancillary_file_group:
-        algorithm_parameters_file: /home/mamba/runconfig/opera_pge_disp_s1_r5.4_calval_algorithm_parameters_historical.yaml
+        algorithm_parameters_file: /home/mamba/runconfig/opera_pge_disp_s1_r5.5_calval_algorithm_parameters_forward.yaml
         static_layers_files:
           - /home/mamba/input_dir/dynamic_ancillary_files/static_layers/OPERA_L2_CSLC-S1-STATIC_T027-056725-IW1_20140403_S1A_v1.0.h5
           - /home/mamba/input_dir/dynamic_ancillary_files/static_layers/OPERA_L2_CSLC-S1-STATIC_T027-056726-IW1_20140403_S1A_v1.0.h5
@@ -176,13 +177,14 @@ RunConfig:
       static_ancillary_file_group:
         frame_to_burst_json: /home/mamba/input_dir/static_ancillary_files/opera-s1-disp-0.5.0-frame-to-burst.json.zip
         reference_date_database_json: /home/mamba/input_dir/static_ancillary_files/opera-disp-s1-reference-dates-minimal-2024-09-19.json
+        algorithm_parameters_overrides_json: /home/mamba/input_dir/static_ancillary_files/opera-disp-s1-algorithm-parameters-overrides-2024-10-14.json
       primary_executable:
-        product_type: DISP_S1_HISTORICAL
+        product_type: DISP_S1_FORWARD
       product_path_group:
         product_path: /home/mamba/output_dir
         scratch_path: /home/mamba/scratch_dir
         sas_output_path: /home/mamba/output_dir
-        product_version: "0.4"
+        product_version: "0.7"
         save_compressed_slc: true
       worker_settings:
         gpu_enabled: false

--- a/.ci/scripts/disp_s1/opera_pge_disp_s1_r5.5_calval_runconfig_historical.yaml
+++ b/.ci/scripts/disp_s1/opera_pge_disp_s1_r5.5_calval_runconfig_historical.yaml
@@ -77,14 +77,13 @@ RunConfig:
             - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg3480.17i
             - /home/mamba/input_dir/dynamic_ancillary_files/ionosphere_files/jplg3600.17i
           troposphere_files:
-
       ProductPathGroup:
         OutputProductPath: /home/mamba/output_dir
         ScratchPath: /home/mamba/scratch_dir
 
       PrimaryExecutable:
         ProductIdentifier: DISP_S1
-        ProductVersion: "0.4"
+        ProductVersion: "0.7"
         ProgramPath: disp-s1
         ProgramOptions:
           - run
@@ -121,7 +120,7 @@ RunConfig:
 
         frame_id: 7091
       dynamic_ancillary_file_group:
-        algorithm_parameters_file: /home/mamba/runconfig/opera_pge_disp_s1_r5.4_calval_algorithm_parameters_forward.yaml
+        algorithm_parameters_file: /home/mamba/runconfig/opera_pge_disp_s1_r5.5_calval_algorithm_parameters_historical.yaml
         static_layers_files:
           - /home/mamba/input_dir/dynamic_ancillary_files/static_layers/OPERA_L2_CSLC-S1-STATIC_T027-056725-IW1_20140403_S1A_v1.0.h5
           - /home/mamba/input_dir/dynamic_ancillary_files/static_layers/OPERA_L2_CSLC-S1-STATIC_T027-056726-IW1_20140403_S1A_v1.0.h5
@@ -176,19 +175,20 @@ RunConfig:
         troposphere_files:
       static_ancillary_file_group:
         frame_to_burst_json: /home/mamba/input_dir/static_ancillary_files/opera-s1-disp-0.5.0-frame-to-burst.json.zip
-        reference_date_database_json:
+        reference_date_database_json: /home/mamba/input_dir/static_ancillary_files/opera-disp-s1-reference-dates-minimal-2024-09-19.json
+        algorithm_parameters_overrides_json: /home/mamba/input_dir/static_ancillary_files/opera-disp-s1-algorithm-parameters-overrides-2024-10-14.json
       primary_executable:
-        product_type: DISP_S1_FORWARD
+        product_type: DISP_S1_HISTORICAL
       product_path_group:
         product_path: /home/mamba/output_dir
         scratch_path: /home/mamba/scratch_dir
         sas_output_path: /home/mamba/output_dir
-        product_version: "0.4"
+        product_version: "0.7"
         save_compressed_slc: true
       worker_settings:
         gpu_enabled: false
-        threads_per_worker: 1
-        n_parallel_bursts: 1
+        threads_per_worker: 4
+        n_parallel_bursts: 2
         block_shape:
           - 512
           - 512

--- a/.ci/scripts/disp_s1/test_int_disp_s1.sh
+++ b/.ci/scripts/disp_s1/test_int_disp_s1.sh
@@ -60,13 +60,15 @@ echo "Input data directory: ${input_dir}"
 echo "Expected data directory: ${expected_data_dir}"
 
 # Copy the RunConfig for the historical workflow
-historical_runconfig="opera_pge_disp_s1_r5.4_calval_runconfig_historical.yaml"
+historical_runconfig="opera_pge_disp_s1_r5.5_calval_runconfig_historical.yaml"
 local_historical_runconfig="${SCRIPT_DIR}/${historical_runconfig}"
 echo "Copying runconfig file $local_historical_runconfig to $runconfig_dir"
 cp ${local_historical_runconfig} ${runconfig_dir}
 
 # Run integration tests for DISP-S1 in both "forward" and "historical" modes
-for mode in forward historical
+# TODO for current delivery, only historical mode testing is supported
+#for mode in forward historical
+for mode in historical
 do
     output_dir="${TMP_DIR}/output_disp_s1/${mode}"
 

--- a/.ci/scripts/disp_s1/test_int_disp_s1.sh
+++ b/.ci/scripts/disp_s1/test_int_disp_s1.sh
@@ -28,9 +28,9 @@ SAMPLE_TIME=15
 # RUNCONFIG should be the name of the runconfig in s3://operasds-dev-pge/disp_s1/
 [ -z "${WORKSPACE}" ] && WORKSPACE=$(realpath "$(dirname "$(realpath "$0")")"/../../..)
 [ -z "${PGE_TAG}" ] && PGE_TAG="${USER}-dev"
-[ -z "${INPUT_DATA}" ] && INPUT_DATA="disp_s1_r5.4_calval_expected_input.zip"
-[ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="disp_s1_r5.4_calval_expected_output.zip"
-[ -z "${RUNCONFIG}" ] && RUNCONFIG="opera_pge_disp_s1_r5.4_calval_runconfig_forward.yaml"
+[ -z "${INPUT_DATA}" ] && INPUT_DATA="disp_s1_r5.5_calval_expected_input.zip"
+[ -z "${EXPECTED_DATA}" ] && EXPECTED_DATA="disp_s1_r5.5_calval_expected_output.zip"
+[ -z "${RUNCONFIG}" ] && RUNCONFIG="opera_pge_disp_s1_r5.5_calval_runconfig_forward.yaml"
 [ -z "${TMP_ROOT}" ] && TMP_ROOT="$DEFAULT_TMP_ROOT"
 
 # Create the test output directory in the work space
@@ -92,7 +92,7 @@ do
     mkdir -p --mode=777 "$scratch_dir"
 
     # Copy the Algorithm Parameters RunConfigs
-    algo_runconfig="opera_pge_disp_s1_r5.4_calval_algorithm_parameters_${mode}.yaml"
+    algo_runconfig="opera_pge_disp_s1_r5.5_calval_algorithm_parameters_${mode}.yaml"
     local_algo_runconfig="${SCRIPT_DIR}/${algo_runconfig}"
     echo "Copying runconfig file $local_algo_runconfig to $runconfig_dir"
     cp ${local_algo_runconfig} ${runconfig_dir}
@@ -110,7 +110,7 @@ do
                -v ${output_dir}:/home/mamba/output_dir \
                -v ${scratch_dir}:/home/mamba/scratch_dir \
                -v ${expected_data_dir}/${mode}:/home/mamba/expected_output_dir \
-               ${PGE_IMAGE}:"${PGE_TAG}" --file /home/mamba/runconfig/opera_pge_disp_s1_r5.4_calval_runconfig_${mode}.yaml
+               ${PGE_IMAGE}:"${PGE_TAG}" --file /home/mamba/runconfig/opera_pge_disp_s1_r5.5_calval_runconfig_${mode}.yaml
 
     docker_exit_status=$?
 

--- a/examples/disp_s1_sample_runconfig-v3.0.0-rc.4.1.yaml
+++ b/examples/disp_s1_sample_runconfig-v3.0.0-rc.4.1.yaml
@@ -83,7 +83,7 @@ RunConfig:
         ProductIdentifier: DISP_S1
 
         # Product version specific to output products
-        ProductVersion: "0.4"
+        ProductVersion: "0.7"
 
         # Path to the executable to run, path must be reachable from
         # within the Docker container (i.e. findable with a "which" command)
@@ -198,6 +198,11 @@ RunConfig:
         # Should be used only when product_type is set oto DISP_S1_HISTORICAL
         #   Type: string | null.
         reference_date_database_json: /home/mamba/input_dir/opera-s1-disp-reference-date.json
+
+        # JSON file containing frame-specific algorithm parameters to override the
+        # defaults passed in the `algorithm_parameters.yaml`.
+        #   Type: string | null.
+        algorithm_parameters_overrides_json: /home/mamba/input_dir/static_ancillary_files/opera-disp-s1-algorithm-parameters-overrides-2024-10-14.json
       primary_executable:
         # Product type of the PGE. Should be one of: DISP_S1_FORWARD or DISP_S1_HISTORICAL
         #   Type: string.
@@ -214,7 +219,7 @@ RunConfig:
         sas_output_path: /home/mamba/output_dir
         # Version of the product.
         #   Type: string.
-        product_version: "0.4"
+        product_version: "0.7"
         # Whether the SAS should output and save the Compressed SLCs in addition to the standard
         #   product output.
         #   Type: boolean.

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -836,7 +836,7 @@ class DispS1Executor(DispS1PreProcessorMixin, DispS1PostProcessorMixin, PgeExecu
     PGE_VERSION = "3.0.0-rc.4.1"
     """Version of the PGE (overrides default from base_pge)"""
 
-    SAS_VERSION = "0.4.4"  # CalVal release https://github.com/opera-adt/disp-s1/releases/tag/v0.4.4
+    SAS_VERSION = "0.4.6"  # CalVal release https://github.com/opera-adt/disp-s1/releases/tag/v0.4.6
 
     def __init__(self, pge_name, runconfig_path, **kwargs):
         super().__init__(pge_name, runconfig_path, **kwargs)

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -180,7 +180,6 @@ class DispS1PostProcessorMixin(PostProcessorMixin):
             # Validate .png file(s)
             nc_file_no_ext, ext = splitext(basename(nc_file))
             png_files = [
-                join(output_dir, f'{nc_file_no_ext}.displacement.png'),
                 join(output_dir, f'{nc_file_no_ext}.short_wavelength_displacement.png')
             ]
 
@@ -845,7 +844,7 @@ class DispS1Executor(DispS1PreProcessorMixin, DispS1PostProcessorMixin, PgeExecu
             {
                 # Note: ordering matters here!
                 '*.nc': self._netcdf_filename,
-                '*.displacement.png': self._browse_filename,
+                '*displacement.png': self._browse_filename,
                 'compressed*.h5': self._compressed_cslc_filename
             }
         )

--- a/src/opera/pge/disp_s1/schema/algorithm_parameters_disp_s1_schema.yaml
+++ b/src/opera/pge/disp_s1/schema/algorithm_parameters_disp_s1_schema.yaml
@@ -131,6 +131,25 @@ unwrap_options:
             # Number of interferograms to merge in one batch. Use zero to merge all
             # interferograms in a single batch.
             num_parallel_ifgs: int(required=False, min=0)
+timeseries_options:
+    # Whether to run the inversion step after unwrapping, if more than a single-reference
+    # network is used.
+    run_inversion: bool()
+    # Norm to use during timeseries inversion.
+    method: enum('L1', 'L2')
+    # Reference point (row, col) used if performing a time series inversion. If not provided, a
+    # point will be selected from a consistent connected component with low amplitude
+    # dispersion.
+    reference_point: any(list(int(), min=2, max=2), null())
+    # Run the velocity estimation from the phase time series.
+    run_velocity: bool()
+    # Pixels with correlation below this value will be masked out.
+    correlation_threshold: num(min=0.0, max=1.0)
+    # Size (rows, columns) of blocks of data to load at a time. 3D dimsion is number of
+    # interferograms (during inversion) and number of SLC dates (during velocity fitting).
+    block_shape: list(int(), min=2, max=2)
+    # Number of parallel blocks to process at once.
+    num_parallel_blocks: int()
 output_options:
     # Output (x, y) resolution (in units of input data).
     output_resolution: any(include('x_y_object'), null())

--- a/src/opera/pge/disp_s1/schema/disp_s1_sas_schema.yaml
+++ b/src/opera/pge/disp_s1/schema/disp_s1_sas_schema.yaml
@@ -39,6 +39,10 @@ static_ancillary_file_group:
     # JSON file containing list of reference date changes for each frame
     reference_date_database_json: str(required=False)
 
+    # JSON file containing frame-specific algorithm parameters to override the
+    # defaults passed in the `algorithm_parameters.yaml`.
+    algorithm_parameters_overrides_json: str(required=False)
+
 primary_executable:
     # Product type of the PGE.
     product_type: enum('DISP_S1_FORWARD', 'DISP_S1_HISTORICAL')
@@ -59,6 +63,9 @@ product_path_group:
     # Whether the SAS should output and save the Compressed SLCs in addition to
     # the standard product output.
     save_compressed_slc: bool(required=True)
+
+    # Location of the static layers product associated with this product
+    static_layers_data_access: str(required=False)
 
 worker_settings:
     # Whether to use GPU for processing (if available).

--- a/src/opera/test/data/test_disp_s1_algorithm_parameters.yaml
+++ b/src/opera/test/data/test_disp_s1_algorithm_parameters.yaml
@@ -182,6 +182,35 @@ unwrap_options:
       #   Type: string.
       #   Options: ['integer', 'L2'].
       bulk_method: L2
+timeseries_options:
+  # Whether to run the inversion step after unwrapping, if more than a single-reference
+  #   network is used.
+  #   Type: boolean.
+  run_inversion: false
+  # Norm to use during timeseries inversion.
+  #   Type: string.
+  #   Options: ['L1', 'L2'].
+  method: L1
+  # Reference point (row, col) used if performing a time series inversion. If not provided, a
+  #   point will be selected from a consistent connected component with low amplitude
+  #   dispersion.
+  #   Type: array | null.
+  reference_point:
+  # Run the velocity estimation from the phase time series.
+  #   Type: boolean.
+  run_velocity: false
+  # Pixels with correlation below this value will be masked out.
+  #   Type: number.
+  correlation_threshold: 0.0
+  # Size (rows, columns) of blocks of data to load at a time. 3D dimsion is number of
+  #   interferograms (during inversion) and number of SLC dates (during velocity fitting).
+  #   Type: array.
+  block_shape:
+    - 256
+    - 256
+  # Number of parallel blocks to process at once.
+  #   Type: integer.
+  num_parallel_blocks: 4
 output_options:
   # Output (x, y) resolution (in units of input data).
   #   Type: object | null.

--- a/src/opera/test/data/test_disp_s1_config.yaml
+++ b/src/opera/test/data/test_disp_s1_config.yaml
@@ -35,7 +35,6 @@ RunConfig:
                 ProgramOptions:
                     - '-p disp_s1_pge_test/output_dir/compressed_slcs;'
                     - 'python3 -c "from opera.util.h5_utils import create_test_disp_metadata_product; create_test_disp_metadata_product(\"disp_s1_pge_test/output_dir/20170217_20170430.nc\")";'
-                    - 'dd if=/dev/urandom of=disp_s1_pge_test/output_dir/20170217_20170430.displacement.png bs=1M count=1;'
                     - 'dd if=/dev/urandom of=disp_s1_pge_test/output_dir/20170217_20170430.short_wavelength_displacement.png bs=1M count=1;'
                     - 'dd if=/dev/urandom of=disp_s1_pge_test/output_dir/compressed_slcs/compressed_t027_056725_iw1_20170217_20170217_20170430.h5 bs=1M count=1;'
                     - 'dd if=/dev/urandom of=disp_s1_pge_test/output_dir/compressed_slcs/compressed_t027_056726_iw1_20170217_20170217_20170430.h5 bs=1M count=1;'
@@ -77,6 +76,8 @@ RunConfig:
 
             static_ancillary_file_group:
                 frame_to_burst_json: disp_s1_pge_test/input_dir/opera-s1-disp-frame-to-burst.json
+                reference_date_database_json: disp_s1_pge_test/input_dir/opera-disp-s1-reference-dates.json
+                algorithm_parameters_overrides_json: disp_s1_pge_test/input_dir/opera-disp-s1-algorithm-parameters-overrides.json
 
             primary_executable:
                 product_type: DISP_S1_FORWARD

--- a/src/opera/test/pge/disp_s1/test_disp_s1_pge.py
+++ b/src/opera/test/pge/disp_s1/test_disp_s1_pge.py
@@ -103,7 +103,9 @@ class DispS1PgeTestCase(unittest.TestCase):
                              'GMAO_tropo_20180210T000000_ztd.nc',
                              'ERA5_N30_N40_W120_W110_20221119_14.grb',
                              'ERA5_N30_N40_W120_W110_20221201_14.grb',
-                             'opera-s1-disp-frame-to-burst.json']
+                             'opera-s1-disp-frame-to-burst.json',
+                             'opera-disp-s1-reference-dates.json',
+                             'opera-disp-s1-algorithm-parameters-overrides.json']
         for dummy_input_file in dummy_input_files:
             os.system(
                 f"echo \"non-empty file\" > {join(input_dir, dummy_input_file)}"
@@ -805,14 +807,14 @@ class DispS1PgeTestCase(unittest.TestCase):
             with open(expected_log_file, 'r', encoding='utf-8') as infile:
                 log_contents = infile.read()
 
-            self.assertIn("SAS output file 20180101_20180330.displacement.png does not exist", log_contents)
+            self.assertIn("SAS output file 20180101_20180330.short_wavelength_displacement.png does not exist", log_contents)
             shutil.rmtree(pge.runconfig.output_product_path)
 
             # PNG is zero sized
             runconfig_dict['RunConfig']['Groups']['PGE']['PrimaryExecutable']['ProgramOptions'] = \
                 ['-p disp_s1_pge_test/output_dir/compressed_slcs;',
                  'dd if=/dev/urandom of=disp_s1_pge_test/output_dir/20180101_20180330.nc bs=1M count=1;',
-                 'touch disp_s1_pge_test/output_dir/20180101_20180330.displacement.png;',
+                 'touch disp_s1_pge_test/output_dir/20180101_20180330.short_wavelength_displacement.png;',
                  '/bin/echo DISP-S1 invoked with RunConfig']
 
             with open(test_runconfig_path, 'w', encoding='utf-8') as outfile:
@@ -828,7 +830,7 @@ class DispS1PgeTestCase(unittest.TestCase):
             with open(expected_log_file, 'r', encoding='utf-8') as infile:
                 log_contents = infile.read()
 
-            self.assertIn("SAS output file 20180101_20180330.displacement.png exists, but is empty",
+            self.assertIn("SAS output file 20180101_20180330.short_wavelength_displacement.png exists, but is empty",
                           log_contents)
             shutil.rmtree(pge.runconfig.output_product_path)
 


### PR DESCRIPTION
## Description
- This branch integrates v0.4.6 of the DISP-S1 CalVal SAS delivery with the corresponding PGE code
- Notable changes in this release include formal support for the "algorithm parameter overrides" config, as well as a temporary disabling of support for "forward" mode production

## Affected Issues
- Resolves #534 

## Testing
- Unit test suite for DISP-S1 has been updated to account for changes in the v0.4.6 delivery
- The integration test for DISP-S1 has been modified to only run the historical mode test for the time being. The test has been run in Jenkins with all output products passing the comparison step.
