### PR TITLE
Release/3.0.0 er.2.0 tropo

### DIFF
--- a/examples/tropo_sample_runconfig-v3.0.0-er.2.0.yaml
+++ b/examples/tropo_sample_runconfig-v3.0.0-er.2.0.yaml
@@ -1,4 +1,4 @@
-# Sample RunConfig for use with the TROPO PGE v3.0.0-er.1.0
+# Sample RunConfig for use with the TROPO PGE v3.0.0-er.2.0
 # This RunConfig should require minimal changes in order to be used with the
 # OPERA PCM.
 

--- a/src/opera/pge/tropo/tropo_pge.py
+++ b/src/opera/pge/tropo/tropo_pge.py
@@ -187,7 +187,7 @@ class TROPOExecutor(TROPOPreProcessorMixin, TROPOPostProcessorMixin, PgeExecutor
     LEVEL = "L4"
     """Processing Level for TROPO Products"""
 
-    PGE_VERSION = "3.0.0-er.1.0"
+    PGE_VERSION = "3.0.0-er.2.0"
     """Version of the PGE"""
 
     SAS_VERSION = "0.2"

--- a/src/opera/test/pge/tropo/test_tropo_pge.py
+++ b/src/opera/test/pge/tropo/test_tropo_pge.py
@@ -55,7 +55,7 @@ class TROPOPgeTestCase(unittest.TestCase):
 
         # Create the input dir expected by the test RunConfig and add a
         # dummy input file
-        self.input_dir = join(self.working_dir.name, "tropo_pge_test/input_dir")
+        self.input_dir = abspath(join(self.working_dir.name, "tropo_pge_test/input_dir"))
         os.makedirs(self.input_dir, exist_ok=True)
         
         rc = RunConfig(join(self.data_dir, 'test_tropo_config.yaml'))


### PR DESCRIPTION
## Description
- Set `PGE_VERSION` to `3.0.0-er.2.0` in `tropo_pge.py` 
- Bug fix in `test_tropo_pge.py` where `input_dir` required an absolute path in some cases

## Affected Issues
- #651 

## Testing
- Successfully built on Jenkins int pipeline
- Successfully built on Jenkins release pipeline
