### PR TITLE
Add RFI_FRAMES_COUNT to DSWx-NI measured parameters

### DIFF
--- a/src/opera/pge/dswx_ni/dswx_ni_pge.py
+++ b/src/opera/pge/dswx_ni/dswx_ni_pge.py
@@ -180,6 +180,12 @@ class DSWxNIPostProcessorMixin(DSWxS1PostProcessorMixin):
         # Extract all metadata assigned by the SAS at product creation time
         try:
             measured_parameters = get_geotiff_metadata(geotiff_product)
+
+            # We may be able to remove this in the future, but RFI_FRAMES_COUNT should be an integer, but None
+            # has been observed
+            if measured_parameters['RFI_FRAMES_COUNT'].lower() == 'none':
+                measured_parameters['RFI_FRAMES_COUNT'] = '0'
+
             output_product_metadata['MeasuredParameters'] = augment_measured_parameters(
                 measured_parameters,
                 self.runconfig.iso_measured_parameter_descriptions,

--- a/src/opera/pge/dswx_ni/templates/dswx_ni_measured_parameters.yaml
+++ b/src/opera/pge/dswx_ni/templates/dswx_ni_measured_parameters.yaml
@@ -285,3 +285,7 @@ ZERO_DOPPLER_START_TIME:
   attribute_data_type: string
   attribute_type: processingInformation
   description: 'Sensing start time. Latest acquisition time of NISAR GCOV set. Format: YYYY-MM-DDTHH:MM:SSZ'
+RFI_FRAMES_COUNT:
+  attribute_data_type: int
+  attribute_type: qualityInformation
+  description: 'Number of NISAR GCOV input frames affected by RFI'

--- a/src/opera/util/mock_utils.py
+++ b/src/opera/util/mock_utils.py
@@ -261,6 +261,7 @@ class MockGdal:  # pragma: no cover
                 "PRODUCT_TYPE": "DSWx-NI",
                 "PRODUCT_VERSION": "['0.1.0']",
                 "PROJECT": "OPERA",
+                "RFI_FRAMES_COUNT": "None",
                 "SENSOR": "LSAR",
                 "SOFTWARE_VERSION": "1.1",
                 "SPACECRAFT_NAME": "NISAR",


### PR DESCRIPTION
## Description
- This PR adds the RFI_FRAMES_COUNT to the DSWx-NI measured parameters config.
- Currently, it looks like this field can incorrectly be set to `None`, so we are checking for that and correcting it to `0`.

## Affected Issues
- [OPERA-2412](https://hysds-core.atlassian.net/browse/OPERA-2412)

## Testing
- [x] Updated mock metadata to include field (with "incorrect" None value)
- [x] Ran unit tests on local & dev
- [x] Verified via manual INT test that ISO attribute is correctly populated (+ `None` translated correctly to `0`)
- [x] Jenkins unit tests
