### PR TITLE
DISP-S1 PGE Release v3.0.5 (+DISP-S1-STATIC release)

### DIFF
--- a/examples/disp_s1_sample_runconfig-v3.0.5.yaml
+++ b/examples/disp_s1_sample_runconfig-v3.0.5.yaml
@@ -1,4 +1,4 @@
-# Sample RunConfig for use with the DISP-S1 PGE v3.0.4
+# Sample RunConfig for use with the DISP-S1 PGE v3.0.5
 # This RunConfig should require minimal changes in order to be used with the
 # OPERA PCM.
 

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -891,7 +891,7 @@ class DispS1Executor(DispS1PreProcessorMixin, DispS1PostProcessorMixin, PgeExecu
     LEVEL = "L3"
     """Processing Level for DISP-S1 Products"""
 
-    PGE_VERSION = "3.0.4"
+    PGE_VERSION = "3.0.5"
     """Version of the PGE (overrides default from base_pge)"""
 
     SAS_VERSION = "0.5.7"  # Final release https://github.com/opera-adt/disp-s1/releases/tag/v0.5.7


### PR DESCRIPTION
Release of PGE v3.0.5 for SAS deliveries 0.5.6 (DISP-S1-STATIC CalVal) & 0.5.7 (DISP-S1 Final)