### PR TITLE
Refactor Measured Parameters Augmentation Functions

### DIFF
--- a/src/opera/pge/base/base_pge.py
+++ b/src/opera/pge/base/base_pge.py
@@ -643,65 +643,6 @@ class PostProcessorMixin:
             # Log stream might be closed by this point so raise an Exception instead
             raise RuntimeError(msg)
 
-    def augment_measured_parameters(self, measured_parameters):
-        """
-        Augment the measured parameters dict into a dict of dicts containing the needed
-        fields for the MeasuredParameters section of the ISO XML file.
-
-        Parameters
-        ----------
-        measured_parameters : dict
-            The GeoTIFF metadata from the output product. See get_geotiff_metadata()
-
-        Returns
-        -------
-        augmented_parameters : dict
-            The metadata fields converted to a list with name, value, types, etc
-        """
-        augmented_parameters = dict()
-
-        descriptions_file = self.runconfig.iso_measured_parameter_descriptions
-
-        if descriptions_file is not None:
-            with open(descriptions_file) as f:
-                descriptions = yaml.safe_load(f)
-
-            missing_description_value = UNDEFINED_ERROR
-        else:
-            descriptions = dict()
-            missing_description_value = UNDEFINED_WARNING
-
-        for name, value in measured_parameters.items():
-            if isinstance(value, np.generic):
-                value = value.item()
-
-            if isinstance(value, np.ndarray):
-                value = value.tolist()
-
-            if isinstance(value, (list, dict)):
-                value = json.dumps(value, cls=NumpyEncoder)
-
-            guessed_data_type = python_type_to_xml_type(value)
-            guessed_attr_name = guess_attribute_display_name(name)
-
-            descriptions.setdefault(name, dict())
-
-            attr_description = descriptions[name].get('description', missing_description_value)
-            data_type = descriptions[name].get('attribute_data_type', guessed_data_type)
-            attr_type = descriptions[name].get('attribute_type', UNDEFINED_ERROR)
-            attr_name = descriptions[name].get('display_name', guessed_attr_name)
-            escape_html = descriptions[name].get('escape_html', False)
-
-            if escape_html:
-                value = html.escape(value)
-
-            augmented_parameters[name] = (
-                dict(name=attr_name, value=value, attr_type=attr_type,
-                     attr_description=attr_description, data_type=data_type)
-            )
-
-        return augmented_parameters
-
     def run_postprocessor(self, **kwargs):  # pylint: disable=unused-argument
         """
         Executes the post-processing steps for PGE job completion.

--- a/src/opera/pge/base/base_pge.py
+++ b/src/opera/pge/base/base_pge.py
@@ -9,16 +9,12 @@ Module defining the Base PGE interfaces from which all other PGEs are derived.
 
 """
 
-import html
-import json
 import os
 from collections import OrderedDict
 from datetime import datetime
 from fnmatch import fnmatch
 from functools import lru_cache
 from os.path import abspath, basename, exists, join, splitext
-
-import numpy as np
 
 from pkg_resources import resource_filename
 
@@ -32,11 +28,6 @@ from opera.util.error_codes import ErrorCode
 from opera.util.logger import PgeLogger
 from opera.util.logger import default_log_file_name
 from opera.util.metfile import MetFile
-from opera.util.render_jinja2 import (python_type_to_xml_type,
-                                      guess_attribute_display_name,
-                                      NumpyEncoder,
-                                      UNDEFINED_ERROR,
-                                      UNDEFINED_WARNING)
 from opera.util.run_utils import create_qa_command_line
 from opera.util.run_utils import create_sas_command_line
 from opera.util.run_utils import get_checksum

--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -16,14 +16,12 @@ from os import walk
 from os.path import getsize, join
 from pathlib import Path
 
-import yaml
-
 from opera.pge.base.base_pge import PgeExecutor
 from opera.pge.base.base_pge import PostProcessorMixin
 from opera.pge.base.base_pge import PreProcessorMixin
 from opera.util.dataset_utils import parse_bounding_polygon_from_wkt
 from opera.util.error_codes import ErrorCode
