### PR TITLE
Fix for stale references in DIST-S1 ISO XML

### DIFF
--- a/.ci/scripts/cslc_s1/test_int_cslc_s1.sh
+++ b/.ci/scripts/cslc_s1/test_int_cslc_s1.sh
@@ -113,6 +113,13 @@ metrics_collection_end "$PGE_NAME" "$container_name" "$docker_exit_status" "$TES
 if [ $docker_exit_status -ne 0 ]; then
     echo "docker exit indicates failure: ${docker_exit_status}"
     overall_status=1
+else
+  # Retrieve the return code written to disk by the comparison script
+  test_status=$(cat "$output_dir/compare_cslc_s1_products.rc")
+
+  if [ $test_status -ne 0 ]; then
+    overall_status=$test_status
+  fi
 fi
 
 # Run the static layer workflow
@@ -140,6 +147,13 @@ metrics_collection_end "${PGE_NAME}_static" "$container_name" "$docker_exit_stat
 if [ $docker_exit_status -ne 0 ]; then
     echo "docker exit indicates failure: ${docker_exit_status}"
     overall_status=1
+else
+  # Retrieve the return code written to disk by the comparison script
+  test_status=$(cat "$output_dir/compare_cslc_s1_products.rc")
+
+  if [ $test_status -ne 0 ]; then
+    overall_status=$test_status
+  fi
 fi
 
 # Copy the PGE/SAS log file(s) to the test results directory so it can be archived

--- a/.ci/scripts/dswx_ni/test_int_dswx_ni.sh
+++ b/.ci/scripts/dswx_ni/test_int_dswx_ni.sh
@@ -115,6 +115,13 @@ cp "${output_dir}"/test_int_dswx_ni_results.html "${TEST_RESULTS_DIR}"/test_int_
 if [ $docker_exit_status -ne 0 ]; then
     echo "docker exit indicates failure: ${docker_exit_status}"
     overall_status=1
+else
+  # Retrieve the return code written to disk by the comparison script
+  test_status=$(cat "$output_dir/compare_dswx_ni_products.rc")
+
+  if [ $test_status -ne 0 ]; then
+    overall_status=$test_status
+  fi
 fi
 
 echo " "

--- a/.ci/scripts/dswx_s1/test_int_dswx_s1.sh
+++ b/.ci/scripts/dswx_s1/test_int_dswx_s1.sh
@@ -115,6 +115,13 @@ cp "${output_dir}"/test_int_dswx_s1_results.html "${TEST_RESULTS_DIR}"/test_int_
 if [ $docker_exit_status -ne 0 ]; then
     echo "docker exit indicates failure: ${docker_exit_status}"
     overall_status=1
+else
+  # Retrieve the return code written to disk by the comparison script
+  test_status=$(cat "$output_dir/compare_dswx_s1_products.rc")
+
+  if [ $test_status -ne 0 ]; then
+    overall_status=$test_status
+  fi
 fi
 
 echo " "

--- a/src/opera/pge/dist_s1/dist_s1_pge.py
+++ b/src/opera/pge/dist_s1/dist_s1_pge.py
@@ -87,11 +87,9 @@ class DistS1PostProcessorMixin(PostProcessorMixin):
     _valid_layer_names = _main_output_layer_names + _confirmation_db_output_layer_names
 
     _product_id_pattern = (r'(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DIST(-ALERT)?)-(?P<source>S1)_'
-                           r'(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})'
-                           r'(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_'
-                           r'(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T'
-                           r'(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1[AC]?)_'
-                           r'(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))')
+                           r'(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>\d{4}\d{2}\d{2}T\d{2}\d{2}\d{2}Z)_'
+                           r'(?P<creation_ts>\d{4}\d{2}\d{2}T\d{2}\d{2}\d{2}Z)_(?P<sensor>S1[AC]?)_(?P<spacing>30)_'
+                           r'(?P<product_version>v\d+[.]\d+))')
 
     _granule_filename_pattern = (_product_id_pattern + rf'((_(?P<layer_name>{"|".join(_valid_layer_names)}))|'
                                                        r'_BROWSE)?[.](?P<ext>tif|tiff|png)$')
@@ -352,7 +350,7 @@ class DistS1PostProcessorMixin(PostProcessorMixin):
         match_result = self._granule_filename_re.match(basename(geotiff_product))
 
         if match_result is None:
-            # This really should not happen due to bassing the _validate_outputs function but check anyway
+            # This really should not happen due to passing the _validate_outputs function but check anyway
             msg = f'Failed to parse DIST-S1 filename {basename(geotiff_product)}'
             self.logger.critical(self.name, ErrorCode.INVALID_OUTPUT, msg)
 

--- a/src/opera/pge/dist_s1/dist_s1_pge.py
+++ b/src/opera/pge/dist_s1/dist_s1_pge.py
@@ -10,6 +10,7 @@ Module defining the implementation for the Surface Disturbance (DIST) from Senti
 
 import os
 import re
+from datetime import datetime
 from os.path import join, isdir, isfile, abspath, basename
 
 from opera.pge.base.base_pge import PreProcessorMixin, PgeExecutor, PostProcessorMixin
@@ -19,7 +20,7 @@ from opera.util.geo_utils import get_geographic_boundaries_from_mgrs_tile
 from opera.util.input_validation import check_input_list
 from opera.util.render_jinja2 import augment_measured_parameters, render_jinja2
 from opera.util.tiff_utils import get_geotiff_metadata
