### PR TITLE
DSWx-HLS Sentinel 2-C/D Support

### DIFF
--- a/src/opera/pge/dswx_hls/dswx_hls_pge.py
+++ b/src/opera/pge/dswx_hls/dswx_hls_pge.py
@@ -112,6 +112,7 @@ class DSWxHLSPreProcessorMixin(PreProcessorMixin):
 
         # Get a list of input files to check for invalid platform metadata
         list_of_input_tifs = []
+
         for input_file in self.runconfig.input_files:
             input_file_path = abspath(input_file)
             if isdir(input_file_path):
@@ -120,7 +121,6 @@ class DSWxHLSPreProcessorMixin(PreProcessorMixin):
                 list_of_input_tifs.append(input_file_path)
 
         for input_tif in list_of_input_tifs:
-
             if re.match(r"^HLS\.L30.*", os.path.basename(input_tif)):
                 input_tif_metadata = get_geotiff_metadata(input_tif)
                 if 'LANDSAT_PRODUCT_ID' in input_tif_metadata:
@@ -133,10 +133,12 @@ class DSWxHLSPreProcessorMixin(PreProcessorMixin):
             if re.match(r"^HLS\.S30.*", os.path.basename(input_tif)):
                 input_tif_metadata = get_geotiff_metadata(input_tif)
                 if 'PRODUCT_URI' in input_tif_metadata:
-                    data_is_S2A = re.match(r"S2A.*", input_tif_metadata['PRODUCT_URI'])
-                    data_is_S2B = re.match(r"S2B.*", input_tif_metadata['PRODUCT_URI'])
-                    if not data_is_S2A and not data_is_S2B:
-                        error_msg = (f"Input file {input_tif} appears to not be Sentinel 2 A/B data, "
+                    # For DSWx-HLS, we only want inputs from Sentinel 2-A/B/C/D
+                    valid_s30_product_types = ("S2A", "S2B", "S2C", "S2D")
+
+                    if not any(re.match(rf"{valid_s30_product_type}.*", input_tif_metadata['PRODUCT_URI'])
+                               for valid_s30_product_type in valid_s30_product_types):
+                        error_msg = (f"Input file {input_tif} appears to not be a supported Sentinel 2 data type, "
                                      f"metadata PRODUCT_URI is {input_tif_metadata['PRODUCT_URI']}.")
                         self.logger.critical(self.name, ErrorCode.INVALID_INPUT, error_msg)
 

--- a/src/opera/test/pge/dswx_hls/test_dswx_hls_pge.py
+++ b/src/opera/test/pge/dswx_hls/test_dswx_hls_pge.py
@@ -449,8 +449,8 @@ class DSWxHLSPgeTestCase(unittest.TestCase):
             """Custom Open method for Sentinel testing"""
             gdal_dataset = MockGdal.MockDSWxHLSGdalDataset()
 
-            # S2C is invalid
-            gdal_dataset.dummy_metadata['PRODUCT_URI'] = "S2C_MSIL1C_20210907T163901_N0301_" \
+            # S1C is invalid
+            gdal_dataset.dummy_metadata['PRODUCT_URI'] = "S1C_MSIL1C_20210907T163901_N0301_" \
                                                          "R126_T15SXR_20210907T202434.SAFE"
             return gdal_dataset
 
@@ -561,7 +561,7 @@ class DSWxHLSPgeTestCase(unittest.TestCase):
 
     @patch.object(opera.util.tiff_utils, "gdal", CustomMockGdal_InvalidSentinel)
     def test_dswx_hls_validate_expected_input_platforms_sentinel(self):
-        """Test exceptions raised for non-Sentinel S2A/B input data"""
+        """Test exceptions raised for non-Sentinel S2 A/B/C/D input data"""
         # Create a filename that will trigger a metadata check
         input_file = os.path.join(self.input_dir, "HLS.S30.T15SXR.2021250T163901.v2.0.SAA.tif")
         os.system(f"touch {input_file}")
@@ -581,8 +581,8 @@ class DSWxHLSPgeTestCase(unittest.TestCase):
 
         # Look for the expected exception message in the log to verify the correct exception was raised.
         # There is a temporary file name in the path, so we only look for the static part.
-        expected_msg = (f"_temp/{input_file} appears to not be Sentinel 2 A/B data, "
-                        f"metadata PRODUCT_URI is S2C_MSIL1C_20210907T163901_N0301_R126_T15SXR_20210907T202434.SAFE.")
+        expected_msg = (f"_temp/{input_file} appears to not be a supported Sentinel 2 data type, "
+                        f"metadata PRODUCT_URI is S1C_MSIL1C_20210907T163901_N0301_R126_T15SXR_20210907T202434.SAFE.")
         self.assertIn(expected_msg, log_contents)
 
     @patch.object(opera.util.tiff_utils, "gdal", CustomMockGdal)

--- a/src/opera/util/dataset_utils.py
+++ b/src/opera/util/dataset_utils.py
@@ -100,7 +100,9 @@ def get_sensor_from_spacecraft_name(spacecraft_name):
             'SENTINEL-1A': 'S1A',
             'SENTINEL-1B': 'S1B',
             'SENTINEL-2A': 'S2A',
-            'SENTINEL-2B': 'S2B'
+            'SENTINEL-2B': 'S2B',
+            'SENTINEL-2C': 'S2C',
+            'SENTINEL-2D': 'S2D'
         }[spacecraft_name.upper()]
     except KeyError:
         raise RuntimeError(f"Unknown spacecraft name '{spacecraft_name}'")


### PR DESCRIPTION
## Description
- This branch adds support for utilizing HLS inputs based on Sentinel 2C (and eventually 2D) acquisitions in the DSWx-HLS PGE.

## Affected Issues
- Resolves #569 

## Testing
- Unit tests for DSWx-HLS updated where necessary
- DSWx-HLS PGE integration test passes
- Ran image based on this branch using the HLS granule `HLS.S30.T42UVG.2025022T065231.v2.0`, which was shown to be based on Sentinel-2C from a job failure in PCM.
