### PR TITLE
618 HTML results column cleanup

### DIFF
--- a/.ci/scripts/cslc_s1/compare_cslc_s1_products.sh
+++ b/.ci/scripts/cslc_s1/compare_cslc_s1_products.sh
@@ -32,7 +32,7 @@ if [ ! -d "$EXPECTED_DIR" ]; then
 fi
 
 initialize_html_results_file "$OUTPUT_DIR" "$PGE_NAME"
-echo "<tr><th>Compare Result</th><th><ul><li>Expected file</li><li>Output file</li></ul></th><th>cslc_s1_compare.py output</th></tr>" >> "$RESULTS_FILE"
+echo "<tr><th>Compare Result</th><th><ul><li>Output file</li><li>Expected file</li></ul></th><th>cslc_s1_compare.py output</th></tr>" >> "$RESULTS_FILE"
 
 declare -a burst_ids=("t064_135518_iw1"
                       "t064_135519_iw1"
@@ -73,7 +73,7 @@ for burst_id in "${burst_ids[@]}"; do
     fi
 
     compare_out="${compare_out//$'\n'/<br>}"
-    update_html_results_file "${cslc_compare_result}" "${ref_product}" "${sec_product}" "${compare_out}"
+    update_html_results_file "${cslc_compare_result}" "${sec_product}" "${ref_product}" "${compare_out}"
 done
 
 finalize_html_results_file

--- a/.ci/scripts/cslc_s1/compare_cslc_s1_static_products.sh
+++ b/.ci/scripts/cslc_s1/compare_cslc_s1_static_products.sh
@@ -32,7 +32,7 @@ if [ ! -d "$EXPECTED_DIR" ]; then
 fi
 
 initialize_html_results_file "$OUTPUT_DIR" "$PGE_NAME"
-echo "<tr><th>Compare Result</th><th><ul><li>Expected file</li><li>Output file</li></ul></th><th>cslc_s1_compare.py output</th></tr>" >> "$RESULTS_FILE"
+echo "<tr><th>Compare Result</th><th><ul><li>Output file</li><li>Expected file</li></ul></th><th>cslc_s1_compare.py output</th></tr>" >> "$RESULTS_FILE"
 
 declare -a burst_ids=("t064_135518_iw1"
                       "t064_135519_iw1"
@@ -70,7 +70,7 @@ for burst_id in "${burst_ids[@]}"; do
     fi
 
     compare_out="${compare_out//$'\n'/<br>}"
-    update_html_results_file "${static_layers_compare_result}" "${ref_product}" "${sec_product}" "${compare_out}"
+    update_html_results_file "${static_layers_compare_result}" "${sec_product}" "${ref_product}" "${compare_out}"
 done
 
 finalize_html_results_file

--- a/.ci/scripts/disp_s1/compare_disp_s1_products.sh
+++ b/.ci/scripts/disp_s1/compare_disp_s1_products.sh
@@ -30,7 +30,7 @@ fi
 
 initialize_html_results_file "$OUTPUT_DIR" "$PGE_NAME"
 
-echo "<tr><th>Compare Result</th><th><ul><li>Expected file</li><li>Output file</li></ul></th><th>disp_s1_compare.py output</th></tr>" >> "$RESULTS_FILE"
+echo "<tr><th>Compare Result</th><th><ul><li>Output file</li><li>Expected file</li></ul></th><th>disp_s1_compare.py output</th></tr>" >> "$RESULTS_FILE"
 
 # overall_status values and their meaning
 # 0 - pass

--- a/.ci/scripts/disp_s1/compare_disp_s1_static_products.sh
+++ b/.ci/scripts/disp_s1/compare_disp_s1_static_products.sh
@@ -31,7 +31,7 @@ fi
 
 initialize_html_results_file "$OUTPUT_DIR" "$PGE_NAME"
 
-echo "<tr><th>Compare Result</th><th><ul><li>Expected file</li><li>Output file</li></ul></th><th>Comparison output</th></tr>" >> "$RESULTS_FILE"
+echo "<tr><th>Compare Result</th><th><ul><li>Output file</li><li>Expected file</li></ul></th><th>Comparison output</th></tr>" >> "$RESULTS_FILE"
 
 # overall_status values and their meaning
 # 0 - pass

--- a/.ci/scripts/dist_s1/compare_dist_s1_products.sh
+++ b/.ci/scripts/dist_s1/compare_dist_s1_products.sh
@@ -27,6 +27,8 @@ fi
 
 initialize_html_results_file "$OUTPUT_DIR" "$PGE_NAME"
 
+echo "<tr><th>Compare Result</th><th><ul><li>Output file</li><li>Expected file</li></ul></th><th>dist_s1_compare.py output</th></tr>" >> "$RESULTS_FILE"
+
 # overall_status values and their meaning
 # 0 - pass
 # 1 - failure to execute some part of this script

--- a/.ci/scripts/dswx_hls/compare_dswx_hls_products.sh
+++ b/.ci/scripts/dswx_hls/compare_dswx_hls_products.sh
@@ -27,7 +27,7 @@ fi
 
 initialize_html_results_file "$OUTPUT_DIR" "$PGE_NAME"
 
-echo "<tr><th>Compare Result</th><th><ul><li>Expected file</li><li>Output file</li></ul></th><th>dswx_hls_compare.py output</th></tr>" >> "$RESULTS_FILE"
+echo "<tr><th>Compare Result</th><th><ul><li>Output file</li><li>Expected file</li></ul></th><th>dswx_hls_compare.py output</th></tr>" >> "$RESULTS_FILE"
 
 # overall_status values and their meaning
 # 0 - pass

--- a/.ci/scripts/dswx_ni/compare_dswx_ni_products.sh
+++ b/.ci/scripts/dswx_ni/compare_dswx_ni_products.sh
@@ -27,6 +27,8 @@ fi
 
 initialize_html_results_file "$OUTPUT_DIR" "$PGE_NAME"
 
+echo "<tr><th>Compare Result</th><th><ul><li>Output file</li><li>Expected file</li></ul></th><th>dswx_compare.py output</th></tr>" >> "$RESULTS_FILE"
+
 # Compare output files against expected files
 for output_file in "$OUTPUT_DIR"/*
 do

--- a/.ci/scripts/dswx_s1/compare_dswx_s1_products.sh
+++ b/.ci/scripts/dswx_s1/compare_dswx_s1_products.sh
@@ -27,6 +27,8 @@ fi
 
 initialize_html_results_file "$OUTPUT_DIR" "$PGE_NAME"
 
+echo "<tr><th>Compare Result</th><th><ul><li>Output file</li><li>Expected file</li></ul></th><th>dswx_compare.py output</th></tr>" >> "$RESULTS_FILE"
+
 # Compare output files against expected files
 for output_file in "$OUTPUT_DIR"/*
 do

--- a/.ci/scripts/rtc_s1/compare_rtc_s1_products.sh
+++ b/.ci/scripts/rtc_s1/compare_rtc_s1_products.sh
@@ -26,6 +26,8 @@ fi
 
 initialize_html_results_file "$OUTPUT_DIR" "$PGE_NAME"
 
+echo "<tr><th>Compare Result</th><th><ul><li>Output file</li><li>Expected file</li></ul></th><th>rtc_s1_compare.py output</th></tr>" >> "$RESULTS_FILE"
+
 # overall_status values and their meaning
 # 0 - pass
 # 1 - failure to execute some part of this script
@@ -73,7 +75,7 @@ for burst_id in "${burst_ids[@]}"; do
 
     # add html breaks to newlines
     compare_output=${compare_output//$'\n'/<br>$'\n'}
-    update_html_results_file "${rtc_compare_result}" "${expected_files}" "${output_files}" "${compare_output}"
+    update_html_results_file "${rtc_compare_result}" "${output_files}" "${expected_files}" "${compare_output}"
 done
 
 finalize_html_results_file

--- a/.ci/scripts/rtc_s1/compare_rtc_s1_static_products.sh
+++ b/.ci/scripts/rtc_s1/compare_rtc_s1_static_products.sh
@@ -26,6 +26,8 @@ fi
 
 initialize_html_results_file "$OUTPUT_DIR" "$PGE_NAME"
 
+echo "<tr><th>Compare Result</th><th><ul><li>Output file</li><li>Expected file</li></ul></th><th>rtc_s1_compare.py output</th></tr>" >> "$RESULTS_FILE"
+
 # overall_status values and their meaning
 # 0 - pass
 # 1 - failure to execute some part of this script
@@ -70,7 +72,7 @@ for burst_id in "${burst_ids[@]}"; do
 
     # add html breaks to newlines
     compare_output=${compare_output//$'\n'/<br>$'\n'}
-    update_html_results_file "${static_layers_compare_result}" "${expected_static_files}" "${output_static_files}" "${compare_output}"
+    update_html_results_file "${static_layers_compare_result}" "${output_static_files}" "${expected_static_files}" "${compare_output}"
 done
 
 finalize_html_results_file

--- a/.ci/scripts/tropo/compare_tropo_products.sh
+++ b/.ci/scripts/tropo/compare_tropo_products.sh
@@ -29,7 +29,7 @@ fi
 
 initialize_html_results_file "$OUTPUT_DIR" "$PGE_NAME"
 
-echo "<tr><th>Compare Result</th><th><ul><li>Expected file</li><li>Output file</li></ul></th><th>opera_tropo validate output</th></tr>" >> "$RESULTS_FILE"
+echo "<tr><th>Compare Result</th><th><ul><li>Output file</li><li>Expected file</li></ul></th><th>opera_tropo validate output</th></tr>" >> "$RESULTS_FILE"
 
 # overall_status values and their meaning
 # 0 - pass
@@ -93,7 +93,7 @@ do
 
     # add html breaks to newlines
     compare_out="${compare_out//$'\n'/<br>}"
-    update_html_results_file "${compare_result}" "${expected_file}" "${output_file}" "${compare_out}"
+    update_html_results_file "${compare_result}" "${output_file}" "${expected_file}" "${compare_out}"
 done
 
 finalize_html_results_file


### PR DESCRIPTION
## Description
-  Ensured the ordering of columns in the product comparison results HTML is consistently "Compare Result, Output file(s), Expected file(s), Comparison output"
-  Added header row to comparison HTML pages where missing

## Affected Issues
- Closes #618 

## Testing
- Ran Int pipeline on all PGEs: `dswx_hls,cslc_s1,rtc_s1,dswx_s1,disp_s1,dswx_ni,dist_s1,tropo` - all had updates to the HTML. Results can be seen in int pipeline job `618_html_column_cleanup/2/artifact/test_results/`