-from opera.util.time import get_time_for_filename
+from opera.util.time import get_time_for_filename, get_iso_time
 
 
 class DistS1PreProcessorMixin(PreProcessorMixin):
@@ -85,33 +86,33 @@ class DistS1PostProcessorMixin(PostProcessorMixin):
 
     _valid_layer_names = _main_output_layer_names + _confirmation_db_output_layer_names
 
+    _product_id_pattern = (r'(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DIST(-ALERT)?)-(?P<source>S1)_'
+                           r'(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})'
+                           r'(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_'
+                           r'(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T'
+                           r'(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1[AC]?)_'
+                           r'(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))')
+
+    _granule_filename_pattern = (_product_id_pattern + rf'((_(?P<layer_name>{"|".join(_valid_layer_names)}))|'
+                                                       r'_BROWSE)?[.](?P<ext>tif|tiff|png)$')
+
+    _product_id_re = re.compile(_product_id_pattern + r'$')
+    _granule_filename_re = re.compile(_granule_filename_pattern)
+
     def _validate_outputs(self):
-        product_id_pattern = (r'(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DIST(-ALERT)?)-(?P<source>S1)_'
-                              r'(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})'
-                              r'(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_'
-                              r'(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T'
-                              r'(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1[AC]?)_'
-                              r'(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))')
-
-        granule_filename_pattern = (product_id_pattern + rf'((_(?P<layer_name>{"|".join(self._valid_layer_names)}))|'
-                                                         r'_BROWSE)?[.](?P<ext>tif|tiff|png)$')
-
-        product_id = re.compile(product_id_pattern + r'$')
-        granule_filename = re.compile(granule_filename_pattern)
-
         output_product_path = abspath(self.runconfig.output_product_path)
         output_products = []
 
         for file in os.listdir(output_product_path):
             dir_path = join(output_product_path, file)
-            if isdir(dir_path) and product_id.match(file):
+            if isdir(dir_path) and self._product_id_re.match(file):
                 bands = []
                 generated_band_names = []
 
                 for granule in os.listdir(dir_path):
                     granule_path = join(dir_path, granule)
                     if isfile(granule_path):
-                        match_result = granule_filename.match(granule)
+                        match_result = self._granule_filename_re.match(granule)
 
                         if match_result is None:  # or match_result.groupdict()['ext'] != 'tif':
                             error_msg = f'Invalid product filename {granule}'
@@ -344,6 +345,23 @@ class DistS1PostProcessorMixin(PostProcessorMixin):
             'size': 3600,  # pixels
             'spacing': 30  # meters/pixel
         }
+
+        # TODO: Replace these with metadata values sourced from the granule when available
+        #  (Or remove entirely if possible to refer to them straight through the MP dict)
+
+        match_result = self._granule_filename_re.match(basename(geotiff_product))
+
+        if match_result is None:
+            # This really should not happen due to bassing the _validate_outputs function but check anyway
+            msg = f'Failed to parse DIST-S1 filename {basename(geotiff_product)}'
+            self.logger.critical(self.name, ErrorCode.INVALID_OUTPUT, msg)
+
+        match_result = match_result.groupdict()
+        acq_time = match_result['acquisition_ts']
+        acq_time = datetime.strptime(acq_time, '%Y%m%dT%H%M%SZ')
+
+        output_product_metadata['acquisition_start_time'] = get_iso_time(acq_time)
+        output_product_metadata['acquisition_end_time'] = get_iso_time(acq_time)
 
         return output_product_metadata
 

--- a/src/opera/pge/dist_s1/templates/OPERA_ISO_metadata_L3_DIST_S1_template.xml.jinja2
+++ b/src/opera/pge/dist_s1/templates/OPERA_ISO_metadata_L3_DIST_S1_template.xml.jinja2
@@ -530,8 +530,8 @@
                         <gmd:EX_TemporalExtent id="boundingTemporalExtent">
                             <gmd:extent>
                                 <gml:TimePeriod gml:id="DIST_Time_Range">
-                                    <gml:beginPosition>{{ product_output.identification.secondary_zero_doppler_start_time }}{# ISO_OPERA_refDateTime #}</gml:beginPosition>
-                                    <gml:endPosition>{{ product_output.identification.secondary_zero_doppler_end_time }}{# ISO_OPERA_secDateTime #}</gml:endPosition>
+                                    <gml:beginPosition>{{ product_output.acquisition_start_time }}{# ISO_OPERA_refDateTime #}</gml:beginPosition>
+                                    <gml:endPosition>{{ product_output.acquisition_end_time }}{# ISO_OPERA_secDateTime #}</gml:endPosition>
                                 </gml:TimePeriod>
                             </gmd:extent>
                         </gmd:EX_TemporalExtent>


### PR DESCRIPTION
## Description
- ACTUALLY addresses #600 (My bad!)
- No metadata field yet for acquisition time so I used the regexes in the output validation to parse the filenames
- Also included are some fixes to [an issue I found](https://github.com/nasa/opera-sds-pge/issues/595#issuecomment-2698718908) in the DSWx-S1 int test script and also found in the scripts for CSLC-S1 and DSWx-NI

## Affected Issues
- Fixes #600 

## Testing
- Unit tests passing both locally & on dev-pge
- Int tests for changed PGEs running on Jenkins (sandbox job 404 - passed)
