### PR TITLE
DIST-S1 Ancillary Filenames Postprocessor

### DIFF
--- a/src/opera/pge/dist_s1/dist_s1_pge.py
+++ b/src/opera/pge/dist_s1/dist_s1_pge.py
@@ -141,7 +141,7 @@ class DistS1PostProcessorMixin(PostProcessorMixin):
         ancillary products associated to a PGE job (catalog metadata, log file,
         etc...).
 
-        The core file name component for DSWx-S1 ancillary products consists of:
+        The core file name component for DIST-S1 ancillary products consists of:
 
         <PROJECT>_<LEVEL>_<PGE NAME>_<PROD TIMETAG>_<SENSOR>_<SPACING>_<PRODUCT VERSION>
 
@@ -184,9 +184,9 @@ class DistS1PostProcessorMixin(PostProcessorMixin):
 
     def _catalog_metadata_filename(self):
         """
-        Returns the file name to use for Catalog Metadata produced by the DSWx-S1 PGE.
+        Returns the file name to use for Catalog Metadata produced by the DIST-S1 PGE.
 
-        The Catalog Metadata file name for the DSWx-S1 PGE consists of:
+        The Catalog Metadata file name for the DIST-S1 PGE consists of:
 
             <Ancillary filename>.catalog.json
 
@@ -202,9 +202,9 @@ class DistS1PostProcessorMixin(PostProcessorMixin):
 
     def _log_filename(self):
         """
-        Returns the file name to use for the PGE/SAS log file produced by the DSWx-S1 PGE.
+        Returns the file name to use for the PGE/SAS log file produced by the DIST-S1 PGE.
 
-        The log file name for the DSWx-S1 PGE consists of:
+        The log file name for the DIST-S1 PGE consists of:
 
             <Ancillary filename>.log
 
@@ -221,9 +221,9 @@ class DistS1PostProcessorMixin(PostProcessorMixin):
     def _qa_log_filename(self):
         """
         Returns the file name to use for the Quality Assurance application log
-        file produced by the DSWx-S1 PGE.
+        file produced by the DIST-S1 PGE.
 
-        The log file name for the DSWx-S1 PGE consists of:
+        The log file name for the DIST-S1 PGE consists of:
 
             <Ancillary filename>.qa.log
 

--- a/src/opera/pge/dist_s1/dist_s1_pge.py
+++ b/src/opera/pge/dist_s1/dist_s1_pge.py
@@ -159,14 +159,16 @@ class DistS1PostProcessorMixin(PostProcessorMixin):
             The file name component to assign to ancillary products created by this PGE.
         """
 
-        #TODO: Get this from metadata
+        # TODO: Get this from metadata
         spacecraft_name = "SENTINEL-1A"
         sensor = get_sensor_from_spacecraft_name(spacecraft_name)
         pixel_spacing = "30"
 
-        #TODO: See above
+        # TODO - for now, use the PGE production time, but ideally this should
+        #        eventually match the production time assigned by the SAS, which
+        #        should be present in the product metadata
         processing_time = get_time_for_filename(
-            datetime.utcnow()
+            self.production_datetime
         )
 
         if not processing_time.endswith('Z'):
@@ -236,6 +238,36 @@ class DistS1PostProcessorMixin(PostProcessorMixin):
 
         """
         return self._ancillary_filename() + ".qa.log"
+
+    # TODO: Figure out how we want to approach this
+    # def _iso_metadata_filename(self, tile_id):
+    #     """
+    #     Returns the file name to use for ISO Metadata produced by the DIST-S1 PGE.
+    #
+    #     The ISO Metadata file name for the DIST-S1 PGE consists of:
+    #
+    #         <DIST-S1 filename>.iso.xml
+    #
+    #     Where <DIST-S1 filename> is returned by DistS1PostProcessorMixin. [TODO: put proper method here]
+    #
+    #     Parameters
+    #     ----------
+    #     tile_id : str
+    #         The MGRS tile identifier used to look up the corresponding cached
+    #         DIST-S1 file name.
+    #
+    #     Returns
+    #     -------
+    #     <iso metadata filename> : str
+    #         The file name to assign to the ISO Metadata product created by this PGE.
+    #
+    #     """
+    #     if tile_id not in self._tile_filename_cache:
+    #         raise RuntimeError(f"No file name cached for tile ID {tile_id}")
+    #
+    #     iso_metadata_filename = self._tile_filename_cache[tile_id]
+    #
+    #     return iso_metadata_filename + ".iso.xml"
 
     def run_postprocessor(self, **kwargs):
         """

--- a/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
+++ b/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
@@ -160,6 +160,21 @@ class DistS1PgeTestCase(unittest.TestCase):
         expected_sas_config_file = join(pge.runconfig.scratch_path, 'test_dist_s1_config_sas.yaml')
         self.assertTrue(os.path.exists(expected_sas_config_file))
 
+        # Check that the catalog metadata file was created in the output directory
+        expected_catalog_metadata_file = join(
+            pge.runconfig.output_product_path, pge._catalog_metadata_filename())
+        self.assertTrue(os.path.exists(expected_catalog_metadata_file))
+
+        # # Check that the ISO metadata file was created and filled in as expected
+        # expected_iso_metadata_file = join(
+        #     pge.runconfig.output_product_path, pge._iso_metadata_filename(tile_id='T10SGD'))
+        # self.assertTrue(os.path.exists(expected_iso_metadata_file))
+        #
+        # with open(expected_iso_metadata_file, 'r', encoding='utf-8') as infile:
+        #     iso_contents = infile.read()
+        #
+        # self.assertNotIn(UNDEFINED_ERROR, iso_contents)
+
         # Check that the log file was created and moved into the output directory
         expected_log_file = pge.logger.get_file_name()
         self.assertTrue(os.path.exists(expected_log_file))


### PR DESCRIPTION
## Description
- Added methods to DIST-S1 Postprocessor to supply DIST-S1 ancillary core filename, catalog metadata JSON filename, PGE log filename and QA log filename
- Also added commented out stub implementation for the ISO XML filename - commented out since we have unresolved questions about the output product

## Affected Issues
- Resolves #580 

## Testing
- Unit tests still pass 
  - On fcf853c, seeing issue with catalog metadata not populated with output products - not sure if expected at the present
