### PR TITLE
Add missing metadata field to DIST-S1 measured parameters

### DIFF
--- a/src/opera/pge/dist_s1/templates/dist_s1_measured_parameters.yaml
+++ b/src/opera/pge/dist_s1/templates/dist_s1_measured_parameters.yaml
@@ -38,6 +38,14 @@ delta_lookback_days_mw:
   attribute_type: processingParameter
   description: 'Delta lookback days for each window relative to post-image acquisition date.'
   display_name: DeltaLookbackDaysMw
+delta_window_days:
+  attribute_data_type: int
+  attribute_type: processingParameter
+  description: "The acceptable window of time to search for pre-image RTC-S1 data. Default is 60 days (or 2
+  months). This amounts to `post_date - lookback_days - delta_window_days` to `post_date - lookback_days`.
+  If lookback strategy is 'multi_window', this means the maximum window of time to search for pre-images on
+  each anniversary date where `post_date - n * lookback_days` are the anniversary dates for n = 1,..."
+  display_name: DeltaWindowDays
 device:
   attribute_data_type: string
   attribute_type: processingParameter

--- a/src/opera/util/mock_utils.py
+++ b/src/opera/util/mock_utils.py
@@ -295,6 +295,7 @@ class MockGdal:  # pragma: no cover
                 "bucket_prefix": "None",
                 "confirmation_confidence_upper_lim": "32000",
                 "confirmation_confidence_threshold": "31.5",
+                "delta_window_days": "60",
                 "delta_lookback_days_mw": "1095,730,365",
                 "device": "cpu",
                 "dst_dir": "/home/ops/scratch_dir",


### PR DESCRIPTION
## Description
- The `delta_window_days` attribute seems to have fallen through the cracks at some point. Adding it to the MPC to avoid missing data in the ISO XML files

## Affected Issues
- [OPERA-2387](https://hysds-core.atlassian.net/browse/OPERA-2387)

## Testing
- No changes
- [x] Unit tests on local
- [x] Unit tests on dev
- [x] Unit tests on Jenkins
- [x] Int tests on dev (MANUALLY CHECK ISO)
- [x] Int tests on Jenkins
