### PR TITLE
DISP-S1 PGE Release v3.0.11-rc.1.0

### DIFF
--- a/examples/disp_s1_sample_runconfig-v3.0.11-rc.1.0.yaml
+++ b/examples/disp_s1_sample_runconfig-v3.0.11-rc.1.0.yaml
@@ -1,4 +1,4 @@
-# Sample RunConfig for use with the DISP-S1 PGE v3.0.10
+# Sample RunConfig for use with the DISP-S1 PGE v3.0.11-rc.1.0
 # This RunConfig should require minimal changes in order to be used with the
 # OPERA PCM.
 

--- a/src/opera/pge/disp_s1/disp_s1_pge.py
+++ b/src/opera/pge/disp_s1/disp_s1_pge.py
@@ -898,7 +898,7 @@ class DispS1Executor(DispS1PreProcessorMixin, DispS1PostProcessorMixin, PgeExecu
     LEVEL = "L3"
     """Processing Level for DISP-S1 Products"""
 
-    PGE_VERSION = "3.0.10"
+    PGE_VERSION = "3.0.11-rc.1.0"
     """Version of the PGE (overrides default from base_pge)"""
 
     SAS_VERSION = "0.5.14"  # Final release https://github.com/opera-adt/disp-s1/releases/tag/v0.5.14


### PR DESCRIPTION
## Description
Release candidate 1.0 of DISP-S1 PGE v3.0.11 with the latest "Final" v0.5.14 release of the SAS.

Note there is no golden dataset yet, so int tests are currently nonfunctional, but a PGE release was needed urgently. Int tests will be made functional for v3.0.11
