### PR TITLE
Patch augment_measured_parameters behavior for non-TIFF PGEs

### DIFF
--- a/src/opera/pge/base/schema/iso_metadata_measured_parameters_config_schema.yaml
+++ b/src/opera/pge/base/schema/iso_metadata_measured_parameters_config_schema.yaml
@@ -24,3 +24,7 @@ parameter:
   # OPTIONAL: Set this flag to true if the value of the attribute should be escaped for HTML characters prior to being
   # written to the output XML. Applies to string and string-like attributes only.
   escape_html: bool(required=False)
+
+  # OPTIONAL: If true, this parameter will log a warning if not present in the output product. Otherwise, it will raise
+  # an error. Defaults to false. Only applicable for CSLC-S1, RTC-S1 and DISP-S1
+  optional: bool(required=False)

--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -647,7 +647,7 @@ class CslcS1PostProcessorMixin(PostProcessorMixin):
                 try:
                     mp = mp[key_path.pop(0)]
                 except KeyError as e:
-                    msg = (f'Measured parameters configuration contains an path {parameter_var_name} that is missing '
+                    msg = (f'Measured parameters configuration contains a path {parameter_var_name} that is missing '
                            f'from the output product')
                     if descriptions[parameter_var_name].get('optional', False):
                         self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)

--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -647,9 +647,12 @@ class CslcS1PostProcessorMixin(PostProcessorMixin):
                 try:
                     mp = mp[key_path.pop(0)]
                 except KeyError as e:
-                    msg = (f'Measured parameters configuration contains an invalid path {parameter_var_name}: no such '
-                           f'entry {e}')
-                    self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
+                    msg = (f'Measured parameters configuration contains an path {parameter_var_name} that is missing '
+                           f'from the output product')
+                    if descriptions[parameter_var_name].get('optional', False):
+                        self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)
+                    else:
+                        self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
 
             new_measured_parameters[parameter_var_name] = mp
 

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -635,7 +635,7 @@ class DispS1PostProcessorMixin(PostProcessorMixin):
                 try:
                     mp = mp[key_path.pop(0)]
                 except KeyError:
-                    msg = (f'Measured parameters configuration contains an path {parameter_var_name} that is missing '
+                    msg = (f'Measured parameters configuration contains a path {parameter_var_name} that is missing '
                            f'from the output product')
                     if descriptions[parameter_var_name].get('optional', False):
                         self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -634,10 +634,13 @@ class DispS1PostProcessorMixin(PostProcessorMixin):
             while len(key_path) > 0:
                 try:
                     mp = mp[key_path.pop(0)]
-                except KeyError as e:
-                    msg = (f'Measured parameters configuration contains an invalid path {parameter_var_name}: no such '
-                           f'entry {e}')
-                    self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
+                except KeyError:
+                    msg = (f'Measured parameters configuration contains an path {parameter_var_name} that is missing '
+                           f'from the output product')
+                    if descriptions[parameter_var_name].get('optional', False):
+                        self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)
+                    else:
+                        self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
 
             new_measured_parameters[parameter_var_name] = mp
 

--- a/src/opera/pge/disp_s1/templates/disp_s1_measured_parameters.yaml
+++ b/src/opera/pge/disp_s1/templates/disp_s1_measured_parameters.yaml
@@ -126,26 +126,31 @@ identification/instrument_name:
   attribute_type: instrumentInformation
   description: Instrument name
   display_name: InstrumentName
+  optional: true  # Non-guarenteed copy from CLSC
 identification/look_direction:
   attribute_data_type: string
   attribute_type: processingInformation
   description: Look direction
   display_name: LookDirection
+  optional: true  # Non-guarenteed copy from CLSC
 identification/track_number:
   attribute_data_type: int
   attribute_type: processingInformation
   description: Track number
   display_name: TrackNumber
+  optional: true  # Non-guarenteed copy from CLSC
 identification/orbit_pass_direction:
   attribute_data_type: string
   attribute_type: processingInformation
   description: Orbit pass direction
   display_name: OrbitPassDirection
+  optional: true  # Non-guarenteed copy from CLSC
 identification/absolute_orbit_number:
   attribute_data_type: int
   attribute_type: instrumentInformation
   description: Absolute orbit number
   display_name: AbsoluteOrbitNumber
