### PR TITLE
Update Jenkins pipelines to be more aggressive in cleaning up build temp data

### DIFF
--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -64,10 +64,10 @@ pipeline {
             steps{
                 sh label: 'Download and install',
                    script: """#!/bin/bash
-                     mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
-                     bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     mkdir -p /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
+                     wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     bash /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
+                     rm /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
                    """
             }
         }
@@ -77,13 +77,13 @@ pipeline {
                     echo "Creating conda env"
                     sh label: 'Installing int test conda environment',
                        script: """#!/bin/bash
-                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda create -n int_test_env python=3.10 pip
-                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init bash
+                         /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda create -n int_test_env python=3.10 pip
+                         /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init bash
                     """
 
                     sh label: 'Installing dependencies to int test conda environment',
                        script: '''#!/bin/bash
-                       . /var/lib/jenkins/.bashrc
+                       . /data/var/lib/jenkins/.bashrc
                        conda activate int_test_env
                        conda install -c conda-forge gdal poppler h5py matplotlib
                        pip install -r ./requirements.txt
@@ -102,7 +102,7 @@ pipeline {
 
                         def statusCode = sh label: "Running Integration Test for image ${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_SUFFIX}:${DOCKER_TAG}", returnStatus:true,
                            script: """#!/bin/bash
-                           . /var/lib/jenkins/.bashrc
+                           . /data/var/lib/jenkins/.bashrc
                            conda activate int_test_env
                            .ci/scripts/${DOCKER_IMAGE_SUFFIX}/test_int_${DOCKER_IMAGE_SUFFIX}.sh --tag ${DOCKER_TAG}
                            """
@@ -145,9 +145,10 @@ pipeline {
             echo "Cleaning up Docker images from local host"
             sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
             echo "Removing int test conda environment"
-            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name int_test_env"
-            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
-            sh "rm -rf /var/lib/jenkins/conda_installs/${RUN_ID}/"
+            sh "/data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name int_test_env"
+            sh "/data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"
+            sh "/data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
+            sh "rm -rf /data/var/lib/jenkins/conda_installs/${RUN_ID}/"
             deleteDir()
         }
         success {

--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -64,10 +64,10 @@ pipeline {
             steps{
                 sh label: 'Download and install',
                    script: """#!/bin/bash
-                     mkdir -p /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
-                     bash /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     rm /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
+                     wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
+                     rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
                    """
             }
         }
@@ -77,13 +77,13 @@ pipeline {
                     echo "Creating conda env"
                     sh label: 'Installing int test conda environment',
                        script: """#!/bin/bash
-                         /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda create -n int_test_env python=3.10 pip
-                         /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init bash
+                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda create -n int_test_env python=3.10 pip
+                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init bash
                     """
 
                     sh label: 'Installing dependencies to int test conda environment',
                        script: '''#!/bin/bash
-                       . /data/var/lib/jenkins/.bashrc
+                       . /var/lib/jenkins/.bashrc
                        conda activate int_test_env
                        conda install -c conda-forge gdal poppler h5py matplotlib
                        pip install -r ./requirements.txt
@@ -102,7 +102,7 @@ pipeline {
 
                         def statusCode = sh label: "Running Integration Test for image ${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_SUFFIX}:${DOCKER_TAG}", returnStatus:true,
                            script: """#!/bin/bash
-                           . /data/var/lib/jenkins/.bashrc
+                           . /var/lib/jenkins/.bashrc
                            conda activate int_test_env
                            .ci/scripts/${DOCKER_IMAGE_SUFFIX}/test_int_${DOCKER_IMAGE_SUFFIX}.sh --tag ${DOCKER_TAG}
                            """
@@ -145,10 +145,10 @@ pipeline {
             echo "Cleaning up Docker images from local host"
             sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
             echo "Removing int test conda environment"
-            sh "/data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name int_test_env"
-            sh "/data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"
-            sh "/data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
-            sh "rm -rf /data/var/lib/jenkins/conda_installs/${RUN_ID}/"
+            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name int_test_env"
+            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"
+            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
+            sh "rm -rf /var/lib/jenkins/conda_installs/${RUN_ID}/"
             deleteDir()
         }
         success {

--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -142,14 +142,20 @@ pipeline {
     }
     post {
         always {
-            echo "Cleaning up Docker images from local host"
-            sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
-            echo "Removing int test conda environment"
-            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name int_test_env"
-            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"
-            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
-            sh "rm -rf /var/lib/jenkins/conda_installs/${RUN_ID}/"
-            deleteDir()
+            script {
+                catchError (buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    echo "Cleaning up Docker images from local host"
+                    sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
+                }
+                catchError (buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    echo "Removing int test conda environment"
+                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name int_test_env"
+                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"
+                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
+                    sh "rm -rf /var/lib/jenkins/conda_installs/${RUN_ID}/"
+                }
+                deleteDir()
+            }
         }
         success {
             echo 'Succeeded!'

--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -143,11 +143,11 @@ pipeline {
     post {
         always {
             script {
-                catchError (buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                catchError (buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Docker image cleanup failed') {
                     echo "Cleaning up Docker images from local host"
                     sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
                 }
-                catchError (buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                catchError (buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Conda cleanup failed') {
                     echo "Removing int test conda environment"
                     sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name int_test_env"
                     sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -107,10 +107,10 @@ pipeline {
             steps{
                 sh label: 'Download and install',
                    script: """#!/bin/bash
-                     mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
-                     bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     mkdir -p /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
+                     wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     bash /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
+                     rm /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
                    """
             }
         }
@@ -121,13 +121,13 @@ pipeline {
                     echo "Installing Sphinx Dependencies"
                     sh label: 'Installing conda environment for Sphinx',
                        script: """#!/bin/bash
-                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda create -n sphinx_env python=3.8 pip
-                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init bash
+                         /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda create -n sphinx_env python=3.8 pip
+                         /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init bash
                     """
 
                     sh label: 'Installing Sphinx to conda environment',
                        script: '''#!/bin/bash
-                       . /var/lib/jenkins/.bashrc
+                       . /data/var/lib/jenkins/.bashrc
                        conda activate sphinx_env
                        pip install -r ./requirements.txt
                        pip install -r ./requirements_dev.txt
@@ -135,14 +135,14 @@ pipeline {
 
                     sh label: 'Invoking clean target for Sphinx build',
                        script: '''#!/bin/bash
-                       . /var/lib/jenkins/.bashrc
+                       . /data/var/lib/jenkins/.bashrc
                        conda activate sphinx_env
                        /usr/bin/make --directory=./docs clean
                        '''
 
                     sh label: 'Invoking html target for Sphinx build',
                        script: '''#!/bin/bash
-                       . /var/lib/jenkins/.bashrc
+                       . /data/var/lib/jenkins/.bashrc
                        conda activate sphinx_env
                        /usr/bin/make --directory=./docs html
                        '''
@@ -241,9 +241,10 @@ pipeline {
             echo "Cleaning up Docker images from local host"
             sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
             echo "Removing Sphinx build environment"
-            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name sphinx_env"
-            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
-            sh "rm -rf /var/lib/jenkins/conda_installs/${RUN_ID}/"
+            sh "/data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name sphinx_env"
+            sh "/data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"
+            sh "/data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
+            sh "rm -rf /data/var/lib/jenkins/conda_installs/${RUN_ID}/"
             deleteDir()
         }
         success {

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -239,11 +239,11 @@ pipeline {
     post {
         always {
             script {
-                catchError (buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                catchError (buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Docker image cleanup failed') {
                     echo "Cleaning up Docker images from local host"
                     sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
                 }
-                catchError (buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                catchError (buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Conda cleanup failed') {
                     echo "Removing Sphinx build environment"
                     sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name sphinx_env"
                     sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -107,10 +107,10 @@ pipeline {
             steps{
                 sh label: 'Download and install',
                    script: """#!/bin/bash
-                     mkdir -p /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
-                     bash /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     rm /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
+                     wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
+                     rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
                    """
             }
         }
@@ -121,13 +121,13 @@ pipeline {
                     echo "Installing Sphinx Dependencies"
                     sh label: 'Installing conda environment for Sphinx',
                        script: """#!/bin/bash
-                         /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda create -n sphinx_env python=3.8 pip
-                         /data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init bash
+                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda create -n sphinx_env python=3.8 pip
+                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init bash
                     """
 
                     sh label: 'Installing Sphinx to conda environment',
                        script: '''#!/bin/bash
-                       . /data/var/lib/jenkins/.bashrc
+                       . /var/lib/jenkins/.bashrc
                        conda activate sphinx_env
                        pip install -r ./requirements.txt
                        pip install -r ./requirements_dev.txt
@@ -135,14 +135,14 @@ pipeline {
 
                     sh label: 'Invoking clean target for Sphinx build',
                        script: '''#!/bin/bash
-                       . /data/var/lib/jenkins/.bashrc
+                       . /var/lib/jenkins/.bashrc
                        conda activate sphinx_env
                        /usr/bin/make --directory=./docs clean
                        '''
 
                     sh label: 'Invoking html target for Sphinx build',
                        script: '''#!/bin/bash
-                       . /data/var/lib/jenkins/.bashrc
+                       . /var/lib/jenkins/.bashrc
                        conda activate sphinx_env
                        /usr/bin/make --directory=./docs html
                        '''
@@ -241,10 +241,10 @@ pipeline {
             echo "Cleaning up Docker images from local host"
             sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
             echo "Removing Sphinx build environment"
-            sh "/data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name sphinx_env"
-            sh "/data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"
-            sh "/data/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
-            sh "rm -rf /data/var/lib/jenkins/conda_installs/${RUN_ID}/"
+            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name sphinx_env"
+            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"
+            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
+            sh "rm -rf /var/lib/jenkins/conda_installs/${RUN_ID}/"
             deleteDir()
         }
         success {

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -238,14 +238,20 @@ pipeline {
     }
     post {
         always {
-            echo "Cleaning up Docker images from local host"
-            sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
-            echo "Removing Sphinx build environment"
-            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name sphinx_env"
-            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"
-            sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
-            sh "rm -rf /var/lib/jenkins/conda_installs/${RUN_ID}/"
-            deleteDir()
+            script {
+                catchError (buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    echo "Cleaning up Docker images from local host"
+                    sh ".ci/scripts/util/cleanup.sh ${DOCKER_TAG}"
+                }
+                catchError (buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    echo "Removing Sphinx build environment"
+                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name sphinx_env"
+                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"
+                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
+                    sh "rm -rf /var/lib/jenkins/conda_installs/${RUN_ID}/"
+                }
+                deleteDir()
+            }
         }
         success {
             echo 'Succeeded!'

--- a/.ci/jenkins/delete-tmp-dirs/Jenkinsfile
+++ b/.ci/jenkins/delete-tmp-dirs/Jenkinsfile
@@ -5,6 +5,10 @@ in order to document the pipeline needed to delete the
 numerous 'tmp<unique_id>' directories that accumulate and consume
 disc space in the add/tmp directory on the opera-pge-ci aws machine.
 Using a Jenkins pipeline was required due to security concerns.
+
+This pipeline will also clean up extraneous docker data and any
+conda installs left over from potential failed executions of the
+int and deploy pipelines
 */
 pipeline {
     agent any

--- a/.ci/jenkins/delete-tmp-dirs/Jenkinsfile
+++ b/.ci/jenkins/delete-tmp-dirs/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
                 echo "Cleaning up old Docker data"
                 sh 'docker system prune -f'
                 echo "Removing any orphaned conda environments"
-                sh 'find /var/lib/jenkins/conda_installs/ -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \\;'
+                sh 'find /data/var/lib/jenkins/conda_installs/ -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \\; || true'
             }
         }
     }

--- a/.ci/jenkins/delete-tmp-dirs/Jenkinsfile
+++ b/.ci/jenkins/delete-tmp-dirs/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
                 echo "Cleaning up old Docker data"
                 sh 'docker system prune -f'
                 echo "Removing any orphaned conda environments"
-                sh 'find /data/var/lib/jenkins/conda_installs/ -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \\; || true'
+                sh 'find /var/lib/jenkins/conda_installs/ -maxdepth 1 -type d -mtime +1 -exec rm -rf {} \\; || true'
             }
         }
     }


### PR DESCRIPTION
## Description
- Clean up conda package cache when environments are uninstalled
- Ensure the conda environment removal post steps are always run, even if prior docker cleanup script step fails
- Stop the cleanup pipeline from failing if conda install dir doesn't exist (doesn't have much effect re disk usage but the pipeline shouldn't fail if it has nothing to clean)

## Affected Issues
- #556 

## Testing
- Ran int test pipelines in sandbox
