### PR TITLE
CSLC-S1 Release 2.1.4

### DIFF
--- a/examples/cslc_s1_sample_runconfig-v2.1.4.yaml
+++ b/examples/cslc_s1_sample_runconfig-v2.1.4.yaml
@@ -1,4 +1,4 @@
-# Sample RunConfig for use with the CSLC-S1 PGE v2.1.3
+# Sample RunConfig for use with the CSLC-S1 PGE v2.1.4
 # This RunConfig should require minimal changes in order to be used with the
 # OPERA PCM.
 

--- a/src/opera/pge/cslc_s1/cslc_s1_pge.py
+++ b/src/opera/pge/cslc_s1/cslc_s1_pge.py
@@ -871,7 +871,7 @@ class CslcS1Executor(CslcS1PreProcessorMixin, CslcS1PostProcessorMixin, PgeExecu
     LEVEL = "L2"
     """Processing Level for CSLC-S1 Products"""
 
-    PGE_VERSION = "2.1.3"
+    PGE_VERSION = "2.1.4"
     """Version of the PGE (overrides default from base_pge)"""
 
     SAS_VERSION = "0.5.7"  # Final release https://github.com/opera-adt/COMPASS/releases/tag/v0.5.7


### PR DESCRIPTION
Release version 2.1.4 of the CSLC-S1 PGE with the latest "Final" v0.5.7 release of the SAS