+  optional: true  # Non-guarenteed copy from CLSC
 identification/static_layers_data_access:
   attribute_data_type: string
   attribute_type: processingInformation
@@ -339,6 +344,7 @@ metadata/platform_id:  # Description copied from CSLC processing_information/inp
   attribute_type: platformInformation
   description: Sensor platform identification string.
   display_name: PlatformID
+  optional: true  # Non-guarenteed copy from CLSC
 metadata/product_pixel_coordinate_convention:
   attribute_data_type: string
   attribute_type: contentInformation
@@ -354,18 +360,22 @@ metadata/slant_range_mid_swath:  # Description copied from CSLC processing_infor
   attribute_type: instrumentInformation
   description: Slant range of the middle of the sub-swath IW2.
   display_name: SlantRangeMidSwath
+  optional: true  # Non-guarenteed copy from CLSC
 metadata/source_data_software_COMPASS_version:  # Description copied from CSLC processing_information/algorithms/COMPASS_version
   attribute_data_type: string
   attribute_type: processingInformation
   description: CSLC-S1 SAS version used for processing.
   display_name: SourceDataSoftwareCOMPASSVersion
+  optional: true  # Non-guarenteed copy from CLSC
 metadata/source_data_software_ISCE3_version:  # Description copied from CSLC processing_information/algorithms/ISCE3_version
   attribute_data_type: string
   attribute_type: processingInformation
   description: ISCE3 version used for processing
   display_name: SourceDataSoftwareISCE3Version
+  optional: true  # Non-guarenteed copy from CLSC
 metadata/source_data_software_s1_reader_version:  # Description copied from CSLC processing_information/algorithms/s1_reader_version
   attribute_data_type: string
   attribute_type: processingInformation
   description: S1-Reader version used for processing
   display_name: SourceDataSoftwareS1ReaderVersion
+  optional: true  # Non-guarenteed copy from CLSC

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -743,9 +743,12 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
                     mp = mp[key_path.pop(0)]
                     new_measured_parameters[parameter_var_name] = mp
                 except KeyError as err:
-                    msg = (f'Measured parameters contains no entry for description '
-                           f'key "{err}"')
-                    self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)
+                    msg = (f'Measured parameters configuration contains an path {parameter_var_name} that is missing '
+                           f'from the output product')
+                    if descriptions[parameter_var_name].get('optional', False):
+                        self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)
+                    else:
+                        self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
 
         augmented_parameters = super().augment_measured_parameters(new_measured_parameters)
 

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -743,7 +743,7 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
                     mp = mp[key_path.pop(0)]
                     new_measured_parameters[parameter_var_name] = mp
                 except KeyError as err:
-                    msg = (f'Measured parameters configuration contains an path {parameter_var_name} that is missing '
+                    msg = (f'Measured parameters configuration contains a path {parameter_var_name} that is missing '
                            f'from the output product')
                     if descriptions[parameter_var_name].get('optional', False):
                         self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)

--- a/src/opera/util/h5_utils.py
+++ b/src/opera/util/h5_utils.py
@@ -563,7 +563,10 @@ def get_disp_s1_product_metadata(file_name):
     return disp_metadata
 
 
-def create_test_disp_metadata_product(file_path):
+def create_test_disp_metadata_product(
+        file_path,
+        omit_cslc_measured_parameters=False
+):
     # pylint: disable=unused-variable,invalid-name,too-many-locals,too-many-statements,too-many-boolean-expressions
     """
     Creates a dummy DISP-S1 h5 metadata file with expected groups and datasets.
@@ -574,6 +577,9 @@ def create_test_disp_metadata_product(file_path):
     ----------
     file_path : str
         Full path to write the dummy DISP H5 metadata file to.
+    omit_cslc_measured_parameters : bool
+        If true, do not create dummy datasets for datasets copied from the input CSLC
+        (https://github.com/opera-adt/disp-s1/blob/fa562e194f26ebdadfdbe6f0defe80b55f212b4a/src/disp_s1/product.py#L1614-L1647)
 
     """
     pge_runconfig_contents = """
@@ -594,23 +600,30 @@ def create_test_disp_metadata_product(file_path):
     """
 
     with h5py.File(file_path, 'w') as outfile:
