### PR TITLE
DIST-S1 Input validations and postprocessor updates

### DIFF
--- a/src/opera/pge/dist_s1/dist_s1_pge.py
+++ b/src/opera/pge/dist_s1/dist_s1_pge.py
@@ -581,7 +581,9 @@ class DistS1PostProcessorMixin(PostProcessorMixin):
                 dst = os.path.join(output_product_path, basename(filename))
 
                 if scratch_path not in src and src != dst:
-                    shutil.move(str(src), dst)
+                    # TODO: Change this to shutil.move() with the next SAS delivery. We need the output directory
+                    #  structure intact for the comparison script since it works on the whole directory
+                    shutil.copy(str(src), dst)
 
     def _checksum_output_products(self):
         """

--- a/src/opera/pge/dist_s1/dist_s1_pge.py
+++ b/src/opera/pge/dist_s1/dist_s1_pge.py
@@ -12,7 +12,7 @@ import os
 import re
 import shutil
 from datetime import datetime
-from itertools import chain, cycle
+from itertools import chain
 from os.path import join, isdir, isfile, abspath, basename, splitext
 
 from opera.pge.base.base_pge import PreProcessorMixin, PgeExecutor, PostProcessorMixin

--- a/src/opera/pge/dist_s1/dist_s1_pge.py
+++ b/src/opera/pge/dist_s1/dist_s1_pge.py
@@ -49,6 +49,7 @@ class DistS1PreProcessorMixin(PreProcessorMixin):
         4. Ensures input RTCs are not from a mixture of Sentinel-1A and Sentinel-1C
         5. Validates that the co- and cross-pol RTCs are in the same order (burst-ID &
            acquisition time)
+        6. Validates no cross-pol RTCs are in copol input lists and vice-versa
         """
 
         sas_config = self.runconfig.sas_config
@@ -156,6 +157,24 @@ class DistS1PreProcessorMixin(PreProcessorMixin):
                 ErrorCode.INVALID_INPUT,
                 msg
             )
