### PR TITLE
Patch for UTM bbox to lat/lon utility function

### DIFF
--- a/src/opera/test/util/test_geo_utils.py
+++ b/src/opera/test/util/test_geo_utils.py
@@ -113,8 +113,8 @@ class GeoUtilsTestCase(unittest.TestCase):
         epsg_code = 32718  # UTM S Zone 18
 
         lat_lon_bounding_box = translate_utm_bbox_to_lat_lon(utm_bounding_box, epsg_code)
-        expected_bounding_box = [-5.497645682689766,  # lat_min
-                                 -5.055731551544852,  # lat_max
+        expected_bounding_box = [-5.500856416282783,  # lat_min
+                                 -5.052781983770057,  # lat_max
                                  -77.70109080363252,  # lon_min
                                  -76.86056393945721]  # lon_max
 

--- a/src/opera/test/util/test_geo_utils.py
+++ b/src/opera/test/util/test_geo_utils.py
@@ -124,6 +124,26 @@ class GeoUtilsTestCase(unittest.TestCase):
 
         self.assertListEqual(list(lat_lon_bounding_box), expected_bounding_box)
 
+    @skipIf(not osr_is_available(), reason="osgeo.osr is not installed on the local instance")
+    def test_translate_utm_bbox_to_lat_lon_high_latitude(self):
+        """Test translation of a UTM bounding box to lat/lon"""
+        # Derived from bounding box of static layer products for granule
+        # OPERA_L2_RTC-S1-STATIC_T010-019886-IW2_20140403_S1A_30_v1.0
+        utm_bounding_box = [330420., -379770., 429540., -343080.]
+        epsg_code = 3413  # NSIDC Sea Ice Polar Stereographic North
+
+        lat_lon_bounding_box = translate_utm_bbox_to_lat_lon(utm_bounding_box, epsg_code)
+        expected_bounding_box = [84.710854962878,     # lat_min
+                                 85.60502003831267,   # lat_max
+                                 -3.975004979772367,  # lon_min
+                                 6.385116581294131]   # lon_max
+
+        # Round off last couple digits since they can vary based on precision error
+        lat_lon_bounding_box = list(map(lambda x: round(x, ndigits=12), lat_lon_bounding_box))
+        expected_bounding_box = list(map(lambda x: round(x, ndigits=12), expected_bounding_box))
+
+        self.assertListEqual(list(lat_lon_bounding_box), expected_bounding_box)
+
     @skipIf(not get_frame_geodataframe_is_available(), reason="opera_utils.get_frame_geodataframe is not installed on the local instance")
     def test_bounding_polygon_from_frame(self):
         """

--- a/src/opera/util/geo_utils.py
+++ b/src/opera/util/geo_utils.py
@@ -89,8 +89,8 @@ def translate_utm_bbox_to_lat_lon(bbox, epsg_code):
     # Project all corners to EPSG 4326 (lat/lon) then compute mins and maxes.
     # This is necessary since RTC-S1-STATIC projections yield products that are "rotated" w.r.t. the equator when
     # projected into EPSG 4326, and therefore we cannot guarantee which product corner represents the product's
-    # min/max lat/lon. In some cases, this yielded invalid bounding boxes where min >= max lat/lon, which caused
-    # ingest issues downstream at ASF.
+    # min/max lat/lon. In some cases, such assumptions yielded invalid bounding boxes where min >= max lat/lon,
+    # which caused ingest issues downstream at ASF.
     #
     # See: https://github.com/nasa/opera-sds-pge/issues/736 for an example annotated illustration of this issue.
     ulc = (xmin, ymax)

--- a/src/opera/util/geo_utils.py
+++ b/src/opera/util/geo_utils.py
@@ -86,6 +86,13 @@ def translate_utm_bbox_to_lat_lon(bbox, epsg_code):
     elevation = 0
     xmin, ymin, xmax, ymax = bbox
 
+    # Project all corners to EPSG 4326 (lat/lon) then compute mins and maxes.
+    # This is necessary since RTC-S1-STATIC projections yield products that are "rotated" w.r.t. the equator when
+    # projected into EPSG 4326, and therefore we cannot guarantee which product corner represents the product's
+    # min/max lat/lon. In some cases, this yielded invalid bounding boxes where min >= max lat/lon, which caused
+    # ingest issues downstream at ASF.
+    #
+    # See: https://github.com/nasa/opera-sds-pge/issues/736 for an example annotated illustration of this issue.
     ulc = (xmin, ymax)
     urc = (xmax, ymax)
     llc = (xmin, ymin)

--- a/src/opera/util/geo_utils.py
+++ b/src/opera/util/geo_utils.py
@@ -86,8 +86,20 @@ def translate_utm_bbox_to_lat_lon(bbox, epsg_code):
     elevation = 0
     xmin, ymin, xmax, ymax = bbox
 
-    lat_min, lon_min, _ = transformation.TransformPoint(xmin, ymin, elevation)
-    lat_max, lon_max, _ = transformation.TransformPoint(xmax, ymax, elevation)
+    ulc = (xmin, ymax)
+    urc = (xmax, ymax)
+    llc = (xmin, ymin)
+    lrc = (xmax, ymin)
+
+    ulc_t = transformation.TransformPoint(*ulc, elevation)
+    urc_t = transformation.TransformPoint(*urc, elevation)
+    llc_t = transformation.TransformPoint(*llc, elevation)
+    lrc_t = transformation.TransformPoint(*lrc, elevation)
+
+    lon_min = min([c[1] for c in [ulc_t, urc_t, llc_t, lrc_t]])
+    lat_min = min([c[0] for c in [ulc_t, urc_t, llc_t, lrc_t]])
+    lon_max = max([c[1] for c in [ulc_t, urc_t, llc_t, lrc_t]])
+    lat_max = max([c[0] for c in [ulc_t, urc_t, llc_t, lrc_t]])
 
     return lat_min, lat_max, lon_min, lon_max
 


### PR DESCRIPTION
## Description
- This PR addresses an issue where the `util.geo_utils.translate_utm_bbox_to_lat_lon` function would return incorrect min/max lat/lon values for certain inputs. This was due to the assumption that the upper right corner == max lat/lon and lower left corner == min lat/lon, which is not always correct for some projections. This PR fixes this issue by instead evaluating all corners of the input bounding box.

## Affected Issues
- Fixes #736 

## Testing
- Added new unit test case for sample product that discovered this bug
- Updated existing test case as it also used a bbox affected by this bug
- Verified tests are passing on dev-pge
