### PR TITLE
RTC-S1 PGE Release 2.1.4

### DIFF
--- a/examples/rtc_s1_sample_runconfig-v2.1.4.yaml
+++ b/examples/rtc_s1_sample_runconfig-v2.1.4.yaml
@@ -1,4 +1,4 @@
-# Sample RunConfig for use with the RTC-S1 PGE v2.1.3
+# Sample RunConfig for use with the RTC-S1 PGE v2.1.4
 # This RunConfig should require minimal changes in order to be used with the
 # OPERA PCM.
 

--- a/src/opera/pge/rtc_s1/rtc_s1_pge.py
+++ b/src/opera/pge/rtc_s1/rtc_s1_pge.py
@@ -959,7 +959,7 @@ class RtcS1Executor(RtcS1PreProcessorMixin, RtcS1PostProcessorMixin, PgeExecutor
     LEVEL = "L2"
     """Processing Level for RTC-S1 Products"""
 
-    PGE_VERSION = "2.1.3"
+    PGE_VERSION = "2.1.4"
     """Version of the PGE (overrides default from base_pge)"""
 
     SAS_VERSION = "1.0.4"  # Final release https://github.com/opera-adt/RTC/releases/tag/v1.0.4


### PR DESCRIPTION
This PR releases the RTC-S1 PGE v2.1.4, with a critical fix to ISO XML generation for the RTC-S1-STATIC product.