+
+        for rtc in pre_rtc_copol + post_rtc_copol:
+            if rtc_pattern.match(os.path.basename(rtc)).groupdict()['pol'] not in ['VV', 'HH']:
+                msg = 'Found non-copol RTC in copol input list'
+                self.logger.critical(
+                    self.name,
+                    ErrorCode.INVALID_INPUT,
+                    msg
+                )
+
+        for rtc in pre_rtc_crosspol + post_rtc_crosspol:
+            if rtc_pattern.match(os.path.basename(rtc)).groupdict()['pol'] not in ['VH', 'HV']:
+                msg = 'Found non-crosspol RTC in crosspol input list'
+                self.logger.critical(
+                    self.name,
+                    ErrorCode.INVALID_INPUT,
+                    msg
+                )
 
     def run_preprocessor(self, **kwargs):
         """

--- a/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
+++ b/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
@@ -185,7 +185,7 @@ class DistS1PgeTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(expected_log_file))
 
         # Lastly, check that the dummy output products were created
-        tif_files = glob.glob(join(pge.runconfig.output_product_path, "*", "*.tif"))
+        tif_files = glob.glob(join(pge.runconfig.output_product_path, "*.tif"))
         self.assertEqual(len(tif_files), 7)
 
         # Open and read the log

--- a/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
+++ b/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
@@ -343,7 +343,10 @@ class DistS1PgeTestCase(unittest.TestCase):
             with open(expected_log_file, 'r', encoding='utf-8') as infile:
                 log_contents = infile.read()
 
-            self.assertIn(f"SAS RTC file groups do not make a subset of PGE Input Files", log_contents)
+            self.assertIn(
+                f"RunConfig SAS group RTC file lists do not make a subset of PGE group Input File list",
+                log_contents
+            )
 
             # Test 3: Detect if input RTC sensors are heterogeneous
 
@@ -401,7 +404,7 @@ class DistS1PgeTestCase(unittest.TestCase):
             with open(expected_log_file, 'r', encoding='utf-8') as infile:
                 log_contents = infile.read()
 
-            self.assertIn(f"Invalid RTC filenames in SAS input", log_contents)
+            self.assertIn(f"Invalid RTC filenames in RunConfig", log_contents)
 
             # Test 5a: Badly ordered RTCs - Fixable
 
@@ -423,7 +426,7 @@ class DistS1PgeTestCase(unittest.TestCase):
             with open(expected_log_file, 'r', encoding='utf-8') as infile:
                 log_contents = infile.read()
 
-            self.assertIn("One or more of the SAS RTC lists is badly ordered. Attempting to sort them", log_contents)
+            self.assertIn("One or more of the RunConfig SAS group RTC lists is badly ordered. Attempting to sort them", log_contents)
 
             # Test 5b: Badly ordered RTCs - Unfixable - Date mismatch
 

--- a/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
+++ b/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
@@ -379,7 +379,7 @@ class DistS1PgeTestCase(unittest.TestCase):
             with open(expected_log_file, 'r', encoding='utf-8') as infile:
                 log_contents = infile.read()
 
-            self.assertIn(f"SAS input contains a RTCs from more than one S1 Sensor", log_contents)
+            self.assertIn(f"RunConfig contains RTCs from more than one S1 Sensor", log_contents)
 
             # Test 4: Incorrect RTC file names
 

--- a/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
+++ b/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
@@ -59,8 +59,8 @@ class DistS1PgeTestCase(unittest.TestCase):
 
         # Create the input dir expected by the test RunConfig and add a
         # dummy input file
-        input_dir = join(self.working_dir.name, "dist_s1_pge_test/input_dir")
-        os.makedirs(input_dir, exist_ok=True)
+        self.input_dir = abspath(join(self.working_dir.name, "dist_s1_pge_test/input_dir"))
+        os.makedirs(self.input_dir, exist_ok=True)
 
         # Create dummy input files based on the test run config
         runconfig_path = join(self.data_dir, 'test_dist_s1_config.yaml')
@@ -205,10 +205,8 @@ class DistS1PgeTestCase(unittest.TestCase):
 
         input_files_group = runconfig_dict['RunConfig']['Groups']['PGE']['InputFilesGroup']
 
-        Path('temp').mkdir(parents=True, exist_ok=True)
-
         # Test that a non-existent file path is detected by pre-processor
-        input_files_group['InputFilePaths'] = ['temp/non_existent_file.tif']
+        input_files_group['InputFilePaths'] = [os.path.join(self.input_dir, 'non_existent_file.tif')]
 
         try:
             with open(test_runconfig_path, 'w', encoding='utf-8') as input_path:
@@ -233,7 +231,7 @@ class DistS1PgeTestCase(unittest.TestCase):
                           f"{input_files_group['InputFilePaths'][0]}", log_contents)
 
             # Test that invalid file types are detected by pre-processor
-            input_files_group['InputFilePaths'] = ['temp/wrong_input_type.h5']
+            input_files_group['InputFilePaths'] = [os.path.join(self.input_dir, 'wrong_input_type.h5')]
 
             with open(input_files_group['InputFilePaths'][0], 'wb') as fp:
                 fp.write(random.randbytes(1024))
@@ -256,7 +254,7 @@ class DistS1PgeTestCase(unittest.TestCase):
                           f'extension.', log_contents)
 
             # Test that empty files are detected by pre-processor
-            input_files_group['InputFilePaths'] = ['temp/empty.tif']
+            input_files_group['InputFilePaths'] = [os.path.join(self.input_dir, 'empty.tif')]
 
             os.system(
                 f"touch {input_files_group['InputFilePaths'][0]}"
@@ -282,9 +280,6 @@ class DistS1PgeTestCase(unittest.TestCase):
             if os.path.exists(test_runconfig_path):
                 os.unlink(test_runconfig_path)
 
-            if os.path.exists('temp'):
-                shutil.rmtree('temp')
-
     def test_dist_s1_pge_input_rtc_validations(self):
         """Test the input RTC validation checks made by DistS1PreProcessorMixin."""
         runconfig_path = join(self.data_dir, 'test_dist_s1_config.yaml')
@@ -296,11 +291,9 @@ class DistS1PgeTestCase(unittest.TestCase):
         backup_runconfig = deepcopy(runconfig_dict)
 
         try:
-            Path('temp').mkdir(parents=True, exist_ok=True)
-
             # Test 1: Detect co/crosspol length mismatch
 
-            s1_file = 'temp/OPERA_L2_RTC-S1_T137-292325-IW1_20241022T015921Z_20241022T180523Z_S1A_30_v1.0_VV.tif'
+            s1_file = os.path.join(self.input_dir, 'OPERA_L2_RTC-S1_T137-292325-IW1_20241022T015921Z_20241022T180523Z_S1A_30_v1.0_VV.tif')
 
             runconfig_dict['RunConfig']['Groups']['PGE']['InputFilesGroup']['InputFilePaths'].append(s1_file)
             runconfig_dict['RunConfig']['Groups']['SAS']['run_config']['pre_rtc_copol'].append(s1_file)
@@ -356,7 +349,7 @@ class DistS1PgeTestCase(unittest.TestCase):
 
             runconfig_dict = deepcopy(backup_runconfig)
 
-            s1c_file = 'temp/OPERA_L2_RTC-S1_T137-292325-IW1_20241022T015921Z_20241022T180523Z_S1C_30_v1.0_VV.tif'
+            s1c_file = os.path.join(self.input_dir, 'OPERA_L2_RTC-S1_T137-292325-IW1_20241022T015921Z_20241022T180523Z_S1C_30_v1.0_VV.tif')
 
             runconfig_dict['RunConfig']['Groups']['PGE']['InputFilesGroup']['InputFilePaths'][0] = s1c_file
             runconfig_dict['RunConfig']['Groups']['SAS']['run_config']['pre_rtc_copol'][0] = s1c_file
@@ -385,7 +378,7 @@ class DistS1PgeTestCase(unittest.TestCase):
 
             runconfig_dict = deepcopy(backup_runconfig)
 
-            s1c_file = 'temp/non_standard_rtc_name.tif'
+            s1c_file = os.path.join(self.input_dir, 'non_standard_rtc_name.tif')
 
             runconfig_dict['RunConfig']['Groups']['PGE']['InputFilesGroup']['InputFilePaths'][0] = s1c_file
             runconfig_dict['RunConfig']['Groups']['SAS']['run_config']['pre_rtc_copol'][0] = s1c_file
@@ -436,7 +429,7 @@ class DistS1PgeTestCase(unittest.TestCase):
 
             runconfig_dict = deepcopy(backup_runconfig)
 
-            s1_file = 'temp/OPERA_L2_RTC-S1_T137-292318-IW1_20240904T015859Z_20240904T150822Z_S1A_30_v1.0_VV.tif'
+            s1_file = os.path.join(self.input_dir, 'OPERA_L2_RTC-S1_T137-292318-IW1_20240904T015859Z_20240904T150822Z_S1A_30_v1.0_VV.tif')
 
             runconfig_dict['RunConfig']['Groups']['PGE']['InputFilesGroup']['InputFilePaths'][0] = s1_file
             runconfig_dict['RunConfig']['Groups']['SAS']['run_config']['pre_rtc_copol'][0] = s1_file
@@ -465,7 +458,7 @@ class DistS1PgeTestCase(unittest.TestCase):
 
             runconfig_dict = deepcopy(backup_runconfig)
 
-            s1_file = 'temp/OPERA_L2_RTC-S1_T137-292317-IW1_20250102T015857Z_20250102T190143Z_S1A_30_v1.0_VV.tif'
+            s1_file = os.path.join(self.input_dir, 'OPERA_L2_RTC-S1_T137-292317-IW1_20250102T015857Z_20250102T190143Z_S1A_30_v1.0_VV.tif')
 
             pre_rtc_copol = runconfig_dict['RunConfig']['Groups']['SAS']['run_config']['pre_rtc_copol']
             pre_rtc_crosspol = runconfig_dict['RunConfig']['Groups']['SAS']['run_config']['pre_rtc_crosspol']
@@ -549,9 +542,6 @@ class DistS1PgeTestCase(unittest.TestCase):
         finally:
             if os.path.exists(test_runconfig_path):
                 os.unlink(test_runconfig_path)
-
-            if os.path.exists('temp'):
-                shutil.rmtree('temp')
 
     @patch.object(opera.util.tiff_utils, "gdal", MockGdal)
     def test_dist_s1_pge_output_validation(self):


### PR DESCRIPTION
## Description
- Implements the following features for the DIST-S1 PGE
  - Flatten SAS output to product output directory
  - Ensure output products are checksummed and included in catalog JSON
  - Extensive validations of SAS RTC input lists to avoid SAS failures:
    - Verify the co- and cross-pol RTC input lists are the same length
    - Verify the combined SAS RTC input lists are a subset of the PGE input list
    - Verify the input RTCs have standard filenames (important for later checks)
    - Verify input RTCs are not from a mixture of Sentinel-1A and Sentinel-1C
    - Verify that the co- and cross-pol RTCs are in the same order (burst-ID & acquisition time)
    - Verify no cross-pol RTCs are in co-pol input lists and vice-versa

## Affected Issues
- Resolves #612
- Resolves #613
- Closes #614 

## Testing
- Implemented new unit tests for DIST-S1 RTC validations
- All unit tests are passing (local & dev-pge)
- Passed int test on dev PGE
  - Verified output dir is flat and catalog JSON contains checksums
