### PR TITLE
Conversion of pkg_resources calls to importlib.resources

### DIFF
--- a/.ci/scripts/cslc_s1/test_cslc_s1.sh
+++ b/.ci/scripts/cslc_s1/test_cslc_s1.sh
@@ -41,6 +41,11 @@ chmod -R 775 ${WORKSPACE}/${TEST_RESULTS_REL_DIR}
 # Docker image rather than code found on the host.
 DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}:/workspace \
+    -v ${WORKSPACE}/src/opera/test/__init__.py:${CONTAINER_HOME}/opera/test/__init__.py \
+    -v ${WORKSPACE}/src/opera/test/pge/base:${CONTAINER_HOME}/opera/test/pge/base \
+    -v ${WORKSPACE}/src/opera/test/pge/${PGE_NAME}:${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
+    -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
@@ -88,10 +93,10 @@ ${DOCKER_RUN} ${ENTRYPOINT} pytest \
     --cov=${CONTAINER_HOME}/opera/util \
     --cov-report=term \
     --cov-report=html:/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/coverage_html \
-    /workspace/src/opera/test/pge/base \
-    /workspace/src/opera/test/pge/${PGE_NAME} \
-    /workspace/src/opera/test/scripts \
-    /workspace/src/opera/test/util > ${TEST_RESULTS_DIR}/pytest.log
+    ${CONTAINER_HOME}/opera/test/pge/base \
+    ${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    ${CONTAINER_HOME}/opera/test/scripts \
+    ${CONTAINER_HOME}/opera/test/util > ${TEST_RESULTS_DIR}/pytest.log
 
 echo "CSLC-S1 PGE Docker image test complete"
 

--- a/.ci/scripts/cslc_s1/test_cslc_s1.sh
+++ b/.ci/scripts/cslc_s1/test_cslc_s1.sh
@@ -86,7 +86,7 @@ ${DOCKER_RUN} ${ENTRYPOINT} pylint \
     ${CONTAINER_HOME}/opera
 
 # pytest (including code coverage)
-${DOCKER_RUN} ${ENTRYPOINT} pytest \
+${DOCKER_RUN} ${ENTRYPOINT} pytest -p no:cacheprovider \
     --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
     --cov=${CONTAINER_HOME}/opera/pge/base \
     --cov=${CONTAINER_HOME}/opera/pge/${PGE_NAME} \

--- a/.ci/scripts/cslc_s1/test_cslc_s1.sh
+++ b/.ci/scripts/cslc_s1/test_cslc_s1.sh
@@ -47,6 +47,7 @@ DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
     -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
+    -e PYLINTHOME=/workspace/${TEST_RESULTS_REL_DIR}/.cache/pylint \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
     --entrypoint conda \

--- a/.ci/scripts/disp_ni/test_disp_ni.sh
+++ b/.ci/scripts/disp_ni/test_disp_ni.sh
@@ -84,7 +84,8 @@ ${DOCKER_RUN} bash -c "export HOME=/home/mamba/opera; source /usr/local/bin/_act
     ${CONTAINER_HOME}/opera"
 
 # pytest (including code coverage)
-${DOCKER_RUN} bash -c "source /usr/local/bin/_activate_current_env.sh; pytest \
+${DOCKER_RUN} bash -c "source /usr/local/bin/_activate_current_env.sh; \
+    pytest -p no:cacheprovider \
     --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
     --cov=${CONTAINER_HOME}/opera/pge/base \
     --cov=${CONTAINER_HOME}/opera/pge/${PGE_NAME} \

--- a/.ci/scripts/disp_ni/test_disp_ni.sh
+++ b/.ci/scripts/disp_ni/test_disp_ni.sh
@@ -41,6 +41,11 @@ chmod -R 775 ${TEST_RESULTS_DIR}
 # Docker image rather than code found on the host.
 DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}:/workspace \
+    -v ${WORKSPACE}/src/opera/test/__init__.py:${CONTAINER_HOME}/opera/test/__init__.py \
+    -v ${WORKSPACE}/src/opera/test/pge/base:${CONTAINER_HOME}/opera/test/pge/base \
+    -v ${WORKSPACE}/src/opera/test/pge/${PGE_NAME}:${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
+    -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
@@ -86,10 +91,10 @@ ${DOCKER_RUN} bash -c "source /usr/local/bin/_activate_current_env.sh; pytest \
     --cov=${CONTAINER_HOME}/opera/util \
     --cov-report=term \
     --cov-report=html:/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/coverage_html \
-    /workspace/src/opera/test/pge/base \
-    /workspace/src/opera/test/pge/${PGE_NAME} \
-    /workspace/src/opera/test/scripts \
-    /workspace/src/opera/test/util > /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest.log 2>&1"
+    ${CONTAINER_HOME}/opera/test/pge/base \
+    ${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    ${CONTAINER_HOME}/opera/test/scripts \
+    ${CONTAINER_HOME}/opera/test/util > /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest.log 2>&1"
 
 echo "DISP-NI PGE Docker image test complete"
 

--- a/.ci/scripts/disp_ni/test_disp_ni.sh
+++ b/.ci/scripts/disp_ni/test_disp_ni.sh
@@ -47,6 +47,7 @@ DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
     -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
+    -e PYLINTHOME=/workspace/${TEST_RESULTS_REL_DIR}/.cache/pylint \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
     --entrypoint ${CONDA_ROOT}/bin/pge_tests_entrypoint.sh \

--- a/.ci/scripts/disp_s1/test_disp_s1.sh
+++ b/.ci/scripts/disp_s1/test_disp_s1.sh
@@ -41,6 +41,11 @@ chmod -R 775 ${TEST_RESULTS_DIR}
 # Docker image rather than code found on the host.
 DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}:/workspace \
+    -v ${WORKSPACE}/src/opera/test/__init__.py:${CONTAINER_HOME}/opera/test/__init__.py \
+    -v ${WORKSPACE}/src/opera/test/pge/base:${CONTAINER_HOME}/opera/test/pge/base \
+    -v ${WORKSPACE}/src/opera/test/pge/${PGE_NAME}:${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
+    -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
@@ -86,10 +91,10 @@ ${DOCKER_RUN} bash -c "source /usr/local/bin/_activate_current_env.sh; pytest \
     --cov=${CONTAINER_HOME}/opera/util \
     --cov-report=term \
     --cov-report=html:/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/coverage_html \
-    /workspace/src/opera/test/pge/base \
-    /workspace/src/opera/test/pge/${PGE_NAME} \
-    /workspace/src/opera/test/scripts \
-    /workspace/src/opera/test/util > /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest.log 2>&1"
+    ${CONTAINER_HOME}/opera/test/pge/base \
+    ${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    ${CONTAINER_HOME}/opera/test/scripts \
+    ${CONTAINER_HOME}/opera/test/util > /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest.log 2>&1"
 
 echo "DISP-S1 PGE Docker image test complete"
 

--- a/.ci/scripts/disp_s1/test_disp_s1.sh
+++ b/.ci/scripts/disp_s1/test_disp_s1.sh
@@ -84,7 +84,8 @@ ${DOCKER_RUN} bash -c "export HOME=/home/mamba/opera; source /usr/local/bin/_act
     ${CONTAINER_HOME}/opera"
 
 # pytest (including code coverage)
-${DOCKER_RUN} bash -c "source /usr/local/bin/_activate_current_env.sh; pytest \
+${DOCKER_RUN} bash -c "source /usr/local/bin/_activate_current_env.sh; \
+    pytest -p no:cacheprovider \
     --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
     --cov=${CONTAINER_HOME}/opera/pge/base \
     --cov=${CONTAINER_HOME}/opera/pge/${PGE_NAME} \

--- a/.ci/scripts/disp_s1/test_disp_s1.sh
+++ b/.ci/scripts/disp_s1/test_disp_s1.sh
@@ -47,6 +47,7 @@ DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
     -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
+    -e PYLINTHOME=/workspace/${TEST_RESULTS_REL_DIR}/.cache/pylint \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
     --entrypoint ${CONDA_ROOT}/bin/pge_tests_entrypoint.sh \

--- a/.ci/scripts/dist_s1/test_dist_s1.sh
+++ b/.ci/scripts/dist_s1/test_dist_s1.sh
@@ -86,7 +86,7 @@ ${DOCKER_RUN} ${ENTRYPOINT} bash -c "export HOME=/home/mamba/opera; pylint \
     ${CONTAINER_HOME}/opera"
 
 # pytest (including code coverage)
-${DOCKER_RUN} ${ENTRYPOINT} bash -c "pytest \
+${DOCKER_RUN} ${ENTRYPOINT} bash -c "pytest -p no:cacheprovider \
     --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
     --cov=${CONTAINER_HOME}/opera/pge/base \
     --cov=${CONTAINER_HOME}/opera/pge/${PGE_NAME} \

--- a/.ci/scripts/dist_s1/test_dist_s1.sh
+++ b/.ci/scripts/dist_s1/test_dist_s1.sh
@@ -47,6 +47,7 @@ DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
     -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
+    -e PYLINTHOME=/workspace/${TEST_RESULTS_REL_DIR}/.cache/pylint \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
     --entrypoint conda \

--- a/.ci/scripts/dist_s1/test_dist_s1.sh
+++ b/.ci/scripts/dist_s1/test_dist_s1.sh
@@ -41,6 +41,11 @@ chmod -R 775 ${TEST_RESULTS_DIR}
 # Docker image rather than code found on the host.
 DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}:/workspace \
+    -v ${WORKSPACE}/src/opera/test/__init__.py:${CONTAINER_HOME}/opera/test/__init__.py \
+    -v ${WORKSPACE}/src/opera/test/pge/base:${CONTAINER_HOME}/opera/test/pge/base \
+    -v ${WORKSPACE}/src/opera/test/pge/${PGE_NAME}:${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
+    -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
@@ -88,10 +93,10 @@ ${DOCKER_RUN} ${ENTRYPOINT} bash -c "pytest \
     --cov=${CONTAINER_HOME}/opera/util \
     --cov-report=term \
     --cov-report=html:/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/coverage_html \
-    /workspace/src/opera/test/pge/base \
-    /workspace/src/opera/test/pge/${PGE_NAME} \
-    /workspace/src/opera/test/scripts \
-    /workspace/src/opera/test/util > /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest.log 2>&1"
+    ${CONTAINER_HOME}/opera/test/pge/base \
+    ${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    ${CONTAINER_HOME}/opera/test/scripts \
+    ${CONTAINER_HOME}/opera/test/util > /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest.log 2>&1"
 
 echo "DIST-S1 PGE Docker image test complete"
 

--- a/.ci/scripts/dswx_hls/test_dswx_hls.sh
+++ b/.ci/scripts/dswx_hls/test_dswx_hls.sh
@@ -41,6 +41,11 @@ chmod -R 775 ${TEST_RESULTS_DIR}
 # Docker image rather than code found on the host.
 DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}:/workspace \
+    -v ${WORKSPACE}/src/opera/test/__init__.py:${CONTAINER_HOME}/opera/test/__init__.py \
+    -v ${WORKSPACE}/src/opera/test/pge/base:${CONTAINER_HOME}/opera/test/pge/base \
+    -v ${WORKSPACE}/src/opera/test/pge/${PGE_NAME}:${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
+    -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
@@ -86,10 +91,10 @@ ${DOCKER_RUN} bash -c "pytest \
     --cov=${CONTAINER_HOME}/opera/util \
     --cov-report=term \
     --cov-report=html:/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/coverage_html \
-    /workspace/src/opera/test/pge/base \
-    /workspace/src/opera/test/pge/${PGE_NAME} \
-    /workspace/src/opera/test/scripts \
-    /workspace/src/opera/test/util > /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest.log 2>&1"
+    ${CONTAINER_HOME}/opera/test/pge/base \
+    ${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    ${CONTAINER_HOME}/opera/test/scripts \
+    ${CONTAINER_HOME}/opera/test/util > /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest.log 2>&1"
 
 echo "DSWx-HLS PGE Docker image test complete"
 

--- a/.ci/scripts/dswx_hls/test_dswx_hls.sh
+++ b/.ci/scripts/dswx_hls/test_dswx_hls.sh
@@ -84,7 +84,7 @@ ${DOCKER_RUN} pylint \
     ${CONTAINER_HOME}/opera
 
 # pytest (including code coverage)
-${DOCKER_RUN} bash -c "pytest \
+${DOCKER_RUN} bash -c "pytest -p no:cacheprovider \
     --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
     --cov=${CONTAINER_HOME}/opera/pge/base \
     --cov=${CONTAINER_HOME}/opera/pge/${PGE_NAME} \

--- a/.ci/scripts/dswx_hls/test_dswx_hls.sh
+++ b/.ci/scripts/dswx_hls/test_dswx_hls.sh
@@ -47,6 +47,7 @@ DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
     -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
+    -e PYLINTHOME=/workspace/${TEST_RESULTS_REL_DIR}/.cache/pylint \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
     --entrypoint ${CONDA_ROOT}/bin/pge_tests_entrypoint.sh \

--- a/.ci/scripts/dswx_ni/test_dswx_ni.sh
+++ b/.ci/scripts/dswx_ni/test_dswx_ni.sh
@@ -41,6 +41,11 @@ chmod -R 775 ${WORKSPACE}/${TEST_RESULTS_REL_DIR}
 # Docker image rather than code found on the host.
 DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}:/workspace \
+    -v ${WORKSPACE}/src/opera/test/__init__.py:${CONTAINER_HOME}/opera/test/__init__.py \
+    -v ${WORKSPACE}/src/opera/test/pge/base:${CONTAINER_HOME}/opera/test/pge/base \
+    -v ${WORKSPACE}/src/opera/test/pge/${PGE_NAME}:${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
+    -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
@@ -80,7 +85,7 @@ ${DOCKER_RUN} ${ENTRYPOINT} pylint \
     ${CONTAINER_HOME}/opera
 
 # pytest (including code coverage)
-${DOCKER_RUN} ${ENTRYPOINT} pytest \
+${DOCKER_RUN} ${ENTRYPOINT} "pytest \
     --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
     --cov=${CONTAINER_HOME}/opera/pge/base \
     --cov=${CONTAINER_HOME}/opera/pge/${PGE_NAME} \
@@ -88,10 +93,10 @@ ${DOCKER_RUN} ${ENTRYPOINT} pytest \
     --cov=${CONTAINER_HOME}/opera/util \
     --cov-report=term \
     --cov-report=html:/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/coverage_html \
-    /workspace/src/opera/test/pge/base \
-    /workspace/src/opera/test/pge/${PGE_NAME} \
-    /workspace/src/opera/test/scripts \
-    /workspace/src/opera/test/util > ${TEST_RESULTS_DIR}/pytest.log
+    ${CONTAINER_HOME}/opera/test/pge/base \
+    ${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    ${CONTAINER_HOME}/opera/test/scripts \
+    ${CONTAINER_HOME}/opera/test/util > ${TEST_RESULTS_DIR}/pytest.log"
 
 echo "DSWx-NI PGE Docker image test complete"
 

--- a/.ci/scripts/dswx_ni/test_dswx_ni.sh
+++ b/.ci/scripts/dswx_ni/test_dswx_ni.sh
@@ -47,6 +47,7 @@ DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
     -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
+    -e PYLINTHOME=/workspace/${TEST_RESULTS_REL_DIR}/.cache/pylint \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
     --entrypoint conda \

--- a/.ci/scripts/dswx_ni/test_dswx_ni.sh
+++ b/.ci/scripts/dswx_ni/test_dswx_ni.sh
@@ -86,7 +86,7 @@ ${DOCKER_RUN} ${ENTRYPOINT} pylint \
     ${CONTAINER_HOME}/opera
 
 # pytest (including code coverage)
-${DOCKER_RUN} ${ENTRYPOINT} "pytest \
+${DOCKER_RUN} ${ENTRYPOINT} "pytest -p no:cacheprovider \
     --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
     --cov=${CONTAINER_HOME}/opera/pge/base \
     --cov=${CONTAINER_HOME}/opera/pge/${PGE_NAME} \

--- a/.ci/scripts/dswx_s1/test_dswx_s1.sh
+++ b/.ci/scripts/dswx_s1/test_dswx_s1.sh
@@ -41,6 +41,11 @@ chmod -R 775 ${WORKSPACE}/${TEST_RESULTS_REL_DIR}
 # Docker image rather than code found on the host.
 DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}:/workspace \
+    -v ${WORKSPACE}/src/opera/test/__init__.py:${CONTAINER_HOME}/opera/test/__init__.py \
+    -v ${WORKSPACE}/src/opera/test/pge/base:${CONTAINER_HOME}/opera/test/pge/base \
+    -v ${WORKSPACE}/src/opera/test/pge/${PGE_NAME}:${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
+    -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
@@ -88,10 +93,10 @@ ${DOCKER_RUN} ${ENTRYPOINT} pytest \
     --cov=${CONTAINER_HOME}/opera/util \
     --cov-report=term \
     --cov-report=html:/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/coverage_html \
-    /workspace/src/opera/test/pge/base \
-    /workspace/src/opera/test/pge/${PGE_NAME} \
-    /workspace/src/opera/test/scripts \
-    /workspace/src/opera/test/util > ${TEST_RESULTS_DIR}/pytest.log
+    ${CONTAINER_HOME}/opera/test/pge/base \
+    ${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    ${CONTAINER_HOME}/opera/test/scripts \
+    ${CONTAINER_HOME}/opera/test/util > ${TEST_RESULTS_DIR}/pytest.log
 
 echo "DSWx-S1 PGE Docker image test complete"
 

--- a/.ci/scripts/dswx_s1/test_dswx_s1.sh
+++ b/.ci/scripts/dswx_s1/test_dswx_s1.sh
@@ -86,7 +86,7 @@ ${DOCKER_RUN} ${ENTRYPOINT} pylint \
     ${CONTAINER_HOME}/opera
 
 # pytest (including code coverage)
-${DOCKER_RUN} ${ENTRYPOINT} pytest \
+${DOCKER_RUN} ${ENTRYPOINT} pytest -p no:cacheprovider \
     --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
     --cov=${CONTAINER_HOME}/opera/pge/base \
     --cov=${CONTAINER_HOME}/opera/pge/${PGE_NAME} \

--- a/.ci/scripts/dswx_s1/test_dswx_s1.sh
+++ b/.ci/scripts/dswx_s1/test_dswx_s1.sh
@@ -47,6 +47,7 @@ DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
     -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
+    -e PYLINTHOME=/workspace/${TEST_RESULTS_REL_DIR}/.cache/pylint \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
     --entrypoint conda \

--- a/.ci/scripts/rtc_s1/test_rtc_s1.sh
+++ b/.ci/scripts/rtc_s1/test_rtc_s1.sh
@@ -47,6 +47,7 @@ DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
     -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
+    -e PYLINTHOME=/workspace/${TEST_RESULTS_REL_DIR}/.cache/pylint \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
     --entrypoint conda \

--- a/.ci/scripts/rtc_s1/test_rtc_s1.sh
+++ b/.ci/scripts/rtc_s1/test_rtc_s1.sh
@@ -86,7 +86,7 @@ ${DOCKER_RUN} ${ENTRYPOINT} pylint \
     ${CONTAINER_HOME}/opera
 
 # pytest (including code coverage)
-${DOCKER_RUN} ${ENTRYPOINT} "pytest \
+${DOCKER_RUN} ${ENTRYPOINT} "pytest -p no:cacheprovider \
     --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
     --cov=${CONTAINER_HOME}/opera/pge/base \
     --cov=${CONTAINER_HOME}/opera/pge/${PGE_NAME} \

--- a/.ci/scripts/rtc_s1/test_rtc_s1.sh
+++ b/.ci/scripts/rtc_s1/test_rtc_s1.sh
@@ -41,6 +41,11 @@ chmod -R 775 ${WORKSPACE}/${TEST_RESULTS_REL_DIR}
 # Docker image rather than code found on the host.
 DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}:/workspace \
+    -v ${WORKSPACE}/src/opera/test/__init__.py:${CONTAINER_HOME}/opera/test/__init__.py \
+    -v ${WORKSPACE}/src/opera/test/pge/base:${CONTAINER_HOME}/opera/test/pge/base \
+    -v ${WORKSPACE}/src/opera/test/pge/${PGE_NAME}:${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
+    -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
@@ -80,7 +85,7 @@ ${DOCKER_RUN} ${ENTRYPOINT} pylint \
     ${CONTAINER_HOME}/opera
 
 # pytest (including code coverage)
-${DOCKER_RUN} ${ENTRYPOINT} pytest \
+${DOCKER_RUN} ${ENTRYPOINT} "pytest \
     --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
     --cov=${CONTAINER_HOME}/opera/pge/base \
     --cov=${CONTAINER_HOME}/opera/pge/${PGE_NAME} \
@@ -88,10 +93,10 @@ ${DOCKER_RUN} ${ENTRYPOINT} pytest \
     --cov=${CONTAINER_HOME}/opera/util \
     --cov-report=term \
     --cov-report=html:/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/coverage_html \
-    /workspace/src/opera/test/pge/base \
-    /workspace/src/opera/test/pge/${PGE_NAME} \
-    /workspace/src/opera/test/scripts \
-    /workspace/src/opera/test/util > ${TEST_RESULTS_DIR}/pytest.log
+    ${CONTAINER_HOME}/opera/test/pge/base \
+    ${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    ${CONTAINER_HOME}/opera/test/scripts \
+    ${CONTAINER_HOME}/opera/test/util > ${TEST_RESULTS_DIR}/pytest.log"
 
 echo "RTC-S1 PGE Docker image test complete"
 

--- a/.ci/scripts/tropo/test_tropo.sh
+++ b/.ci/scripts/tropo/test_tropo.sh
@@ -86,7 +86,7 @@ ${DOCKER_RUN} ${ENTRYPOINT} bash -c "pylint \
     ${CONTAINER_HOME}/opera"
 
 # pytest (including code coverage)
-${DOCKER_RUN} ${ENTRYPOINT} bash -c "pytest \
+${DOCKER_RUN} ${ENTRYPOINT} bash -c "pytest -p no:cacheprovider \
     --junit-xml=/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest-junit.xml \
     --cov=${CONTAINER_HOME}/opera/pge/base \
     --cov=${CONTAINER_HOME}/opera/pge/${PGE_NAME} \

--- a/.ci/scripts/tropo/test_tropo.sh
+++ b/.ci/scripts/tropo/test_tropo.sh
@@ -47,6 +47,7 @@ DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
     -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
+    -e PYLINTHOME=/workspace/${TEST_RESULTS_REL_DIR}/.cache/pylint \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
     --entrypoint conda \

--- a/.ci/scripts/tropo/test_tropo.sh
+++ b/.ci/scripts/tropo/test_tropo.sh
@@ -41,6 +41,11 @@ chmod -R 775 ${TEST_RESULTS_DIR}
 # Docker image rather than code found on the host.
 DOCKER_RUN="docker run --rm \
     -v ${WORKSPACE}:/workspace \
+    -v ${WORKSPACE}/src/opera/test/__init__.py:${CONTAINER_HOME}/opera/test/__init__.py \
+    -v ${WORKSPACE}/src/opera/test/pge/base:${CONTAINER_HOME}/opera/test/pge/base \
+    -v ${WORKSPACE}/src/opera/test/pge/${PGE_NAME}:${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    -v ${WORKSPACE}/src/opera/test/scripts:${CONTAINER_HOME}/opera/test/scripts \
+    -v ${WORKSPACE}/src/opera/test/util:${CONTAINER_HOME}/opera/test/util \
     -v ${WORKSPACE}/src/opera/test/data:${CONTAINER_HOME}/opera/test/data \
     -w /workspace/${TEST_RESULTS_REL_DIR} \
     -u ${UID}:$(id -g) \
@@ -88,10 +93,10 @@ ${DOCKER_RUN} ${ENTRYPOINT} bash -c "pytest \
     --cov=${CONTAINER_HOME}/opera/util \
     --cov-report=term \
     --cov-report=html:/workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/coverage_html \
-    /workspace/src/opera/test/pge/base \
-    /workspace/src/opera/test/pge/${PGE_NAME} \
-    /workspace/src/opera/test/scripts \
-    /workspace/src/opera/test/util > /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest.log 2>&1"
+    ${CONTAINER_HOME}/opera/test/pge/base \
+    ${CONTAINER_HOME}/opera/test/pge/${PGE_NAME} \
+    ${CONTAINER_HOME}/opera/test/scripts \
+    ${CONTAINER_HOME}/opera/test/util > /workspace/${TEST_RESULTS_REL_DIR}/${PGE_NAME}/pytest.log 2>&1"
 
 echo "TROPO PGE Docker image test complete"
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -392,4 +392,4 @@ min-public-methods=0
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/src/opera/pge/base/base_pge.py
+++ b/src/opera/pge/base/base_pge.py
@@ -16,7 +16,7 @@ from fnmatch import fnmatch
 from functools import lru_cache
 from os.path import abspath, basename, exists, join, splitext
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 import yamale
 from yamale import YamaleError
@@ -190,11 +190,7 @@ class PreProcessorMixin:
                 msg = f'Could not load description file {description_file}, file does not exist.'
                 self.logger.critical(self.name, ErrorCode.ISO_METADATA_DESCRIPTIONS_CONFIG_NOT_FOUND, msg)
 
-            schema_file = resource_filename(
-                'opera',
-                'pge/base/schema/iso_metadata_measured_parameters_config_schema.yaml'
-            )
-
+            schema_file = str(files('opera').joinpath('pge/base/schema/iso_metadata_measured_parameters_config_schema.yaml'))
             schema = yamale.make_schema(schema_file)
             data = yamale.make_data(description_file)
 

--- a/src/opera/pge/base/runconfig.py
+++ b/src/opera/pge/base/runconfig.py
@@ -16,14 +16,14 @@ Adapted By: Scott Collins
 import os
 from os.path import abspath, basename, isabs, isdir, isfile, join
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 import yamale
 
 import yaml
 
 
-BASE_PGE_SCHEMA = resource_filename('opera', 'pge/base/schema/base_pge_schema.yaml')
+BASE_PGE_SCHEMA = str(files('opera').joinpath('pge/base/schema/base_pge_schema.yaml'))
 """Path to the Yamale schema applicable to the PGE portion of each RunConfig"""
 
 
@@ -277,7 +277,7 @@ class RunConfig:
         return (
             sas_schema_path
             if isabs(sas_schema_path)
-            else resource_filename('opera', sas_schema_path)
+            else str(files('opera').joinpath(sas_schema_path))
         )
 
     @property
@@ -290,7 +290,7 @@ class RunConfig:
             return (
                 algorithm_parameters_schema_path
                 if isabs(algorithm_parameters_schema_path)
-                else resource_filename('opera', algorithm_parameters_schema_path)
+                else str(files('opera').joinpath(algorithm_parameters_schema_path))
             )
 
     @property
@@ -332,7 +332,7 @@ class RunConfig:
         return (
             iso_template_path
             if isabs(iso_template_path)
-            else resource_filename('opera', iso_template_path)
+            else str(files('opera').joinpath(iso_template_path))
         )
 
     @property
@@ -345,7 +345,7 @@ class RunConfig:
         return (
             iso_descriptions_path
             if isabs(iso_descriptions_path)
-            else resource_filename('opera', iso_descriptions_path)
+            else str(files('opera').joinpath(iso_descriptions_path))
         )
 
     @property

--- a/src/opera/test/__init__.py
+++ b/src/opera/test/__init__.py
@@ -8,3 +8,40 @@ test
 The unit-level regression test module for the OPERA PGE Subsystem.
 
 """
+import os
+import pathlib
+import types
+from importlib.resources import as_file, files
+
+from typing import Union, ContextManager
+
+Package = Union[types.ModuleType, str]
+Resource = Union[str, os.PathLike]
+
+
+def normalize_path(path):
+    """Normalize a path by ensuring it is a string.
+
+    If the resulting string contains path separators, an exception is raised.
+    """
+    str_path = str(path)
+    parent, file_name = os.path.split(str_path)
+    if parent:
+        raise ValueError(f'{path!r} must be only a file name')
+    return file_name
+
+
+def path(package: Package, resource: Resource,) -> ContextManager[pathlib.Path]:
+    """A context manager providing a file path object to the resource.
+
+    If the resource does not already exist on its own on the file system,
+    a temporary file will be created. If the file was created, the file
+    will be deleted upon exiting the context manager (no exception is
+    raised if the file was deleted prior to the context manager
+    exiting).
+
+    This function (and normalize_path) are adapted from the _legacy.py module
+    of the imporlib_resources repository to avoid deprecation warnings emitted
+    from use of the baseline  importlib.resources.path function.
+    """
+    return as_file(files(package) / normalize_path(resource))

--- a/src/opera/test/pge/base/test_base_pge.py
+++ b/src/opera/test/pge/base/test_base_pge.py
@@ -17,7 +17,7 @@ from os.path import abspath, exists, join
 from pathlib import Path
 from unittest.mock import patch
 
-from importlib.resources import files
+from opera.test import path
 
 import yaml
 
@@ -36,7 +36,8 @@ class BasePgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up class method: set up directories for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test.pge', 'base') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
         os.chdir(cls.test_dir)
 

--- a/src/opera/test/pge/base/test_base_pge.py
+++ b/src/opera/test/pge/base/test_base_pge.py
@@ -17,7 +17,7 @@ from os.path import abspath, exists, join
 from pathlib import Path
 from unittest.mock import patch
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 import yaml
 
@@ -36,7 +36,7 @@ class BasePgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up class method: set up directories for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
         os.chdir(cls.test_dir)
 

--- a/src/opera/test/pge/base/test_runconfig.py
+++ b/src/opera/test/pge/base/test_runconfig.py
@@ -12,6 +12,7 @@ import tempfile
 import unittest
 from os.path import join
 
+from opera.test import path
 from importlib.resources import files
 
 from yamale import YamaleError
@@ -28,7 +29,8 @@ class RunconfigTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         """Initialize class variables for required paths"""
-        cls.test_dir = str(files(__name__))
+        with path('opera.test.pge', 'base') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
         cls.valid_config_full = join(cls.data_dir, "valid_runconfig_full.yaml")
         cls.valid_config_no_sas = join(cls.data_dir, "valid_runconfig_no_sas.yaml")
@@ -50,9 +52,9 @@ class RunconfigTestCase(unittest.TestCase):
         self.assertEqual(runconfig.sas_program_path, "pybind_opera.workflows.example_workflow")
         self.assertListEqual(runconfig.sas_program_options, ["--debug", "--restart"])
         self.assertEqual(runconfig.error_code_base, 100000)
-        self.assertEqual(runconfig.sas_schema_path, str(files("opera").joinpath("test/data/sample_sas_schema.yaml")))        
+        self.assertEqual(runconfig.sas_schema_path, str(files("opera").joinpath("test/data/sample_sas_schema.yaml")))
         self.assertEqual(runconfig.iso_template_path, str(files("opera").joinpath("sample_iso_template.xml.jinja2")))
-        self.assertEqual(runconfig.iso_measured_parameter_descriptions, 
+        self.assertEqual(runconfig.iso_measured_parameter_descriptions,
                          str(files("opera").joinpath("sample_iso_measured_parameter_descriptions.yaml")))
         self.assertEqual(runconfig.qa_enabled, True)
         self.assertEqual(runconfig.qa_program_path, "/opt/QualityAssurance/sample_qa.py")

--- a/src/opera/test/pge/base/test_runconfig.py
+++ b/src/opera/test/pge/base/test_runconfig.py
@@ -12,7 +12,7 @@ import tempfile
 import unittest
 from os.path import join
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from yamale import YamaleError
 
@@ -28,7 +28,7 @@ class RunconfigTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         """Initialize class variables for required paths"""
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
         cls.valid_config_full = join(cls.data_dir, "valid_runconfig_full.yaml")
         cls.valid_config_no_sas = join(cls.data_dir, "valid_runconfig_no_sas.yaml")
@@ -50,10 +50,10 @@ class RunconfigTestCase(unittest.TestCase):
         self.assertEqual(runconfig.sas_program_path, "pybind_opera.workflows.example_workflow")
         self.assertListEqual(runconfig.sas_program_options, ["--debug", "--restart"])
         self.assertEqual(runconfig.error_code_base, 100000)
-        self.assertEqual(runconfig.sas_schema_path, resource_filename("opera", "test/data/sample_sas_schema.yaml"))
-        self.assertEqual(runconfig.iso_template_path, resource_filename("opera", "sample_iso_template.xml.jinja2"))
-        self.assertEqual(runconfig.iso_measured_parameter_descriptions,
-                         resource_filename("opera", "sample_iso_measured_parameter_descriptions.yaml"))
+        self.assertEqual(runconfig.sas_schema_path, str(files("opera").joinpath("test/data/sample_sas_schema.yaml")))        
+        self.assertEqual(runconfig.iso_template_path, str(files("opera").joinpath("sample_iso_template.xml.jinja2")))
+        self.assertEqual(runconfig.iso_measured_parameter_descriptions, 
+                         str(files("opera").joinpath("sample_iso_measured_parameter_descriptions.yaml")))
         self.assertEqual(runconfig.qa_enabled, True)
         self.assertEqual(runconfig.qa_program_path, "/opt/QualityAssurance/sample_qa.py")
         self.assertListEqual(runconfig.qa_program_options, ["--debug"])

--- a/src/opera/test/pge/cslc_s1/test_cslc_s1_pge.py
+++ b/src/opera/test/pge/cslc_s1/test_cslc_s1_pge.py
@@ -17,7 +17,7 @@ import unittest
 from io import StringIO
 from os.path import abspath, exists, join
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 import yaml
 
@@ -41,7 +41,7 @@ class CslcS1PgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/cslc_s1/test_cslc_s1_pge.py
+++ b/src/opera/test/pge/cslc_s1/test_cslc_s1_pge.py
@@ -17,7 +17,7 @@ import unittest
 from io import StringIO
 from os.path import abspath, exists, join
 
-from importlib.resources import files
+from opera.test import path
 
 import yaml
 
@@ -41,7 +41,8 @@ class CslcS1PgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test.pge', 'cslc_s1') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/disp_ni/test_disp_ni_pge.py
+++ b/src/opera/test/pge/disp_ni/test_disp_ni_pge.py
@@ -14,7 +14,7 @@ import unittest
 from io import StringIO
 from os.path import abspath, join, exists
 
-from importlib.resources import files
+from opera.test import path
 
 import yaml
 
@@ -38,7 +38,8 @@ class DispNIPgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test.pge', 'disp_ni') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/disp_ni/test_disp_ni_pge.py
+++ b/src/opera/test/pge/disp_ni/test_disp_ni_pge.py
@@ -14,7 +14,7 @@ import unittest
 from io import StringIO
 from os.path import abspath, join, exists
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 import yaml
 
@@ -38,7 +38,7 @@ class DispNIPgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/disp_s1/test_disp_s1_pge.py
+++ b/src/opera/test/pge/disp_s1/test_disp_s1_pge.py
@@ -17,7 +17,7 @@ from os.path import abspath, exists, join
 from subprocess import CompletedProcess, Popen
 from unittest.mock import patch
 
-from importlib.resources import files
+from opera.test import path
 
 import pytest
 
@@ -73,7 +73,8 @@ class DispS1PgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test.pge', 'disp_s1') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/disp_s1/test_disp_s1_pge.py
+++ b/src/opera/test/pge/disp_s1/test_disp_s1_pge.py
@@ -17,7 +17,7 @@ from os.path import abspath, exists, join
 from subprocess import CompletedProcess, Popen
 from unittest.mock import patch
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 import pytest
 
@@ -73,7 +73,7 @@ class DispS1PgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
+++ b/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import yaml
-from importlib.resources import files
+from opera.test import path
 
 import opera.util.tiff_utils
 from opera.pge import RunConfig
@@ -43,7 +43,8 @@ class DistS1PgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test.pge', 'dist_s1') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
+++ b/src/opera/test/pge/dist_s1/test_dist_s1_pge.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import yaml
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 import opera.util.tiff_utils
 from opera.pge import RunConfig
@@ -43,7 +43,7 @@ class DistS1PgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/dswx_hls/test_dswx_hls_pge.py
+++ b/src/opera/test/pge/dswx_hls/test_dswx_hls_pge.py
@@ -16,7 +16,7 @@ from io import StringIO
 from os.path import abspath, join
 from unittest.mock import patch
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 import yaml
 
@@ -43,7 +43,7 @@ class DSWxHLSPgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/dswx_hls/test_dswx_hls_pge.py
+++ b/src/opera/test/pge/dswx_hls/test_dswx_hls_pge.py
@@ -16,7 +16,7 @@ from io import StringIO
 from os.path import abspath, join
 from unittest.mock import patch
 
-from importlib.resources import files
+from opera.test import path
 
 import yaml
 
@@ -43,7 +43,8 @@ class DSWxHLSPgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test.pge', 'dswx_hls') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/dswx_ni/test_dswx_ni_pge.py
+++ b/src/opera/test/pge/dswx_ni/test_dswx_ni_pge.py
@@ -16,7 +16,7 @@ from io import StringIO
 from os.path import abspath, join
 from unittest.mock import patch
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 import yaml
 
@@ -41,7 +41,7 @@ class DswxNIPgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/dswx_ni/test_dswx_ni_pge.py
+++ b/src/opera/test/pge/dswx_ni/test_dswx_ni_pge.py
@@ -16,7 +16,7 @@ from io import StringIO
 from os.path import abspath, join
 from unittest.mock import patch
 
-from importlib.resources import files
+from opera.test import path
 
 import yaml
 
@@ -41,7 +41,8 @@ class DswxNIPgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test.pge', 'dswx_ni') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/dswx_s1/test_dswx_s1_pge.py
+++ b/src/opera/test/pge/dswx_s1/test_dswx_s1_pge.py
@@ -16,7 +16,7 @@ from io import StringIO
 from os.path import abspath, exists, isdir, join
 from unittest.mock import patch
 
-from importlib.resources import files
+from opera.test import path
 
 import yaml
 
@@ -42,7 +42,8 @@ class DswxS1PgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test.pge', 'dswx_s1') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/dswx_s1/test_dswx_s1_pge.py
+++ b/src/opera/test/pge/dswx_s1/test_dswx_s1_pge.py
@@ -16,7 +16,7 @@ from io import StringIO
 from os.path import abspath, exists, isdir, join
 from unittest.mock import patch
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 import yaml
 
@@ -42,7 +42,7 @@ class DswxS1PgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
+++ b/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
@@ -17,7 +17,7 @@ import unittest
 from io import StringIO
 from os.path import abspath, exists, join
 
-from importlib.resources import files
+from opera.test import path
 
 import yaml
 
@@ -41,7 +41,8 @@ class RtcS1PgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test.pge', 'rtc_s1') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
+++ b/src/opera/test/pge/rtc_s1/test_rtc_s1_pge.py
@@ -17,7 +17,7 @@ import unittest
 from io import StringIO
 from os.path import abspath, exists, join
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 import yaml
 
@@ -41,7 +41,7 @@ class RtcS1PgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/tropo/test_tropo_pge.py
+++ b/src/opera/test/pge/tropo/test_tropo_pge.py
@@ -18,7 +18,7 @@ from os.path import abspath, exists, join
 from pathlib import Path
 
 import yaml
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from opera.pge import RunConfig
 from opera.pge.tropo.tropo_pge import TROPOExecutor
@@ -39,7 +39,7 @@ class TROPOPgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/pge/tropo/test_tropo_pge.py
+++ b/src/opera/test/pge/tropo/test_tropo_pge.py
@@ -18,7 +18,7 @@ from os.path import abspath, exists, join
 from pathlib import Path
 
 import yaml
-from importlib.resources import files
+from opera.test import path
 
 from opera.pge import RunConfig
 from opera.pge.tropo.tropo_pge import TROPOExecutor
@@ -39,7 +39,8 @@ class TROPOPgeTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set up directories and files for testing"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test.pge', 'tropo') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/scripts/test_pge_main.py
+++ b/src/opera/test/scripts/test_pge_main.py
@@ -14,7 +14,7 @@ import unittest
 from os.path import abspath, join
 from pathlib import Path
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from opera.pge import PgeExecutor, RunConfig
 from opera.scripts import pge_main
@@ -36,7 +36,7 @@ class PgeMainTestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
         cls.scripts_dir = abspath(join(os.pardir, os.pardir, 'scripts'))
 

--- a/src/opera/test/scripts/test_pge_main.py
+++ b/src/opera/test/scripts/test_pge_main.py
@@ -14,7 +14,7 @@ import unittest
 from os.path import abspath, join
 from pathlib import Path
 
-from importlib.resources import files
+from opera.test import path
 
 from opera.pge import PgeExecutor, RunConfig
 from opera.scripts import pge_main
@@ -36,7 +36,8 @@ class PgeMainTestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test', 'scripts') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
         cls.scripts_dir = abspath(join(os.pardir, os.pardir, 'scripts'))
 
@@ -46,17 +47,11 @@ class PgeMainTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        """
-        At completion re-establish starting directory
-        -------
-        """
+        """At completion re-establish starting directory"""
         os.chdir(cls.starting_dir)
 
     def setUp(self) -> None:
-        """
-        Use the temporary directory as the working directory
-        -------
-        """
+        """Use the temporary directory as the working directory"""
         self.working_dir = tempfile.TemporaryDirectory(
             prefix="test_pge_main_", suffix='temp', dir=os.curdir
         )
@@ -68,10 +63,7 @@ class PgeMainTestCase(unittest.TestCase):
         Path('input/input_file02.h5').touch()
 
     def tearDown(self) -> None:
-        """
-        Return to starting directory
-        -------
-        """
+        """Return to starting directory"""
         os.chdir(self.test_dir)
         self.working_dir.cleanup()
 

--- a/src/opera/test/util/test_dataset_utils.py
+++ b/src/opera/test/util/test_dataset_utils.py
@@ -14,7 +14,7 @@ import unittest
 from os.path import abspath, join
 from re import match
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from opera.util.dataset_utils import get_hls_filename_fields
 from opera.util.dataset_utils import parse_bounding_polygon_from_wkt
@@ -30,7 +30,7 @@ class DatasetUtilsTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set directories"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_dataset_utils.py
+++ b/src/opera/test/util/test_dataset_utils.py
@@ -14,7 +14,7 @@ import unittest
 from os.path import abspath, join
 from re import match
 
-from importlib.resources import files
+from opera.test import path
 
 from opera.util.dataset_utils import get_hls_filename_fields
 from opera.util.dataset_utils import parse_bounding_polygon_from_wkt
@@ -30,7 +30,8 @@ class DatasetUtilsTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set directories"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test', 'util') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_geo_utils.py
+++ b/src/opera/test/util/test_geo_utils.py
@@ -14,7 +14,7 @@ import unittest
 from os.path import abspath, join
 from unittest import skipIf
 
-from importlib.resources import files
+from opera.test import path
 
 from opera.util.geo_utils import get_geographic_boundaries_from_mgrs_tile
 from opera.util.geo_utils import translate_utm_bbox_to_lat_lon
@@ -43,7 +43,8 @@ class GeoUtilsTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set directories"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test', 'util') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_geo_utils.py
+++ b/src/opera/test/util/test_geo_utils.py
@@ -14,7 +14,7 @@ import unittest
 from os.path import abspath, join
 from unittest import skipIf
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from opera.util.geo_utils import get_geographic_boundaries_from_mgrs_tile
 from opera.util.geo_utils import translate_utm_bbox_to_lat_lon
@@ -43,7 +43,7 @@ class GeoUtilsTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set directories"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_logger.py
+++ b/src/opera/test/util/test_logger.py
@@ -16,7 +16,7 @@ from io import StringIO
 from os.path import abspath, exists, join
 from random import randint
 
-from importlib.resources import files
+from opera.test import path
 
 from opera.util.error_codes import (CODES_PER_RANGE,
                                     CRITICAL_RANGE_START,
@@ -49,7 +49,8 @@ class LoggerTestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test', 'util') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         cls.config_file = join(cls.data_dir, "test_base_pge_config.yaml")

--- a/src/opera/test/util/test_logger.py
+++ b/src/opera/test/util/test_logger.py
@@ -16,7 +16,7 @@ from io import StringIO
 from os.path import abspath, exists, join
 from random import randint
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from opera.util.error_codes import (CODES_PER_RANGE,
                                     CRITICAL_RANGE_START,
@@ -49,7 +49,7 @@ class LoggerTestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         cls.config_file = join(cls.data_dir, "test_base_pge_config.yaml")

--- a/src/opera/test/util/test_metfile.py
+++ b/src/opera/test/util/test_metfile.py
@@ -12,8 +12,7 @@ import tempfile
 import unittest
 from os.path import abspath, exists
 
-from importlib.resources import files
-
+from opera.test import path
 from opera.util.metfile import MetFile
 
 
@@ -33,7 +32,8 @@ class MetFileTestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test', 'util') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
 
         os.chdir(cls.test_dir)
 

--- a/src/opera/test/util/test_metfile.py
+++ b/src/opera/test/util/test_metfile.py
@@ -12,7 +12,7 @@ import tempfile
 import unittest
 from os.path import abspath, exists
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from opera.util.metfile import MetFile
 
@@ -33,7 +33,7 @@ class MetFileTestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
 
         os.chdir(cls.test_dir)
 

--- a/src/opera/test/util/test_render_jinja2.py
+++ b/src/opera/test/util/test_render_jinja2.py
@@ -14,7 +14,7 @@ import unittest
 from glob import glob
 from os.path import abspath, join
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from opera.util.logger import PgeLogger
 from opera.util.render_jinja2 import JSON_VALIDATOR, render_jinja2, UNDEFINED_ERROR, XML_VALIDATOR, YAML_VALIDATOR
@@ -36,7 +36,7 @@ class RenderJinja2TestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_render_jinja2.py
+++ b/src/opera/test/util/test_render_jinja2.py
@@ -14,7 +14,7 @@ import unittest
 from glob import glob
 from os.path import abspath, join
 
-from importlib.resources import files
+from opera.test import path
 
 from opera.util.logger import PgeLogger
 from opera.util.render_jinja2 import JSON_VALIDATOR, render_jinja2, UNDEFINED_ERROR, XML_VALIDATOR, YAML_VALIDATOR
@@ -36,7 +36,8 @@ class RenderJinja2TestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test', 'util') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_run_utils.py
+++ b/src/opera/test/util/test_run_utils.py
@@ -15,7 +15,7 @@ import unittest
 from os.path import abspath
 from unittest.mock import patch
 
-from importlib.resources import files
+from opera.test import path
 
 from opera.util.logger import PgeLogger
 from opera.util.run_utils import create_qa_command_line
@@ -39,7 +39,8 @@ class RunUtilsTestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test', 'util') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = os.path.join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_run_utils.py
+++ b/src/opera/test/util/test_run_utils.py
@@ -15,7 +15,7 @@ import unittest
 from os.path import abspath
 from unittest.mock import patch
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from opera.util.logger import PgeLogger
 from opera.util.run_utils import create_qa_command_line
@@ -39,7 +39,7 @@ class RunUtilsTestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = os.path.join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_tiff_utils.py
+++ b/src/opera/test/util/test_tiff_utils.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from os.path import abspath, join
 from unittest import skipIf
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from opera.util.tiff_utils import get_geotiff_dimensions
 from opera.util.tiff_utils import get_geotiff_hls_dataset
@@ -48,7 +48,7 @@ class TiffUtilsTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set directories"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_tiff_utils.py
+++ b/src/opera/test/util/test_tiff_utils.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from os.path import abspath, join
 from unittest import skipIf
 
-from importlib.resources import files
+from opera.test import path
 
 from opera.util.tiff_utils import get_geotiff_dimensions
 from opera.util.tiff_utils import get_geotiff_hls_dataset
@@ -48,7 +48,8 @@ class TiffUtilsTestCase(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Set directories"""
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test', 'util') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_time.py
+++ b/src/opera/test/util/test_time.py
@@ -14,7 +14,7 @@ import unittest
 from datetime import datetime
 from os.path import abspath, join
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from opera.util.time import get_catalog_metadata_datetime_str
 from opera.util.time import get_current_iso_time
@@ -34,7 +34,7 @@ class TimeTestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_time.py
+++ b/src/opera/test/util/test_time.py
@@ -14,7 +14,7 @@ import unittest
 from datetime import datetime
 from os.path import abspath, join
 
-from importlib.resources import files
+from opera.test import path
 
 from opera.util.time import get_catalog_metadata_datetime_str
 from opera.util.time import get_current_iso_time
@@ -34,7 +34,8 @@ class TimeTestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test', 'util') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_usage_metrics.py
+++ b/src/opera/test/util/test_usage_metrics.py
@@ -14,7 +14,7 @@ import unittest
 from os.path import abspath, join
 from sys import platform
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from opera.util.usage_metrics import get_os_metrics
 
@@ -32,7 +32,7 @@ class UsageMetricsTestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(files(__name__))
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/test/util/test_usage_metrics.py
+++ b/src/opera/test/util/test_usage_metrics.py
@@ -14,7 +14,7 @@ import unittest
 from os.path import abspath, join
 from sys import platform
 
-from importlib.resources import files
+from opera.test import path
 
 from opera.util.usage_metrics import get_os_metrics
 
@@ -32,7 +32,8 @@ class UsageMetricsTestCase(unittest.TestCase):
 
         """
         cls.starting_dir = abspath(os.curdir)
-        cls.test_dir = str(files(__name__))
+        with path('opera.test', 'util') as test_dir_path:
+            cls.test_dir = str(test_dir_path)
         cls.data_dir = join(cls.test_dir, os.pardir, "data")
 
         os.chdir(cls.test_dir)

--- a/src/opera/util/metfile.py
+++ b/src/opera/util/metfile.py
@@ -18,13 +18,13 @@ import os
 
 import jsonschema
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 
 class MetFile:
     """Class used to read and write .json catalog metadata files."""
 
-    SCHEMA_PATH = resource_filename('opera', 'pge/base/schema/catalog_metadata_schema.json')
+    SCHEMA_PATH = str(files('opera').joinpath('pge/base/schema/catalog_metadata_schema.json'))
 
     def __init__(self, met_dict=None):
         """


### PR DESCRIPTION
## Description
- Removes usage of `pkg_resources` in favor of `importlib.resources`
    - `pkg_resources` was primarily used in tests but could also be found in `base_pge.py`, `runconfig.py`, and `metfile.py`
    - `importlib.resources.files` as a replacement to `pkg_resources.resource_filename` produces a `Traversable`, an abstract interface for a resource that may or may not exist as a regular file on disk. Our usage is just for file paths on disk (as opposed to say existing within a zip or wheel), so we're able to cast the `Traversable` to a `str`, which suits our needs.
    - There is room for an additional safety check when working with a `Traversable`: `.is_file()` can be used prior to casting to a `str`. In the event that `is_file()` is false, a context manager `importlib.resources.as_file` can be used, although that currently isn't the case anywhere in `opera-sds-pge`.

## Affected Issues
- Closes #701 

## Testing
- TROPO unit test and integration tests were used, which both passed as expected (and without the `pkg_resources` deprecation warning). Exhaustive testing was not done on all PGEs as the implementation was the same across the board. 