-        x_dset = outfile.create_dataset("x", data=np.zeros(10,), dtype='float64')
-        y_dset = outfile.create_dataset("y", data=np.zeros(10,), dtype='float64')
+        x_dset = outfile.create_dataset("x", data=np.zeros(10, ), dtype='float64')
+        y_dset = outfile.create_dataset("y", data=np.zeros(10, ), dtype='float64')
 
         identification_grp = outfile.create_group("/identification")
         frame_id_dset = identification_grp.create_dataset("frame_id", data=123, dtype='int64')
         product_version_dset = identification_grp.create_dataset("product_version",
                                                                  data=np.bytes_("0.2"))
         reference_zero_doppler_start_time_dset = identification_grp.create_dataset("reference_zero_doppler_start_time",
-                                                                                   data=np.bytes_("2017-02-17 13:27:50.139658"))
+                                                                                   data=np.bytes_(
+                                                                                       "2017-02-17 13:27:50.139658"))
         reference_zero_doppler_end_time_dset = identification_grp.create_dataset("reference_zero_doppler_end_time",
-                                                                                 data=np.bytes_("2017-02-17 13:27:55.979493"))
+                                                                                 data=np.bytes_(
+                                                                                     "2017-02-17 13:27:55.979493"))
         secondary_zero_doppler_start_time_dset = identification_grp.create_dataset("secondary_zero_doppler_start_time",
-                                                                                   data=np.bytes_("2017-04-30 13:27:52.049224"))
+                                                                                   data=np.bytes_(
+                                                                                       "2017-04-30 13:27:52.049224"))
         secondary_zero_doppler_end_time_dset = identification_grp.create_dataset("secondary_zero_doppler_end_time",
-                                                                                 data=np.bytes_("2017-04-30 13:27:57.891116"))
-        bounding_polygon_dset = identification_grp.create_dataset("bounding_polygon",
-                                                                  data=np.bytes_("POLYGON ((-119.26 39.15, -119.32 39.16, -119.22 39.32, -119.26 39.15))"))
+                                                                                 data=np.bytes_(
+                                                                                     "2017-04-30 13:27:57.891116"))
+        bounding_polygon_dset = identification_grp.create_dataset(
+              "bounding_polygon",
+              data=np.bytes_(
+                  "POLYGON ((-119.26 39.15, -119.32 39.16, -119.22 39.32, -119.26 39.15))")
+        )
         radar_wavelength_dset = identification_grp.create_dataset("radar_wavelength",
                                                                   data=0.05546576, dtype='float64')
         reference_datetime_dset = identification_grp.create_dataset("reference_datetime",
@@ -619,24 +632,36 @@ def create_test_disp_metadata_product(file_path):
                                                                     data=np.bytes_("2022-12-13 00:00:00.000000"))
         average_temporal_coherence_dset = identification_grp.create_dataset("average_temporal_coherence",
                                                                             data=0.9876175064678105, dtype='float64')
-        ceos_analysis_ready_data_document_identifier_dset = identification_grp.create_dataset("ceos_analysis_ready_data_document_identifier",
-                                                                                              data=np.bytes_("https://ceos.org/ard/files/PFS/NRB/v5.5/CARD4L-PFS_NRB_v5.5.pdf"))
-        source_data_access_dset = identification_grp.create_dataset("source_data_access",
-                                                                    data=np.bytes_("OPERA_L2_CSLC-S1_T027-056725-IW1_20170217T132750Z_20240625T060850Z_S1A_VV_v1.1,"
-                                                                                    "OPERA_L2_CSLC-S1_T027-056726-IW1_20170217T132752Z_20240625T060850Z_S1A_VV_v1.1"))
+        ceos_analysis_ready_data_document_identifier_dset = identification_grp.create_dataset(
+            "ceos_analysis_ready_data_document_identifier",
+            data=np.bytes_("https://ceos.org/ard/files/PFS/NRB/v5.5/CARD4L-PFS_NRB_v5.5.pdf"))
+        source_data_access_dset = identification_grp.create_dataset(
+            "source_data_access",
+            data=np.bytes_(
+                "OPERA_L2_CSLC-S1_T027-056725-IW1_20170217T132750Z_20240625T060850Z_S1A_VV_v1.1,"
+                "OPERA_L2_CSLC-S1_T027-056726-IW1_20170217T132752Z_20240625T060850Z_S1A_VV_v1.1")
+        )
         source_data_x_spacing_dset = identification_grp.create_dataset("source_data_x_spacing", data=5, dtype='int64')
         source_data_y_spacing_dset = identification_grp.create_dataset("source_data_y_spacing", data=10, dtype='int64')