-from opera.util.h5_utils import get_cslc_s1_product_metadata, MEASURED_PARAMETER_PATH_SEPARATOR
+from opera.util.h5_utils import get_cslc_s1_product_metadata
 from opera.util.input_validation import validate_slc_s1_inputs
 from opera.util.render_jinja2 import augment_hd5_measured_parameters, render_jinja2
 from opera.util.time import get_time_for_filename

--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -23,7 +23,7 @@ from opera.util.dataset_utils import parse_bounding_polygon_from_wkt
 from opera.util.error_codes import ErrorCode
 from opera.util.h5_utils import get_cslc_s1_product_metadata
 from opera.util.input_validation import validate_slc_s1_inputs
-from opera.util.render_jinja2 import augment_hd5_measured_parameters, render_jinja2
+from opera.util.render_jinja2 import augment_hdf5_measured_parameters, render_jinja2
 from opera.util.time import get_time_for_filename
 
 
@@ -622,7 +622,7 @@ class CslcS1PostProcessorMixin(PostProcessorMixin):
         # Extract all metadata assigned by the SAS at product creation time
         try:
             output_product_metadata = get_cslc_s1_product_metadata(cslc_product)
-            output_product_metadata['MeasuredParameters'] = augment_hd5_measured_parameters(
+            output_product_metadata['MeasuredParameters'] = augment_hdf5_measured_parameters(
                 output_product_metadata,
                 self.runconfig.iso_measured_parameter_descriptions,
                 self.logger

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -26,7 +26,7 @@ from opera.util.error_codes import ErrorCode
 from opera.util.h5_utils import get_cslc_s1_product_metadata
 from opera.util.h5_utils import get_disp_s1_product_metadata
 from opera.util.input_validation import validate_algorithm_parameters_config, validate_disp_inputs
-from opera.util.render_jinja2 import augment_hd5_measured_parameters, render_jinja2
+from opera.util.render_jinja2 import augment_hdf5_measured_parameters, render_jinja2
 from opera.util.time import get_time_for_filename, get_catalog_metadata_datetime_str
 
 
@@ -621,7 +621,7 @@ class DispS1PostProcessorMixin(PostProcessorMixin):
                 'ProcessingDateTime': get_catalog_metadata_datetime_str(self.production_datetime)
             }
 
-            output_product_metadata['MeasuredParameters'] = augment_hd5_measured_parameters(
+            output_product_metadata['MeasuredParameters'] = augment_hdf5_measured_parameters(
                 output_product_metadata,
                 self.runconfig.iso_measured_parameter_descriptions,
                 self.logger

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -28,7 +28,7 @@ from opera.util.h5_utils import get_cslc_s1_product_metadata
 from opera.util.h5_utils import get_disp_s1_product_metadata
 from opera.util.h5_utils import MEASURED_PARAMETER_PATH_SEPARATOR
 from opera.util.input_validation import validate_algorithm_parameters_config, validate_disp_inputs
-from opera.util.render_jinja2 import render_jinja2
+from opera.util.render_jinja2 import augment_hd5_measured_parameters, render_jinja2
 from opera.util.time import get_time_for_filename, get_catalog_metadata_datetime_str
 
 
@@ -591,66 +591,6 @@ class DispS1PostProcessorMixin(PostProcessorMixin):
         """
         return self._ancillary_filename() + ".qa.log"
 
-    def augment_measured_parameters(self, measured_parameters):
-        """
-        Override of the augment_measured_parameters() method in Base PGE with an added
-        "preprocessing" step to handle the structure of HDF5 metadata. While GeoTIFF
-        metadata is a flat dictionary, HDF5 metadata is a nested dictionary structure,
-        wherein the variable "keys" can be arbitrarily deep into the structure and
-        the values likewise can be nested dictionaries.
-
-        The preprocessing step in this method selectively flattens the metadata
-        dictionary based on the "paths" provided in the variable keys of the configuration
-        YAML file. The result of this preprocessing is then safely passed to the base
-        method to get the correct structure expected by the Jinja template.
-
-        Parameters
-        ----------
-        measured_parameters : dict
-            The HDF5 metadata from the output product. See get_disp_s1_product_metadata()
-
-        Returns
-        -------
-        augmented_parameters : dict
-            The metadata fields converted to a list with name, value, types, etc
-        """
-        descriptions_file = self.runconfig.iso_measured_parameter_descriptions
-
-        new_measured_parameters = {}
-
-        if descriptions_file:
-            with open(descriptions_file) as f:
-                descriptions = yaml.safe_load(f)
-        else:
-            msg = ('Measured parameters configuration is needed to extract the measured parameters attributes from the'
-                   'DISP-S1 metadata')
-            self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_NOT_FOUND, msg)
-
-        for parameter_var_name in descriptions:
-            key_path = parameter_var_name.split(MEASURED_PARAMETER_PATH_SEPARATOR)
-
-            mp = measured_parameters
-            missing = False
-
-            while len(key_path) > 0:
-                try:
-                    mp = mp[key_path.pop(0)]
-                except KeyError:
-                    msg = (f'Measured parameters configuration contains a path {parameter_var_name} that is missing '
-                           f'from the output product')
-                    if descriptions[parameter_var_name].get('optional', False):
-                        self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)
-                        missing = True
-                    else:
-                        self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
-
-            if not missing:
-                new_measured_parameters[parameter_var_name] = mp
-
-        augmented_parameters = super().augment_measured_parameters(new_measured_parameters)
-
-        return augmented_parameters
-
     def _collect_disp_s1_product_metadata(self, disp_product):
         """
         Gathers the available metadata from a sample output DISP-S1 product for
@@ -683,7 +623,11 @@ class DispS1PostProcessorMixin(PostProcessorMixin):
                 'ProcessingDateTime': get_catalog_metadata_datetime_str(self.production_datetime)
             }
 
-            output_product_metadata['MeasuredParameters'] = self.augment_measured_parameters(output_product_metadata)
+            output_product_metadata['MeasuredParameters'] = augment_hd5_measured_parameters(
+                output_product_metadata,
+                self.runconfig.iso_measured_parameter_descriptions,
+                self.logger
+            )
         except Exception as err:
             msg = f'Failed to extract metadata from {disp_product}, reason: {err}'
             self.logger.critical(self.name, ErrorCode.ISO_METADATA_COULD_NOT_EXTRACT_METADATA, msg)

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -18,7 +18,6 @@ from collections import OrderedDict
 from os import listdir
 from os.path import abspath, basename, exists, getsize, join, splitext
 
-import yaml
 from opera.pge.base.base_pge import PgeExecutor
 from opera.pge.base.base_pge import PostProcessorMixin
 from opera.pge.base.base_pge import PreProcessorMixin
@@ -26,7 +25,6 @@ from opera.util.dataset_utils import parse_bounding_polygon_from_wkt
 from opera.util.error_codes import ErrorCode
 from opera.util.h5_utils import get_cslc_s1_product_metadata
 from opera.util.h5_utils import get_disp_s1_product_metadata
-from opera.util.h5_utils import MEASURED_PARAMETER_PATH_SEPARATOR
 from opera.util.input_validation import validate_algorithm_parameters_config, validate_disp_inputs
 from opera.util.render_jinja2 import augment_hd5_measured_parameters, render_jinja2
 from opera.util.time import get_time_for_filename, get_catalog_metadata_datetime_str

--- a/src/opera/pge/dswx_hls/dswx_hls_pge.py
+++ b/src/opera/pge/dswx_hls/dswx_hls_pge.py
@@ -25,7 +25,7 @@ from opera.util.dataset_utils import get_sensor_from_spacecraft_name
 from opera.util.error_codes import ErrorCode
 from opera.util.geo_utils import get_geographic_boundaries_from_mgrs_tile
 from opera.util.input_validation import validate_dswx_inputs
-from opera.util.render_jinja2 import render_jinja2
+from opera.util.render_jinja2 import augment_measured_parameters, render_jinja2
 from opera.util.tiff_utils import get_geotiff_hls_dataset
 from opera.util.tiff_utils import get_geotiff_hls_sensor_product_id
 from opera.util.tiff_utils import get_geotiff_metadata
@@ -433,7 +433,11 @@ class DSWxHLSPostProcessorMixin(PostProcessorMixin):
         # Extract all metadata assigned by the SAS at product creation time
         try:
             measured_parameters = get_geotiff_metadata(representative_product)
-            output_product_metadata['MeasuredParameters'] = self.augment_measured_parameters(measured_parameters)
+            output_product_metadata['MeasuredParameters'] = augment_measured_parameters(
+                measured_parameters,
+                self.runconfig.iso_measured_parameter_descriptions,
+                self.logger
+            )
         except Exception as err:
             msg = f'Failed to extract metadata from {representative_product}, reason: {err}'
             self.logger.critical(self.name, ErrorCode.ISO_METADATA_COULD_NOT_EXTRACT_METADATA, msg)

--- a/src/opera/pge/dswx_s1/dswx_s1_pge.py
+++ b/src/opera/pge/dswx_s1/dswx_s1_pge.py
@@ -22,7 +22,7 @@ from opera.util.error_codes import ErrorCode
 from opera.util.geo_utils import get_geographic_boundaries_from_mgrs_tile
 from opera.util.input_validation import validate_algorithm_parameters_config
 from opera.util.input_validation import validate_dswx_inputs
-from opera.util.render_jinja2 import render_jinja2
+from opera.util.render_jinja2 import augment_measured_parameters, render_jinja2
 from opera.util.run_utils import get_checksum
 from opera.util.tiff_utils import get_geotiff_metadata
 from opera.util.time import get_time_for_filename
@@ -445,7 +445,11 @@ class DSWxS1PostProcessorMixin(PostProcessorMixin):
         # Extract all metadata assigned by the SAS at product creation time
         try:
             measured_parameters = get_geotiff_metadata(geotiff_product)
-            output_product_metadata['MeasuredParameters'] = self.augment_measured_parameters(measured_parameters)
+            output_product_metadata['MeasuredParameters'] = augment_measured_parameters(
+                measured_parameters,
+                self.runconfig.iso_measured_parameter_descriptions,
+                self.logger
+            )
         except Exception as err:
             msg = f'Failed to extract metadata from {geotiff_product}, reason: {err}'
             self.logger.critical(self.name, ErrorCode.ISO_METADATA_COULD_NOT_EXTRACT_METADATA, msg)

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -15,8 +15,6 @@ from datetime import datetime
 from os import walk
 from os.path import basename, getsize, join
 
-import yaml
-
 from opera.pge.base.base_pge import PgeExecutor
 from opera.pge.base.base_pge import PostProcessorMixin
 from opera.pge.base.base_pge import PreProcessorMixin
@@ -25,7 +23,6 @@ from opera.util.dataset_utils import parse_bounding_polygon_from_wkt
 from opera.util.error_codes import ErrorCode
 from opera.util.geo_utils import translate_utm_bbox_to_lat_lon
 from opera.util.h5_utils import get_rtc_s1_product_metadata
-from opera.util.h5_utils import MEASURED_PARAMETER_PATH_SEPARATOR
 from opera.util.input_validation import validate_slc_s1_inputs
 from opera.util.render_jinja2 import augment_hd5_measured_parameters, render_jinja2
 from opera.util.time import get_time_for_filename

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -24,7 +24,7 @@ from opera.util.error_codes import ErrorCode
 from opera.util.geo_utils import translate_utm_bbox_to_lat_lon
 from opera.util.h5_utils import get_rtc_s1_product_metadata
 from opera.util.input_validation import validate_slc_s1_inputs
-from opera.util.render_jinja2 import augment_hd5_measured_parameters, render_jinja2
+from opera.util.render_jinja2 import augment_hdf5_measured_parameters, render_jinja2
 from opera.util.time import get_time_for_filename
 
 
@@ -754,7 +754,7 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
                 self.logger.critical(self.name, ErrorCode.ISO_METADATA_RENDER_FAILED, str(err))
 
         # Augment the metadata with descriptions from the measured parameter config for RTC-S1
-        output_product_metadata['MeasuredParameters'] = augment_hd5_measured_parameters(
+        output_product_metadata['MeasuredParameters'] = augment_hdf5_measured_parameters(
             output_product_metadata,
             self.runconfig.iso_measured_parameter_descriptions,
             self.logger

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -27,7 +27,7 @@ from opera.util.geo_utils import translate_utm_bbox_to_lat_lon
 from opera.util.h5_utils import get_rtc_s1_product_metadata
 from opera.util.h5_utils import MEASURED_PARAMETER_PATH_SEPARATOR
 from opera.util.input_validation import validate_slc_s1_inputs
-from opera.util.render_jinja2 import render_jinja2
+from opera.util.render_jinja2 import augment_hd5_measured_parameters, render_jinja2
 from opera.util.time import get_time_for_filename
 
 
@@ -698,66 +698,6 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
         """
         return self._ancillary_filename() + ".qa.log"
 
-    def augment_measured_parameters(self, measured_parameters):
-        """
-        Override of the augment_measured_parameters() method in Base PGE with an added
-        "preprocessing" step to handle the structure of HDF5 metadata. While GeoTIFF
-        metadata is a flat dictionary, HDF5 metadata is a nested dictionary structure,
-        wherein the variable "keys" can be arbitrarily deep into the structure and
-        the values likewise can be nested dictionaries.
-
-        The preprocessing step in this method selectively flattens the metadata
-        dictionary based on the "paths" provided in the variable keys of the configuration
-        YAML file. The result of this preprocessing is then safely passed to the base
-        method to get the correct structure expected by the Jinja template.
-
-        Parameters
-        ----------
-        measured_parameters : dict
-            The HDF5 metadata from the output product. See get_rtc_s1_product_metadata()
-
-        Returns
-        -------
-        augmented_parameters : dict
-            The metadata fields converted to a list with name, value, types, etc
-        """
-        descriptions_file = self.runconfig.iso_measured_parameter_descriptions
-
-        new_measured_parameters = {}
-
-        if descriptions_file:
-            with open(descriptions_file) as infile:
-                descriptions = yaml.safe_load(infile)
-        else:
-            msg = ('Measured parameters configuration is needed to extract the '
-                   'measured parameters attributes from the RTC-S1 metadata')
-            self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_NOT_FOUND, msg)
-
-        for parameter_var_name in descriptions:
-            key_path = parameter_var_name.split(MEASURED_PARAMETER_PATH_SEPARATOR)
-
-            mp = measured_parameters
-            missing = False
-
-            while len(key_path) > 0:
-                try:
-                    mp = mp[key_path.pop(0)]
-                except KeyError:
-                    msg = (f'Measured parameters configuration contains a path {parameter_var_name} that is missing '
-                           f'from the output product')
-                    if descriptions[parameter_var_name].get('optional', False):
-                        self.logger.warning(self.name, ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)
-                        missing = True
-                    else:
-                        self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
-
-            if not missing:
-                new_measured_parameters[parameter_var_name] = mp
-
-        augmented_parameters = super().augment_measured_parameters(new_measured_parameters)
-
-        return augmented_parameters
-
     def _collect_rtc_product_metadata(self, metadata_product):
         """
         Gathers the available metadata from an HDF5 product created by
@@ -817,7 +757,11 @@ class RtcS1PostProcessorMixin(PostProcessorMixin):
                 self.logger.critical(self.name, ErrorCode.ISO_METADATA_RENDER_FAILED, str(err))
 
         # Augment the metadata with descriptions from the measured parameter config for RTC-S1
-        output_product_metadata['MeasuredParameters'] = self.augment_measured_parameters(output_product_metadata)
+        output_product_metadata['MeasuredParameters'] = augment_hd5_measured_parameters(
+            output_product_metadata,
+            self.runconfig.iso_measured_parameter_descriptions,
+            self.logger
+        )
 
         return output_product_metadata
 

--- a/src/opera/util/render_jinja2.py
+++ b/src/opera/util/render_jinja2.py
@@ -11,6 +11,7 @@ Original Author: David White
 Adapted by: Jim Hofman
 """
 
+import html
 import json
 import os
 import re
@@ -24,6 +25,7 @@ import numpy as np
 
 from lxml import etree
 from opera.util.error_codes import ErrorCode
+from opera.util.h5_utils import MEASURED_PARAMETER_PATH_SEPARATOR
 from opera.util.logger import PgeLogger
 
 XML_TYPES = {
@@ -202,6 +204,134 @@ def python_type_to_xml_type(obj) -> str:
     return XML_TYPES[obj]
 
 
+def augment_measured_parameters(measured_parameters: dict, mpc_path: str, logger: PgeLogger) -> dict:
+    """
+    Augment the measured parameters dict of GeoTIFF metadata into a dict of dicts
+    containing the needed fields for the MeasuredParameters section of the ISO XML
+    file.
+
+    For HDF5 or NetCDF metadata, use augment_hd5_measured_parameters()
+
+    Parameters
+    ----------
+    measured_parameters : dict
+       The GeoTIFF metadata from the output product. See get_geotiff_metadata()
+    mpc_path: str
+        Path to the Measured Parameters Descriptions YAML file
+    logger: PgeLogger
+        PgeLogger instance
+
+    Returns
+    -------
+    augmented_parameters : dict
+       The metadata fields converted to a list with name, value, types, etc
+    """
+    augmented_parameters = dict()
+
+    if mpc_path is not None:
+        with open(mpc_path) as f:
+            descriptions = yaml.safe_load(f)
+
+        missing_description_value = UNDEFINED_ERROR
+    else:
+        descriptions = dict()
+        missing_description_value = UNDEFINED_WARNING
+
+    for name, value in measured_parameters.items():
+        if isinstance(value, np.generic):
+            value = value.item()
+
+        if isinstance(value, np.ndarray):
+            value = value.tolist()
+
+        if isinstance(value, (list, dict)):
+            value = json.dumps(value, cls=NumpyEncoder)
+
+        guessed_data_type = python_type_to_xml_type(value)
+        guessed_attr_name = guess_attribute_display_name(name)
+
+        descriptions.setdefault(name, dict())
+
+        attr_description = descriptions[name].get('description', missing_description_value)
+        data_type = descriptions[name].get('attribute_data_type', guessed_data_type)
+        attr_type = descriptions[name].get('attribute_type', UNDEFINED_ERROR)
+        attr_name = descriptions[name].get('display_name', guessed_attr_name)
+        escape_html = descriptions[name].get('escape_html', False)
+
+        if escape_html:
+            value = html.escape(value)
+
+        augmented_parameters[name] = (
+            dict(name=attr_name, value=value, attr_type=attr_type,
+                 attr_description=attr_description, data_type=data_type)
+        )
+
+    return augmented_parameters
+
+
+def augment_hd5_measured_parameters(measured_parameters: dict, mpc_path: str, logger: PgeLogger) -> dict:
+    """
+    The augment_measured_parameters() function wrapped in a "preprocessing" step to
+    handle the structure of HDF5 metadata. While GeoTIFF metadata is a flat
+    dictionary, HDF5 metadata is a nested dictionary structure, wherein the variable
+    "keys" can be arbitrarily deep into the structure and the values likewise can be
+    nested dictionaries.
+
+    The preprocessing step in this method selectively flattens the metadata
+    dictionary based on the "paths" provided in the variable keys of the configuration
+    YAML file. The result of this preprocessing is then safely passed to the base
+    method to get the correct structure expected by the Jinja template.
+
+    Parameters
+    ----------
+    measured_parameters : dict
+        The HDF5 metadata from the output product. See get_cslc_s1_product_metadata()
+    mpc_path: str
+        Path to the Measured Parameters Descriptions YAML file
+    logger: PgeLogger
+        PgeLogger instance
+
+    Returns
+    -------
+    augmented_parameters : dict
+        The metadata fields converted to a list with name, value, types, etc
+    """
+    new_measured_parameters = {}
+
+    if mpc_path:
+        with open(mpc_path) as f:
+            descriptions = yaml.safe_load(f)
+    else:
+        msg = ('Measured parameters configuration is needed to extract the measured parameters attributes from the '
+               'metadata')
+        logger.critical("render_jinja2", ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_NOT_FOUND, msg)
+
+    for parameter_var_name in descriptions:
+        key_path = parameter_var_name.split(MEASURED_PARAMETER_PATH_SEPARATOR)
+
+        mp = measured_parameters
+        missing = False
+
+        while len(key_path) > 0:
+            try:
+                mp = mp[key_path.pop(0)]
+            except KeyError:
+                msg = (f'Measured parameters configuration contains a path {parameter_var_name} that is missing '
+                       f'from the output product')
+                if descriptions[parameter_var_name].get('optional', False):
+                    logger.warning("render_jinja2", ErrorCode.ISO_METADATA_NO_ENTRY_FOR_DESCRIPTION, msg)
+                    missing = True
+                else:
+                    logger.critical("render_jinja2", ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_INVALID, msg)
+
+        if not missing:
+            new_measured_parameters[parameter_var_name] = mp
+
+    augmented_parameters = augment_measured_parameters(new_measured_parameters, mpc_path, logger)
+
+    return augmented_parameters
+
+
 class NumpyEncoder(json.JSONEncoder):
     """Class to handle serialization of Numpy types during JSON enconding"""
     def default(self, obj):
@@ -214,6 +344,7 @@ class NumpyEncoder(json.JSONEncoder):
         if isinstance(obj, np.bool_):
             return bool(obj)
         return super(NumpyEncoder, self).default(obj)
+
 
 def guess_attribute_display_name(var_name: str) -> str:
     """

--- a/src/opera/util/render_jinja2.py
+++ b/src/opera/util/render_jinja2.py
@@ -269,7 +269,7 @@ def augment_measured_parameters(measured_parameters: dict, mpc_path: str, logger
     return augmented_parameters
 
 
-def augment_hd5_measured_parameters(measured_parameters: dict, mpc_path: str, logger: PgeLogger) -> dict:
+def augment_hdf5_measured_parameters(measured_parameters: dict, mpc_path: str, logger: PgeLogger) -> dict:
     """
     The augment_measured_parameters() function wrapped in a "preprocessing" step to
     handle the structure of HDF5 metadata. While GeoTIFF metadata is a flat

--- a/src/opera/util/render_jinja2.py
+++ b/src/opera/util/render_jinja2.py
@@ -327,9 +327,7 @@ def augment_hd5_measured_parameters(measured_parameters: dict, mpc_path: str, lo
         if not missing:
             new_measured_parameters[parameter_var_name] = mp
 
-    augmented_parameters = augment_measured_parameters(new_measured_parameters, mpc_path, logger)
-
-    return augmented_parameters
+    return augment_measured_parameters(new_measured_parameters, mpc_path, logger)
 
 
 class NumpyEncoder(json.JSONEncoder):


### PR DESCRIPTION
## Description
- Move the base implementation of `augment_measured_parameters` and its specialized overrides in CSLC-S1, RTC-S1 and DISP-S1 into the `opera.util.render_jinja2` module

## Affected Issues
- Resolves #579 

## Testing
- Verified unit tests still pass (local)
- Ran int tests on opera-dev-pge for PGEs using `augment_measured_parameters` (DSWx-HLS) and `augment_hd5_measured_parameters` (CSLC-S1) with images built off the main branch and this PR and diff'd an iso XML for a sample product from each to validate no significant changes/regressions in template filling occurred
- Some more PGE int tests to check nothing else broke (Particularly RTC-S1, DISP-S1 and DSWx-NI)
