### PR TITLE
DISP-S1 ISO XML patches

### DIFF
--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -646,6 +646,7 @@ class CslcS1PostProcessorMixin(PostProcessorMixin):
             while len(key_path) > 0:
                 try:
                     mp = mp[key_path.pop(0)]
+                    new_measured_parameters[parameter_var_name] = mp
                 except KeyError as e:
                     msg = (f'Measured parameters configuration contains a path {parameter_var_name} that is missing '
                            f'from the output product')
@@ -653,8 +654,6 @@ class CslcS1PostProcessorMixin(PostProcessorMixin):
                         self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)
                     else:
                         self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
-
-            new_measured_parameters[parameter_var_name] = mp
 
         augmented_parameters = super().augment_measured_parameters(new_measured_parameters)
 

--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -642,18 +642,22 @@ class CslcS1PostProcessorMixin(PostProcessorMixin):
             key_path = parameter_var_name.split(MEASURED_PARAMETER_PATH_SEPARATOR)
 
             mp = measured_parameters
+            missing = False
 
             while len(key_path) > 0:
                 try:
                     mp = mp[key_path.pop(0)]
-                    new_measured_parameters[parameter_var_name] = mp
-                except KeyError as e:
+                except KeyError:
                     msg = (f'Measured parameters configuration contains a path {parameter_var_name} that is missing '
                            f'from the output product')
                     if descriptions[parameter_var_name].get('optional', False):
                         self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)
+                        missing = True
                     else:
                         self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
+
+            if not missing:
+                new_measured_parameters[parameter_var_name] = mp
 
         augmented_parameters = super().augment_measured_parameters(new_measured_parameters)
 

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -630,18 +630,22 @@ class DispS1PostProcessorMixin(PostProcessorMixin):
             key_path = parameter_var_name.split(MEASURED_PARAMETER_PATH_SEPARATOR)
 
             mp = measured_parameters
+            missing = False
 
             while len(key_path) > 0:
                 try:
                     mp = mp[key_path.pop(0)]
-                    new_measured_parameters[parameter_var_name] = mp
                 except KeyError:
                     msg = (f'Measured parameters configuration contains a path {parameter_var_name} that is missing '
                            f'from the output product')
                     if descriptions[parameter_var_name].get('optional', False):
                         self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)
+                        missing = True
                     else:
                         self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
+
+            if not missing:
+                new_measured_parameters[parameter_var_name] = mp
 
         augmented_parameters = super().augment_measured_parameters(new_measured_parameters)
 

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -634,6 +634,7 @@ class DispS1PostProcessorMixin(PostProcessorMixin):
             while len(key_path) > 0:
                 try:
                     mp = mp[key_path.pop(0)]
+                    new_measured_parameters[parameter_var_name] = mp
                 except KeyError:
                     msg = (f'Measured parameters configuration contains a path {parameter_var_name} that is missing '
                            f'from the output product')
@@ -641,8 +642,6 @@ class DispS1PostProcessorMixin(PostProcessorMixin):
                         self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)
                     else:
                         self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
-
-            new_measured_parameters[parameter_var_name] = mp
 
         augmented_parameters = super().augment_measured_parameters(new_measured_parameters)
 

--- a/src/opera/pge/disp_s1/templates/OPERA_ISO_metadata_L3_DISP_S1_template.xml.jinja2
+++ b/src/opera/pge/disp_s1/templates/OPERA_ISO_metadata_L3_DISP_S1_template.xml.jinja2
@@ -706,17 +706,6 @@
                     </gmd:source>
                     {%- endfor %}
                     {%- endif %}
-                    {%- if run_config.Groups.PGE.DynamicAncillaryFilesGroup.AncillaryFileMap.troposphere_files is not none %}
-                    {%- for troposphere_file in run_config.Groups.PGE.DynamicAncillaryFilesGroup.AncillaryFileMap.troposphere_files %}
-                    <gmd:source>
-                        <gmd:LI_Source>
-                            <gmd:description>
-                                <gco:CharacterString>Troposphere Model - {{ troposphere_file }}{# ISO_OPERA_troposphereFile #}</gco:CharacterString>
-                            </gmd:description>
-                        </gmd:LI_Source>
-                    </gmd:source>
-                    {%- endfor %}
-                    {%- endif %}
                 </gmd:LI_Lineage>
             </gmd:lineage>
         </gmd:DQ_DataQuality>

--- a/src/opera/pge/disp_s1/templates/disp_s1_measured_parameters.yaml
+++ b/src/opera/pge/disp_s1/templates/disp_s1_measured_parameters.yaml
@@ -91,6 +91,7 @@ identification/source_data_access:
   attribute_type: contentInformation
   description: Source data access information
   display_name: SourceDataAccess
+  escape_html: true
 identification/source_data_x_spacing:
   attribute_data_type: int
   attribute_type: contentInformation
@@ -156,6 +157,7 @@ identification/static_layers_data_access:
   attribute_type: processingInformation
   description: Location of the static layers product associated with this product (URL or DOI).
   display_name: StaticLayersDataAccess
+  escape_html: true
 identification/radar_band:
   attribute_data_type: string
   attribute_type: instrumentInformation
@@ -191,6 +193,7 @@ identification/product_data_access:
   attribute_type: processingInformation
   description: The metadata identifies the location from where the source data can be retrieved, expressed as a URL or DOI.
   display_name: ProductDataAccess
+  escape_html: true
 identification/radar_center_frequency:
   attribute_data_type: float
   attribute_type: instrumentInformation

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -737,18 +737,22 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
             key_path = parameter_var_name.split(MEASURED_PARAMETER_PATH_SEPARATOR)
 
             mp = measured_parameters
+            missing = False
 
             while len(key_path) > 0:
                 try:
                     mp = mp[key_path.pop(0)]
-                    new_measured_parameters[parameter_var_name] = mp
-                except KeyError as err:
+                except KeyError:
                     msg = (f'Measured parameters configuration contains a path {parameter_var_name} that is missing '
                            f'from the output product')
                     if descriptions[parameter_var_name].get('optional', False):
                         self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)
+                        missing = True
                     else:
                         self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
+
+            if not missing:
+                new_measured_parameters[parameter_var_name] = mp
 
         augmented_parameters = super().augment_measured_parameters(new_measured_parameters)
 


### PR DESCRIPTION
## Description
- Escape some measured parameter values
- Fix bug with missing MPs not being skipped properly
  - Also fixed in CSLC-S1; fix was already present in RTC-S1
- Removed obsolete reference to troposphere files from template

## Affected Issues
- #571 

## Testing
- Ran integration test on dev-pge and inspected ISO XML file and PGE log file
