### PR TITLE
Switch Jenkins conda installer to miniforge

### DIFF
--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
                 sh label: 'Download and install',
                    script: """#!/bin/bash
                      mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge
-                     wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
+                     wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
                      bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge
                      rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
                    """

--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -60,14 +60,14 @@ pipeline {
                 }
             }
         }
-        stage('Install miniconda') {
+        stage('Install miniforge') {
             steps{
                 sh label: 'Download and install',
                    script: """#!/bin/bash
-                     mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
-                     bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge
+                     wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
+                     bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge
+                     rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
                    """
             }
         }
@@ -77,8 +77,8 @@ pipeline {
                     echo "Creating conda env"
                     sh label: 'Installing int test conda environment',
                        script: """#!/bin/bash
-                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda create -n int_test_env python=3.10 pip
-                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init bash
+                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/bin/conda create -n int_test_env python=3.10 pip
+                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/bin/conda init bash
                     """
 
                     sh label: 'Installing dependencies to int test conda environment',
@@ -149,9 +149,9 @@ pipeline {
                 }
                 catchError (buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Conda cleanup failed') {
                     echo "Removing int test conda environment"
-                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name int_test_env"
-                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"
-                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
+                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/bin/conda env remove --yes --name int_test_env"
+                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/bin/conda clean -ay"
+                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/bin/conda init --reverse"
                     sh "rm -rf /var/lib/jenkins/conda_installs/${RUN_ID}/"
                 }
                 deleteDir()

--- a/.ci/jenkins/build-int-test/Jenkinsfile
+++ b/.ci/jenkins/build-int-test/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
                 sh label: 'Download and install',
                    script: """#!/bin/bash
                      mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge
-                     wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
+                     wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
                      bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge
                      rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
                    """

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -103,14 +103,14 @@ pipeline {
                 }
             }
         }
-        stage('Install miniconda') {
+        stage('Install miniforge') {
             steps{
                 sh label: 'Download and install',
                    script: """#!/bin/bash
-                     mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
-                     bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3
-                     rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/miniconda.sh
+                     mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge
+                     wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
+                     bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge
+                     rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
                    """
             }
         }
@@ -121,8 +121,8 @@ pipeline {
                     echo "Installing Sphinx Dependencies"
                     sh label: 'Installing conda environment for Sphinx',
                        script: """#!/bin/bash
-                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda create -n sphinx_env python=3.8 pip
-                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init bash
+                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/bin/conda create -n sphinx_env python=3.8 pip
+                         /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/bin/conda init bash
                     """
 
                     sh label: 'Installing Sphinx to conda environment',
@@ -245,9 +245,9 @@ pipeline {
                 }
                 catchError (buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Conda cleanup failed') {
                     echo "Removing Sphinx build environment"
-                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda env remove --yes --name sphinx_env"
-                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda clean -ay"
-                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniconda3/bin/conda init --reverse"
+                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/bin/conda env remove --yes --name sphinx_env"
+                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/bin/conda clean -ay"
+                    sh "/var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/bin/conda init --reverse"
                     sh "rm -rf /var/lib/jenkins/conda_installs/${RUN_ID}/"
                 }
                 deleteDir()

--- a/.ci/jenkins/build-test-deploy/Jenkinsfile
+++ b/.ci/jenkins/build-test-deploy/Jenkinsfile
@@ -108,7 +108,7 @@ pipeline {
                 sh label: 'Download and install',
                    script: """#!/bin/bash
                      mkdir -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge
-                     wget -q "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
+                     wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
                      bash /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh -b -u -p /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge
                      rm /var/lib/jenkins/conda_installs/${RUN_ID}/miniforge/miniforge.sh
                    """


### PR DESCRIPTION
## Description
- In order to avoid license issues with miniconda, switch to miniforge in int and deploy pipelines 

## Affected Issues
- Closes #602 

## Testing
- [x] Ran int pipeline 
- [x] Ran release pipeline w/ doc build enabled to fully utilize conda env
