### PR TITLE
Fix for stale references in DISP-S1 ISO XML

### DIFF
--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -618,7 +618,9 @@ class DispS1PostProcessorMixin(PostProcessorMixin):
                 'ProductLevel': 3,
                 'ProductType': 'DISP-S1',
                 'ProductSource': 'Sentinel-1',
-                'ProcessingDateTime': get_catalog_metadata_datetime_str(self.production_datetime)
+                'ProcessingDateTime': get_catalog_metadata_datetime_str(self.production_datetime),
+                'StartTime': output_product_metadata['identification']['secondary_zero_doppler_start_time'],
+                'EndTime': output_product_metadata['identification']['secondary_zero_doppler_end_time']
             }
 
             output_product_metadata['MeasuredParameters'] = augment_hdf5_measured_parameters(

--- a/src/opera/pge/disp_s1/templates/OPERA_ISO_metadata_L3_DISP_S1_template.xml.jinja2
+++ b/src/opera/pge/disp_s1/templates/OPERA_ISO_metadata_L3_DISP_S1_template.xml.jinja2
@@ -510,8 +510,8 @@
                         <gmd:EX_TemporalExtent id="boundingTemporalExtent">
                             <gmd:extent>
                                 <gml:TimePeriod gml:id="DISP_Time_Range">
-                                    <gml:beginPosition>{{ product_output.identification.secondary_zero_doppler_start_time }}{# ISO_OPERA_refDateTime #}</gml:beginPosition>
-                                    <gml:endPosition>{{ product_output.identification.secondary_zero_doppler_end_time }}{# ISO_OPERA_secDateTime #}</gml:endPosition>
+                                    <gml:beginPosition>{{ product_output.static.StartTime }}{# ISO_OPERA_refDateTime #}</gml:beginPosition>
+                                    <gml:endPosition>{{ product_output.static.EndTime }}{# ISO_OPERA_secDateTime #}</gml:endPosition>
                                 </gml:TimePeriod>
                             </gmd:extent>
                         </gmd:EX_TemporalExtent>


### PR DESCRIPTION
## Description
- Adds secondary zero doppler start/end times to top-level product metadata subdictionary and refers to that in ISO XML template

## Affected Issues
- Fixes #600 

## Testing
- Verified sections populated during local unit test execution
- ~~Verification with int test on dev-pge underway~~
- Passed int test on dev-pge (`/data/tmp/tmp.XjaXM3K6YO/output_disp_s1/historical`)