-        near_range_incidence_angle_dset = identification_grp.create_dataset("near_range_incidence_angle", data=30.9, dtype='float32')
-        far_range_incidence_angle_dset = identification_grp.create_dataset("far_range_incidence_angle", data=36.8, dtype='float32')
-        product_sample_spacing_dset = identification_grp.create_dataset("product_sample_spacing", data=30, dtype='int64')
-        product_bounding_box_dset = identification_grp.create_dataset("product_bounding_box", data=np.bytes_("280230.0,3555240.0,572310.0,3767970.0"))
-        product_pixel_coordinate_convention_dset = identification_grp.create_dataset("product_pixel_coordinate_convention", data=np.bytes_("center"))
+        near_range_incidence_angle_dset = identification_grp.create_dataset("near_range_incidence_angle", data=30.9,
+                                                                            dtype='float32')
+        far_range_incidence_angle_dset = identification_grp.create_dataset("far_range_incidence_angle", data=36.8,
+                                                                           dtype='float32')
+        product_sample_spacing_dset = identification_grp.create_dataset("product_sample_spacing", data=30,
+                                                                        dtype='int64')
+        product_bounding_box_dset = identification_grp.create_dataset("product_bounding_box", data=np.bytes_(
+            "280230.0,3555240.0,572310.0,3767970.0"))
+        product_pixel_coordinate_convention_dset = identification_grp.create_dataset(
+            "product_pixel_coordinate_convention", data=np.bytes_("center"))
         mission_id_dset = identification_grp.create_dataset("mission_id", data=np.bytes_("S1A"))
-        instrument_name_dset = identification_grp.create_dataset("instrument_name", data=np.bytes_("C-SAR"))
-        look_direction_dset = identification_grp.create_dataset("look_direction", data=np.bytes_("Right"))
-        track_number_dset = identification_grp.create_dataset("track_number", data=27, dtype='int64')
-        orbit_pass_direction_dset = identification_grp.create_dataset("orbit_pass_direction", data=np.bytes_("Descending"))
-        absolute_orbit_number_dset = identification_grp.create_dataset("absolute_orbit_number", data=15324, dtype="int64")
+        if not omit_cslc_measured_parameters:
+            instrument_name_dset = identification_grp.create_dataset("instrument_name", data=np.bytes_("C-SAR"))
+            look_direction_dset = identification_grp.create_dataset("look_direction", data=np.bytes_("Right"))
+            track_number_dset = identification_grp.create_dataset("track_number", data=27, dtype='int64')
+            orbit_pass_direction_dset = identification_grp.create_dataset("orbit_pass_direction",
+                                                                          data=np.bytes_("Descending"))
+            absolute_orbit_number_dset = identification_grp.create_dataset("absolute_orbit_number", data=15324,
+                                                                           dtype="int64")
 
         acquisition_mode_dset = identification_grp.create_dataset("acquisition_mode", data=np.bytes_("IW"))
         ceos_analysis_ready_data_product_type_dset = identification_grp.create_dataset(
@@ -649,7 +674,8 @@ def create_test_disp_metadata_product(file_path):
                                                                            data=np.bytes_("2025-01-17 22:47:38"))
         product_data_access_dset = identification_grp.create_dataset("product_data_access", data=np.bytes_(
             "https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=DISP-S1"))
