### PR TITLE
DISP-S1 PGE Release v3.0.0

### DIFF
--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -901,7 +901,7 @@ class DispS1Executor(DispS1PreProcessorMixin, DispS1PostProcessorMixin, PgeExecu
     LEVEL = "L3"
     """Processing Level for DISP-S1 Products"""
 
-    PGE_VERSION = "3.0.0-rc.4.2"
+    PGE_VERSION = "3.0.0"
     """Version of the PGE (overrides default from base_pge)"""
 
     SAS_VERSION = "0.5.1"  # Final release https://github.com/opera-adt/disp-s1/releases/tag/v0.5.1


### PR DESCRIPTION
PGE Release v3.0.0 for DISP-S1. This release incorporates v0.5.1 of the "Final" DISP-S1 SAS delivery.