-        radar_center_frequency_dset = identification_grp.create_dataset("radar_center_frequency", data=5405000454.33435, dtype="float64")
+        radar_center_frequency_dset = identification_grp.create_dataset("radar_center_frequency", data=5405000454.33435,
+                                                                        dtype="float64")
         source_data_azimuth_resolutions_dset = identification_grp.create_dataset("source_data_azimuth_resolutions",
                                                                                  data=np.bytes_("[22.5, 22.7, 22.6]"))
         source_data_dem_name_dset = identification_grp.create_dataset("source_data_dem_name",
@@ -659,7 +685,20 @@ def create_test_disp_metadata_product(file_path):
         source_data_earliest_processing_datetime_dset = identification_grp.create_dataset(
             "source_data_earliest_processing_datetime", data=np.bytes_("2024-06-25T00:00:00"))
         source_data_file_list_dset = identification_grp.create_dataset("source_data_file_list", data=np.bytes_(
-            "OPERA_L2_CSLC-S1_T027-056725-IW1_20170217T132750Z_20240625T060850Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056726-IW1_20170217T132752Z_20240625T060850Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056725-IW1_20170301T132749Z_20240625T090210Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056726-IW1_20170301T132752Z_20240625T090210Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056725-IW1_20170313T132750Z_20240625T121542Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056726-IW1_20170313T132753Z_20240625T121542Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056725-IW1_20170325T132750Z_20240625T163704Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056726-IW1_20170325T132753Z_20240625T163704Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056725-IW1_20170406T132750Z_20240625T225442Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056726-IW1_20170406T132753Z_20240625T225442Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056725-IW1_20170418T132751Z_20240626T003055Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056726-IW1_20170418T132754Z_20240626T003055Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056725-IW1_20170430T132752Z_20240626T015700Z_S1A_VV_v1.1,OPERA_L2_CSLC-S1_T027-056726-IW1_20170430T132754Z_20240626T015700Z_S1A_VV_v1.1"))
+            "OPERA_L2_CSLC-S1_T027-056725-IW1_20170217T132750Z_20240625T060850Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056726-IW1_20170217T132752Z_20240625T060850Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056725-IW1_20170301T132749Z_20240625T090210Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056726-IW1_20170301T132752Z_20240625T090210Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056725-IW1_20170313T132750Z_20240625T121542Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056726-IW1_20170313T132753Z_20240625T121542Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056725-IW1_20170325T132750Z_20240625T163704Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056726-IW1_20170325T132753Z_20240625T163704Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056725-IW1_20170406T132750Z_20240625T225442Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056726-IW1_20170406T132753Z_20240625T225442Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056725-IW1_20170418T132751Z_20240626T003055Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056726-IW1_20170418T132754Z_20240626T003055Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056725-IW1_20170430T132752Z_20240626T015700Z_S1A_VV_v1.1,"
+            "OPERA_L2_CSLC-S1_T027-056726-IW1_20170430T132754Z_20240626T015700Z_S1A_VV_v1.1"))
         source_data_latest_acquisition_dset = identification_grp.create_dataset("source_data_latest_acquisition",
                                                                                 data=np.bytes_("2017-04-30T00:00:00"))
         source_data_latest_processing_datetime_dset = identification_grp.create_dataset(
@@ -679,19 +718,24 @@ def create_test_disp_metadata_product(file_path):
                                                                              data=np.bytes_("S1A"))
         source_data_secondary_orbit_type_dset = identification_grp.create_dataset("source_data_secondary_orbit_type",
                                                                                   data=np.bytes_("precise orbit file"))
-        static_layers_data_access_dset = identification_grp.create_dataset("static_layers_data_access",
-                                                                           data=np.bytes_("https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=DISP-S1-STATIC&frame=7091"))
+        static_layers_data_access_dset = identification_grp.create_dataset(
+           "static_layers_data_access",
+           data=np.bytes_(
+               "https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=DISP-S1-STATIC&frame=7091")
+        )
         radar_band_dset = identification_grp.create_dataset("radar_band", data=np.bytes_("C"))
 
         metadata_grp = outfile.create_group("/metadata")
         disp_s1_software_version_dset = metadata_grp.create_dataset("disp_s1_software_version",
-                                                                          data=np.bytes_("0.2.7"))
+                                                                    data=np.bytes_("0.2.7"))
         dolphin_software_version_dset = metadata_grp.create_dataset("dolphin_software_version",
-                                                                          data=np.bytes_("0.15.3"))
+                                                                    data=np.bytes_("0.15.3"))
         pge_runconfig_dset = metadata_grp.create_dataset("pge_runconfig",
                                                          data=np.bytes_(pge_runconfig_contents))
-        algorithm_parameters_yaml_dset = metadata_grp.create_dataset("algorithm_parameters_yaml", data=np.bytes_(algorithm_parameters_contents))
-        dolphin_workflow_config_dset = metadata_grp.create_dataset("dolphin_workflow_config", data=np.bytes_(dolphin_workflow_config_contents))
+        algorithm_parameters_yaml_dset = metadata_grp.create_dataset("algorithm_parameters_yaml",
+                                                                     data=np.bytes_(algorithm_parameters_contents))
+        dolphin_workflow_config_dset = metadata_grp.create_dataset("dolphin_workflow_config",
+                                                                   data=np.bytes_(dolphin_workflow_config_contents))
 
         algorithm_theoretical_basis_document_id_dset = metadata_grp.create_dataset(
             "algorithm_theoretical_basis_document_id", data=np.bytes_("JPL D-108765"))
@@ -709,23 +753,32 @@ def create_test_disp_metadata_product(file_path):
             "ceos_persistent_scatterer_selection_criteria", data=np.bytes_("Amplitude Dispersion"))
         ceos_persistent_scatterer_selection_criteria_doi_dset = metadata_grp.create_dataset(
             "ceos_persistent_scatterer_selection_criteria_doi", data=np.bytes_("https://doi.org/10.1109/36.898661"))
-        ceos_phase_similarity_metric_doi_dset = metadata_grp.create_dataset("ceos_phase_similarity_metric_doi",
-                                                                            data=np.bytes_(
-                                                                                "https://doi.org/10.1109/TGRS.2022.3210868"))
+        ceos_phase_similarity_metric_doi_dset = metadata_grp.create_dataset(
+            "ceos_phase_similarity_metric_doi",
+            data=np.bytes_(
+                "https://doi.org/10.1109/TGRS.2022.3210868")
+        )
         ceos_phase_unwrapping_method_dset = metadata_grp.create_dataset("ceos_phase_unwrapping_method",
                                                                         data=np.bytes_("UnwrapMethod.SNAPHU"))
-        ceos_phase_unwrapping_snaphu_doi_dset = metadata_grp.create_dataset("ceos_phase_unwrapping_snaphu_doi",
-                                                                            data=np.bytes_(
-                                                                                "https://doi.org/10.1364/JOSAA.18.000338"))
-        platform_id_dset = metadata_grp.create_dataset("platform_id", data=np.bytes_("S1A"))
+        ceos_phase_unwrapping_snaphu_doi_dset = metadata_grp.create_dataset(
+            "ceos_phase_unwrapping_snaphu_doi",
+            data=np.bytes_(
+                "https://doi.org/10.1364/JOSAA.18.000338")
+        )
         product_pixel_coordinate_convention_dset = metadata_grp.create_dataset("product_pixel_coordinate_convention",
                                                                                data=np.bytes_("center"))
         product_specification_document_id_dset = metadata_grp.create_dataset("product_specification_document_id",
                                                                              data=np.bytes_("JPL D-108278"))
-        slant_range_mid_swath_dset = metadata_grp.create_dataset("slant_range_mid_swath", data=875720.2393261964, dtype="float64")
-        source_data_software_COMPASS_version_dset = metadata_grp.create_dataset("source_data_software_COMPASS_version",
-                                                                                data=np.bytes_("0.5.5"))
-        source_data_software_ISCE3_version_dset = metadata_grp.create_dataset("source_data_software_ISCE3_version",
-                                                                              data=np.bytes_("0.15.1"))
-        source_data_software_s1_reader_version_dset = metadata_grp.create_dataset(
-            "source_data_software_s1_reader_version", data=np.bytes_("0.2.4"))
+
+        if not omit_cslc_measured_parameters:
+            platform_id_dset = metadata_grp.create_dataset("platform_id", data=np.bytes_("S1A"))
+            slant_range_mid_swath_dset = metadata_grp.create_dataset("slant_range_mid_swath", data=875720.2393261964,
+                                                                     dtype="float64")
+            source_data_software_COMPASS_version_dset = metadata_grp.create_dataset(
+                "source_data_software_COMPASS_version",
+                data=np.bytes_("0.5.5")
+            )
+            source_data_software_ISCE3_version_dset = metadata_grp.create_dataset("source_data_software_ISCE3_version",
+                                                                                  data=np.bytes_("0.15.1"))
+            source_data_software_s1_reader_version_dset = metadata_grp.create_dataset(
+                "source_data_software_s1_reader_version", data=np.bytes_("0.2.4"))


### PR DESCRIPTION
## Description
- Add new option `optional` to MPC to instruct PGE to log warning if a parameter is missing. Currently only applicable to DISP-S1, CLSC-S1 and RTC-S1 with MPC configured for DISP-S1 parameters that are copied from the source CSLC

## Affected Issues
- Fixes #567 

## Testing
- Added unit test